### PR TITLE
ticket/ORCH-001: Add include_movies and include_tv_shows columns to Room model

### DIFF
--- a/.opencode
+++ b/.opencode
@@ -1,0 +1,1 @@
+/home/andrew/jelly-swipe/.opencode

--- a/alembic/versions/0002_add_media_type_columns.py
+++ b/alembic/versions/0002_add_media_type_columns.py
@@ -1,0 +1,28 @@
+"""Add include_movies and include_tv_shows columns to rooms table."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0002_media_type"
+down_revision = "0001_phase36"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "rooms",
+        sa.Column("include_movies", sa.Integer(), nullable=False, server_default=sa.text("1")),
+    )
+    op.add_column(
+        "rooms",
+        sa.Column("include_tv_shows", sa.Integer(), nullable=False, server_default=sa.text("0")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("rooms", "include_tv_shows")
+    op.drop_column("rooms", "include_movies")

--- a/jellyswipe/models/room.py
+++ b/jellyswipe/models/room.py
@@ -23,6 +23,8 @@ class Room(Base):
     last_match_data: Mapped[str | None] = mapped_column(Text, nullable=True)
     deck_position: Mapped[str | None] = mapped_column(Text, nullable=True)
     deck_order: Mapped[str | None] = mapped_column(Text, nullable=True)
+    include_movies: Mapped[int] = mapped_column(nullable=False, server_default="1")
+    include_tv_shows: Mapped[int] = mapped_column(nullable=False, server_default="0")
 
     swipes: Mapped[list["Swipe"]] = relationship(
         "Swipe",

--- a/jellyswipe/repositories/rooms.py
+++ b/jellyswipe/repositories/rooms.py
@@ -31,6 +31,8 @@ class RoomRepository:
         current_genre: str,
         solo_mode: bool,
         deck_position_json: str,
+        include_movies: bool = True,
+        include_tv_shows: bool = False,
     ) -> None:
         self._session.add(
             Room(
@@ -40,6 +42,8 @@ class RoomRepository:
                 current_genre=current_genre,
                 solo_mode=1 if solo_mode else 0,
                 deck_position=deck_position_json,
+                include_movies=1 if include_movies else 0,
+                include_tv_shows=1 if include_tv_shows else 0,
             )
         )
 
@@ -149,4 +153,6 @@ class RoomRepository:
             last_match_data_json=row.last_match_data,
             deck_position_json=row.deck_position,
             deck_order_json=row.deck_order,
+            include_movies=bool(row.include_movies),
+            include_tv_shows=bool(row.include_tv_shows),
         )

--- a/jellyswipe/room_types.py
+++ b/jellyswipe/room_types.py
@@ -15,6 +15,8 @@ class RoomRecord:
     last_match_data_json: str | None
     deck_position_json: str | None
     deck_order_json: str | None
+    include_movies: bool
+    include_tv_shows: bool
 
 
 @dataclass(slots=True)

--- a/jellyswipe/services/room_lifecycle.py
+++ b/jellyswipe/services/room_lifecycle.py
@@ -75,6 +75,8 @@ class RoomLifecycleService:
                 current_genre="All",
                 solo_mode=False,
                 deck_position_json=deck_json,
+                include_movies=True,
+                include_tv_shows=False,
             )
             session_dict["active_room"] = pairing_code
             session_dict["solo_mode"] = False
@@ -103,6 +105,8 @@ class RoomLifecycleService:
                 current_genre="All",
                 solo_mode=True,
                 deck_position_json=deck_json,
+                include_movies=True,
+                include_tv_shows=False,
             )
             session_dict["active_room"] = pairing_code
             session_dict["solo_mode"] = True

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,1 @@
+/home/andrew/jelly-swipe/opencode.json

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -52,11 +52,15 @@ class TestAlembicBaseline:
                 "last_match_data",
                 "deck_position",
                 "deck_order",
+                "include_movies",
+                "include_tv_shows",
             }
             assert columns["movie_data"]["dflt_value"] in ("'[]'", '"[]"', "[]")
             assert columns["ready"]["dflt_value"] in ("0", "'0'")
             assert columns["current_genre"]["dflt_value"] in ("'All'", '"All"')
             assert columns["solo_mode"]["dflt_value"] in ("0", "'0'")
+            assert columns["include_movies"]["dflt_value"] in ("1", "'1'")
+            assert columns["include_tv_shows"]["dflt_value"] in ("0", "'0'")
         finally:
             conn.close()
 
@@ -117,11 +121,13 @@ class TestAlembicBaseline:
             )
             conn.commit()
 
-            room = conn.execute("SELECT movie_data, ready, current_genre, solo_mode FROM rooms WHERE pairing_code = ?", ("ROOM1",)).fetchone()
+            room = conn.execute("SELECT movie_data, ready, current_genre, solo_mode, include_movies, include_tv_shows FROM rooms WHERE pairing_code = ?", ("ROOM1",)).fetchone()
             assert room["movie_data"] == "[]"
             assert room["ready"] == 0
             assert room["current_genre"] == "All"
             assert room["solo_mode"] == 0
+            assert room["include_movies"] == 1
+            assert room["include_tv_shows"] == 0
         finally:
             conn.close()
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -13,7 +13,7 @@ import pytest
 from jellyswipe.migrations import build_sqlite_url, upgrade_to_head
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-_EXPECTED_REVISION = "0001_phase36"
+_EXPECTED_REVISION = "0002_media_type"
 
 
 def _table_names(conn: sqlite3.Connection) -> set[str]:
@@ -21,6 +21,12 @@ def _table_names(conn: sqlite3.Connection) -> set[str]:
         "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
     ).fetchall()
     return {r[0] for r in rows}
+
+
+def _get_room_columns(conn: sqlite3.Connection) -> dict[str, str]:
+    """Get column names and their default values for the rooms table."""
+    rows = conn.execute("PRAGMA table_info(rooms)").fetchall()
+    return {row[1]: row[4] for row in rows}  # column name -> default value
 
 
 
@@ -84,5 +90,46 @@ def test_fresh_database_upgrade_then_subprocess_idempotent(tmp_path: Path) -> No
         ).fetchone()
         assert rev2 is not None
         assert rev2[0] == _EXPECTED_REVISION
+    finally:
+        conn.close()
+
+
+def test_migration_adds_media_type_columns_with_defaults(tmp_path: Path) -> None:
+    """Test that migration adds include_movies and include_tv_shows columns with correct defaults."""
+    db_path = tmp_path / "media_type_test.db"
+    url = build_sqlite_url(str(db_path))
+    
+    # Apply migration
+    upgrade_to_head(url)
+    
+    assert db_path.is_file()
+    
+    conn = sqlite3.connect(db_path)
+    try:
+        # Check columns exist with correct defaults
+        columns = _get_room_columns(conn)
+        assert "include_movies" in columns, f"include_movies column missing, have {list(columns.keys())}"
+        assert "include_tv_shows" in columns, f"include_tv_shows column missing, have {list(columns.keys())}"
+        
+        # Verify defaults (SQLite stores defaults as strings)
+        assert columns["include_movies"] == "1", f"include_movies default is {columns['include_movies']}, expected '1'"
+        assert columns["include_tv_shows"] == "0", f"include_tv_shows default is {columns['include_tv_shows']}, expected '0'"
+        
+        # Create a room using INSERT to verify defaults work
+        conn.execute(
+            """
+            INSERT INTO rooms (pairing_code, movie_data, ready, current_genre, solo_mode, deck_position)
+            VALUES ('TEST', '[]', 0, 'All', 0, '{}')
+            """
+        )
+        conn.commit()
+        
+        # Verify the room has correct defaults
+        row = conn.execute(
+            "SELECT include_movies, include_tv_shows FROM rooms WHERE pairing_code = 'TEST'"
+        ).fetchone()
+        assert row is not None
+        assert row[0] == 1, f"include_movies should default to 1, got {row[0]}"
+        assert row[1] == 0, f"include_tv_shows should default to 0, got {row[1]}"
     finally:
         conn.close()

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -104,6 +104,51 @@ class TestRoomRepository:
             assert md == "{}"
             await session.commit()
 
+    async def test_create_with_media_type_fields(self, runtime_sessionmaker):
+        """Test that RoomRepository.create() persists include_movies and include_tv_shows."""
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.rooms.create(
+                "MEDIA_TEST",
+                movie_data_json="[]",
+                ready=False,
+                current_genre="All",
+                solo_mode=False,
+                deck_position_json="{}",
+                include_movies=False,
+                include_tv_shows=True,
+            )
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            record = await uow.rooms.get_room("MEDIA_TEST")
+            
+        assert record is not None
+        assert record.include_movies is False
+        assert record.include_tv_shows is True
+        
+        # Also test default values (movies-only)
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.rooms.create(
+                "DEFAULT_TEST",
+                movie_data_json="[]",
+                ready=False,
+                current_genre="All",
+                solo_mode=False,
+                deck_position_json="{}",
+            )
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            record = await uow.rooms.get_room("DEFAULT_TEST")
+            
+        assert record is not None
+        assert record.include_movies is True
+        assert record.include_tv_shows is False
+
 
 @pytest.mark.anyio
 class TestMatchRepository:


### PR DESCRIPTION
## Add include_movies and include_tv_shows columns to Room model

Add two new integer columns to the `rooms` table to store the session's immutable media-type selection: `include_movies` (default 1) and `include_tv_shows` (default 0). This is the foundation for all TV show support.

**Files to modify:**
- `alembic/versions/` — new migration adding both columns with server defaults
- `jellyswipe/models/room.py` — add `include_movies: Mapped[int]` and `include_tv_shows: Mapped[int]` mapped columns
- `jellyswipe/room_types.py` — add `include_movies: bool` and `include_tv_shows: bool` to `RoomRecord` dataclass
- `jellyswipe/repositories/rooms.py` — update `RoomRepository.create()` to accept `include_movies` and `include_tv_shows`, and update `_to_record()` to map them
- `jellyswipe/services/room_lifecycle.py` — pass `include_movies`/`include_tv_shows` through `create_room` and `create_solo_room` to the repository

**Key decisions:**
- Internal column names stay movie-specific (per grilling decision B). Only `media_type` is added as a per-card concept later.
- Existing rooms are movies-only, so `include_movies=1, include_tv_shows=0` as server defaults is correct.
- Media type selection is immutable after session creation (PRD §2).


### Acceptance Criteria

- Alembic migration adds `include_movies INTEGER NOT NULL DEFAULT 1` and `include_tv_shows INTEGER NOT NULL DEFAULT 0` to the `rooms` table.
- Migration runs cleanly on an existing database (all existing rooms get include_movies=1, include_tv_shows=0).
- `Room` ORM model has both new mapped columns.
- `RoomRecord` dataclass includes both fields.
- `RoomRepository.create()` accepts and persists both fields.
- `_to_record()` maps both columns from ORM to dataclass.
- All existing tests pass after migration and model changes.


---
Ticket: `ORCH-001`