### PR TITLE
ticket/ORCH-005: Build mixed deck with round-robin interleaving and empty-genre validation

### DIFF
--- a/jellyswipe/routers/rooms.py
+++ b/jellyswipe/routers/rooms.py
@@ -23,7 +23,10 @@ from jellyswipe import XSSSafeJSONResponse
 from jellyswipe.db_runtime import get_sessionmaker
 from jellyswipe.dependencies import AuthUser, DBUoW, get_provider, require_auth
 from jellyswipe.repositories.rooms import RoomRepository
-from jellyswipe.services.room_lifecycle import RoomLifecycleService, UniqueRoomCodeExhaustedError
+from jellyswipe.services.room_lifecycle import (
+    RoomLifecycleService,
+    UniqueRoomCodeExhaustedError,
+)
 from jellyswipe.services.swipe_match import SwipeMatchService
 
 rooms_router = APIRouter()
@@ -38,12 +41,15 @@ swipe_match_service = SwipeMatchService()
 # Module-level helpers (per D-11)
 # ============================================================================
 
-def make_error_response(message: str, status_code: int, request: Request, extra_fields: dict = None) -> XSSSafeJSONResponse:
+
+def make_error_response(
+    message: str, status_code: int, request: Request, extra_fields: dict = None
+) -> XSSSafeJSONResponse:
     """Create an error response with request_id."""
     if status_code >= 500:
-        message = 'Internal server error'
-    body = {'error': message}
-    body['request_id'] = getattr(request.state, 'request_id', 'unknown')
+        message = "Internal server error"
+    body = {"error": message}
+    body["request_id"] = getattr(request.state, "request_id", "unknown")
     if extra_fields:
         body.update(extra_fields)
     return XSSSafeJSONResponse(content=body, status_code=status_code)
@@ -52,12 +58,12 @@ def make_error_response(message: str, status_code: int, request: Request, extra_
 def log_exception(exc: Exception, request: Request, context: dict = None) -> None:
     """Log exception with request context."""
     log_data = {
-        'request_id': getattr(request.state, 'request_id', 'unknown'),
-        'route': request.url.path,
-        'method': request.method,
-        'exception_type': type(exc).__name__,
-        'exception_message': str(exc),
-        'stack_trace': traceback.format_exc(),
+        "request_id": getattr(request.state, "request_id", "unknown"),
+        "route": request.url.path,
+        "method": request.method,
+        "exception_type": type(exc).__name__,
+        "exception_message": str(exc),
+        "stack_trace": traceback.format_exc(),
     }
     if context:
         log_data.update(context)
@@ -68,10 +74,13 @@ def log_exception(exc: Exception, request: Request, context: dict = None) -> Non
 # Room routes
 # ============================================================================
 
-@rooms_router.post('/room')
-async def create_room(request: Request, uow: DBUoW, user: AuthUser = Depends(require_auth)):
+
+@rooms_router.post("/room")
+async def create_room(
+    request: Request, uow: DBUoW, user: AuthUser = Depends(require_auth)
+):
     """Create a new room with setup choices.
-    
+
     Accepts JSON body: {"movies": true, "tv_shows": false, "solo": false}
     Backward compat: if body is empty/missing, defaults to movies-only hosted session.
     """
@@ -89,12 +98,12 @@ async def create_room(request: Request, uow: DBUoW, user: AuthUser = Depends(req
                 status_code=400,
             )
     body = body or {}
-    
+
     # Validate that boolean fields are actual booleans, not strings or other types
     movies_val = body.get("movies", True)
     tv_shows_val = body.get("tv_shows", False)
     solo_val = body.get("solo", False)
-    
+
     if not isinstance(movies_val, bool):
         return XSSSafeJSONResponse(
             content={"error": "movies must be a boolean value"},
@@ -110,18 +119,18 @@ async def create_room(request: Request, uow: DBUoW, user: AuthUser = Depends(req
             content={"error": "solo must be a boolean value"},
             status_code=400,
         )
-    
+
     include_movies = movies_val
     include_tv_shows = tv_shows_val
     solo = solo_val
-    
+
     # Validate: at least one media type must be selected
     if not include_movies and not include_tv_shows:
         return XSSSafeJSONResponse(
             content={"error": "At least one of movies or tv_shows must be true"},
             status_code=400,
         )
-    
+
     try:
         return await room_lifecycle_service.create_room(
             request.session,
@@ -133,30 +142,38 @@ async def create_room(request: Request, uow: DBUoW, user: AuthUser = Depends(req
             solo=solo,
         )
     except UniqueRoomCodeExhaustedError:
-        return XSSSafeJSONResponse(content={'error': 'Could not generate unique room code'}, status_code=503)
+        return XSSSafeJSONResponse(
+            content={"error": "Could not generate unique room code"}, status_code=503
+        )
 
 
-@rooms_router.post('/room/solo')
-async def create_solo_room(request: Request, uow: DBUoW, user: AuthUser = Depends(require_auth)):
+@rooms_router.post("/room/solo")
+async def create_solo_room(
+    request: Request, uow: DBUoW, user: AuthUser = Depends(require_auth)
+):
     """Deprecated: POST /room/solo is removed. Use POST /room with {"solo": true} instead."""
-    return XSSSafeJSONResponse(content={'error': 'Endpoint removed. Use POST /room with {"solo": true}'}, status_code=404)
+    return XSSSafeJSONResponse(
+        content={"error": 'Endpoint removed. Use POST /room with {"solo": true}'},
+        status_code=404,
+    )
 
 
-@rooms_router.post('/room/{code}/join')
-async def join_room_route(code: str, request: Request, uow: DBUoW, user: AuthUser = Depends(require_auth)):
+@rooms_router.post("/room/{code}/join")
+async def join_room_route(
+    code: str, request: Request, uow: DBUoW, user: AuthUser = Depends(require_auth)
+):
     """Join an existing room."""
-    payload = await room_lifecycle_service.join_room(code, request.session, user.user_id, uow)
+    payload = await room_lifecycle_service.join_room(
+        code, request.session, user.user_id, uow
+    )
     if payload is None:
-        return XSSSafeJSONResponse(content={'error': 'Invalid Code'}, status_code=404)
+        return XSSSafeJSONResponse(content={"error": "Invalid Code"}, status_code=404)
     return payload
 
 
-@rooms_router.post('/room/{code}/swipe')
+@rooms_router.post("/room/{code}/swipe")
 async def swipe(
-    code: str,
-    request: Request,
-    uow: DBUoW,
-    user: AuthUser = Depends(require_auth)
+    code: str, request: Request, uow: DBUoW, user: AuthUser = Depends(require_auth)
 ):
     """Swipe on a movie with BEGIN IMMEDIATE transaction.
 
@@ -167,9 +184,9 @@ async def swipe(
         data = await request.json()
     except Exception:
         data = {}
-    mid = data.get('media_id')
+    mid = data.get("media_id")
     if not mid:
-        return JSONResponse(content={'error': 'media_id required'}, status_code=400)
+        return JSONResponse(content={"error": "media_id required"}, status_code=400)
     mid = str(mid)
 
     title = None
@@ -179,14 +196,16 @@ async def swipe(
         title = resolved.title
         thumb = f"/proxy?path=jellyfin/{mid}/Primary"
     except RuntimeError as exc:
-        logging.getLogger().warning(f"Failed to resolve metadata for media_id={mid}: {exc}")
+        logging.getLogger().warning(
+            f"Failed to resolve metadata for media_id={mid}: {exc}"
+        )
 
     result = await swipe_match_service.swipe(
         code=code,
         request_session=request.session,
         user_id=user.user_id,
         movie_id=mid,
-        direction=data.get('direction'),
+        direction=data.get("direction"),
         title=title,
         thumb=thumb,
         uow=uow,
@@ -195,52 +214,62 @@ async def swipe(
         body, status_code = result
         return XSSSafeJSONResponse(content=body, status_code=status_code)
 
-    return {'accepted': True}
+    return {"accepted": True}
 
 
-@rooms_router.get('/matches')
-async def get_matches(request: Request, uow: DBUoW, user: AuthUser = Depends(require_auth)):
+@rooms_router.get("/matches")
+async def get_matches(
+    request: Request, uow: DBUoW, user: AuthUser = Depends(require_auth)
+):
     """Get matches for the current room or history."""
-    code = request.session.get('active_room')
-    view = request.query_params.get('view')
+    code = request.session.get("active_room")
+    view = request.query_params.get("view")
     return await room_lifecycle_service.get_matches(code, user.user_id, view, uow)
 
 
-@rooms_router.post('/room/{code}/quit')
-async def quit_room(code: str, request: Request, uow: DBUoW, user: AuthUser = Depends(require_auth)):
+@rooms_router.post("/room/{code}/quit")
+async def quit_room(
+    code: str, request: Request, uow: DBUoW, user: AuthUser = Depends(require_auth)
+):
     """Quit a room and archive matches."""
-    return await room_lifecycle_service.quit_room(code, request.session, user.user_id, uow)
+    return await room_lifecycle_service.quit_room(
+        code, request.session, user.user_id, uow
+    )
 
 
-@rooms_router.post('/matches/delete')
-async def delete_match(request: Request, uow: DBUoW, user: AuthUser = Depends(require_auth)):
+@rooms_router.post("/matches/delete")
+async def delete_match(
+    request: Request, uow: DBUoW, user: AuthUser = Depends(require_auth)
+):
     """Delete a match from history."""
     try:
         data = await request.json()
     except Exception:
         data = {}
-    mid = data.get('media_id')
+    mid = data.get("media_id")
     if not mid:
-        return JSONResponse(content={'error': 'media_id required'}, status_code=400)
+        return JSONResponse(content={"error": "media_id required"}, status_code=400)
     mid = str(mid)
     return await swipe_match_service.delete_match(
         movie_id=mid,
         user_id=user.user_id,
-        active_room=request.session.get('active_room'),
+        active_room=request.session.get("active_room"),
         uow=uow,
     )
 
 
-@rooms_router.post('/room/{code}/undo')
-async def undo_swipe(code: str, request: Request, uow: DBUoW, user: AuthUser = Depends(require_auth)):
+@rooms_router.post("/room/{code}/undo")
+async def undo_swipe(
+    code: str, request: Request, uow: DBUoW, user: AuthUser = Depends(require_auth)
+):
     """Undo the last swipe."""
     try:
         data = await request.json()
     except Exception:
         data = {}
-    mid = data.get('media_id')
+    mid = data.get("media_id")
     if not mid:
-        return JSONResponse(content={'error': 'media_id required'}, status_code=400)
+        return JSONResponse(content={"error": "media_id required"}, status_code=400)
     mid = str(mid)
     return await swipe_match_service.undo_swipe(
         code=code,
@@ -251,36 +280,49 @@ async def undo_swipe(code: str, request: Request, uow: DBUoW, user: AuthUser = D
     )
 
 
-@rooms_router.get('/room/{code}/deck')
-async def get_deck(code: str, request: Request, uow: DBUoW, user: AuthUser = Depends(require_auth)):
+@rooms_router.get("/room/{code}/deck")
+async def get_deck(
+    code: str, request: Request, uow: DBUoW, user: AuthUser = Depends(require_auth)
+):
     """Get a page of movies from the deck."""
     try:
-        page = max(1, int(request.query_params.get('page', 1)))
+        page = max(1, int(request.query_params.get("page", 1)))
     except (ValueError, TypeError):
-        return XSSSafeJSONResponse(content={'error': 'Invalid page parameter'}, status_code=400)
+        return XSSSafeJSONResponse(
+            content={"error": "Invalid page parameter"}, status_code=400
+        )
     return await room_lifecycle_service.get_deck(code, user.user_id, page, uow)
 
 
-@rooms_router.post('/room/{code}/genre')
-async def set_genre(code: str, request: Request, uow: DBUoW, user: AuthUser = Depends(require_auth)):
+@rooms_router.post("/room/{code}/genre")
+async def set_genre(
+    code: str, request: Request, uow: DBUoW, user: AuthUser = Depends(require_auth)
+):
     """Set the genre filter for the room and reload the deck."""
     try:
         data = await request.json()
     except Exception:
         data = {}
-    genre = data.get('genre')
+    genre = data.get("genre")
     if not genre:
-        return XSSSafeJSONResponse(content={'error': 'Genre required'}, status_code=400)
-    return await room_lifecycle_service.set_genre(code, genre, get_provider(), uow)
+        return XSSSafeJSONResponse(content={"error": "Genre required"}, status_code=400)
+    new_list = await room_lifecycle_service.set_genre(code, genre, get_provider(), uow)
+    if not new_list:
+        return XSSSafeJSONResponse(
+            content={"error": "No media found for this genre"}, status_code=400
+        )
+    return new_list
 
 
-@rooms_router.get('/room/{code}/status')
-async def room_status(code: str, _request: Request, uow: DBUoW, _user: AuthUser = Depends(require_auth)):
+@rooms_router.get("/room/{code}/status")
+async def room_status(
+    code: str, _request: Request, uow: DBUoW, _user: AuthUser = Depends(require_auth)
+):
     """Get the current status of the room."""
     return await room_lifecycle_service.get_status(code, uow)
 
 
-@rooms_router.get('/room/{code}/stream')
+@rooms_router.get("/room/{code}/stream")
 def room_stream(code: str, request: Request, auth: AuthUser = Depends(require_auth)):
     """SSE stream for room state changes.
 
@@ -290,6 +332,7 @@ def room_stream(code: str, request: Request, auth: AuthUser = Depends(require_au
     Each poll uses a short-lived async SQLAlchemy session (PAR-05) — no request-scoped UoW
     and no raw sqlite connection spanning the stream lifetime.
     """
+
     async def generate():
         last_genre = None
         last_ready = None
@@ -309,7 +352,7 @@ def room_stream(code: str, request: Request, auth: AuthUser = Depends(require_au
                     snapshot = await repo.fetch_stream_snapshot(code)
 
                 if snapshot is None:
-                    yield {"data": json.dumps({'closed': True})}
+                    yield {"data": json.dumps({"closed": True})}
                     return
 
                 ready = snapshot.ready
@@ -320,14 +363,14 @@ def room_stream(code: str, request: Request, auth: AuthUser = Depends(require_au
 
                 payload = {}
                 if ready != last_ready:
-                    payload['ready'] = ready
-                    payload['solo'] = solo
+                    payload["ready"] = ready
+                    payload["solo"] = solo
                     last_ready = ready
                 if genre != last_genre:
-                    payload['genre'] = genre
+                    payload["genre"] = genre
                     last_genre = genre
                 if match_ts and match_ts != last_match_ts:
-                    payload['last_match'] = last_match
+                    payload["last_match"] = last_match
                     last_match_ts = match_ts
 
                 if payload:
@@ -351,4 +394,6 @@ def room_stream(code: str, request: Request, auth: AuthUser = Depends(require_au
 
     # D-03: EventSourceResponse handles text/event-stream media type and SSE framing.
     # D-04: Verify Cache-Control and X-Accel-Buffering headers are present on response.
-    return EventSourceResponse(generate(), headers={'Cache-Control': 'no-cache', 'X-Accel-Buffering': 'no'})
+    return EventSourceResponse(
+        generate(), headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"}
+    )

--- a/jellyswipe/services/room_lifecycle.py
+++ b/jellyswipe/services/room_lifecycle.py
@@ -18,7 +18,9 @@ class UniqueRoomCodeExhaustedError(Exception):
 
 
 class DeckProvider(Protocol):
-    def fetch_deck(self, media_types: list[str], genre_name: str | None = None) -> list[dict[str, Any]]: ...
+    def fetch_deck(
+        self, media_types: list[str], genre_name: str | None = None
+    ) -> list[dict[str, Any]]: ...
 
 
 class RoomLifecycleService:
@@ -77,6 +79,20 @@ class RoomLifecycleService:
             if include_tv_shows:
                 media_types.append("tv_show")
             movie_list = provider.fetch_deck(media_types=media_types)
+
+            # Interleave movies and TV shows when both are requested (round-robin)
+            if include_movies and include_tv_shows:
+                movies = [m for m in movie_list if m.get("media_type") == "movie"]
+                tv_shows = [t for t in movie_list if t.get("media_type") == "tv_show"]
+                interleaved = []
+                max_len = max(len(movies), len(tv_shows))
+                for i in range(max_len):
+                    if i < len(movies):
+                        interleaved.append(movies[i])
+                    if i < len(tv_shows):
+                        interleaved.append(tv_shows[i])
+                movie_list = interleaved
+
             deck_json = json.dumps({user_id: 0})
             await uow.rooms.create(
                 pairing_code,
@@ -188,7 +204,7 @@ class RoomLifecycleService:
         slice_ = movies[start:end]
         # Map id → media_id and add media_type for API response (exclude original id)
         result = []
-        for m in (slice_ if isinstance(slice_, list) else []):
+        for m in slice_ if isinstance(slice_, list) else []:
             item = {k: v for k, v in m.items() if k != "id"}
             item["media_id"] = m.get("id")
             item["media_type"] = m.get("media_type", "movie")
@@ -215,6 +231,24 @@ class RoomLifecycleService:
             media_types.append("tv_show")
 
         new_list = provider.fetch_deck(media_types=media_types, genre_name=genre)
+
+        # Interleave movies and TV shows when both are requested (round-robin)
+        if room.include_movies and room.include_tv_shows:
+            movies = [m for m in new_list if m.get("media_type") == "movie"]
+            tv_shows = [t for t in new_list if t.get("media_type") == "tv_show"]
+            interleaved = []
+            max_len = max(len(movies), len(tv_shows))
+            for i in range(max_len):
+                if i < len(movies):
+                    interleaved.append(movies[i])
+                if i < len(tv_shows):
+                    interleaved.append(tv_shows[i])
+            new_list = interleaved
+
+        # Validate: empty genre filter returns empty list (caller should return 400)
+        if not new_list:
+            return []
+
         await uow.rooms.set_genre_and_deck(
             code,
             genre,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -234,20 +234,52 @@ class FakeProvider:
         self.favorites_added.append((user_token, movie_id))
 
     def fetch_deck(self, media_types=None, genre_name=None):
-        """Return a list of 25 fake movie cards for deck testing."""
-        return [
-            {
-                "id": f"movie-{i}",
-                "title": f"Movie {i}",
-                "summary": f"Summary {i}",
-                "thumb": f"/proxy?path=jellyfin/movie-{i}/Primary",
-                "rating": 7.0,
-                "duration": "1h 30m",
-                "year": 2024,
-                "media_type": "movie",
-            }
-            for i in range(25)
-        ]
+        """Return a list of fake movie/TV cards for deck testing.
+
+        Args:
+            media_types: List of media types to fetch ("movie", "tv_show").
+                        Defaults to ["movie"] if not specified.
+            genre_name: Optional genre filter (ignored in fake implementation).
+
+        Returns:
+            List of card dicts with media_type field set.
+        """
+        if media_types is None:
+            media_types = ["movie"]
+
+        cards = []
+        if "movie" in media_types:
+            cards.extend(
+                [
+                    {
+                        "id": f"movie-{i}",
+                        "title": f"Movie {i}",
+                        "summary": f"Summary {i}",
+                        "thumb": f"/proxy?path=jellyfin/movie-{i}/Primary",
+                        "rating": 7.0,
+                        "duration": "1h 30m",
+                        "year": 2024,
+                        "media_type": "movie",
+                    }
+                    for i in range(25)
+                ]
+            )
+        if "tv_show" in media_types:
+            cards.extend(
+                [
+                    {
+                        "id": f"tv-{i}",
+                        "title": f"TV Show {i}",
+                        "summary": f"TV Summary {i}",
+                        "thumb": f"/proxy?path=jellyfin/tv-{i}/Primary",
+                        "year": 2024,
+                        "media_type": "tv_show",
+                        "season_count": 3,
+                    }
+                    for i in range(25)
+                ]
+            )
+        return cards
 
     def list_genres(self):
         return ["All", "Action", "Comedy"]

--- a/tests/test_room_lifecycle.py
+++ b/tests/test_room_lifecycle.py
@@ -8,7 +8,12 @@ import jellyswipe.db
 import jellyswipe.db_runtime
 import pytest
 from sqlalchemy import update
-from jellyswipe.db_runtime import build_async_sqlite_url, dispose_runtime, get_sessionmaker, initialize_runtime
+from jellyswipe.db_runtime import (
+    build_async_sqlite_url,
+    dispose_runtime,
+    get_sessionmaker,
+    initialize_runtime,
+)
 from jellyswipe.db_uow import DatabaseUnitOfWork
 from jellyswipe.migrations import build_sqlite_url, upgrade_to_head
 from jellyswipe.models.match import Match
@@ -41,7 +46,9 @@ async def runtime_sessionmaker(db_path, monkeypatch):
     await dispose_runtime()
 
 
-async def force_create_room(svc: RoomLifecycleService, prov: FakeProvider, user_id: str, uow) -> str:
+async def force_create_room(
+    svc: RoomLifecycleService, prov: FakeProvider, user_id: str, uow
+) -> str:
     sess: dict = {}
     out = await svc.create_room(sess, user_id, prov, uow)
     return str(out["pairing_code"])
@@ -88,6 +95,67 @@ async def test_create_and_solo_set_session_cursor_defaults(runtime_sessionmaker)
 
     assert sess_solo["active_room"] == pc2
     assert sess_solo["solo_mode"] is True
+
+
+@pytest.mark.anyio
+async def test_create_room_with_mixed_media_interleaves(runtime_sessionmaker):
+    """Test that when both movies and TV shows are requested, deck interleaves them."""
+    svc = RoomLifecycleService()
+    prov = FakeProvider()
+    uid = prov._user_id
+
+    sess: dict = {}
+    async with runtime_sessionmaker() as session:
+        uow = DatabaseUnitOfWork(session)
+        out = await svc.create_room(
+            sess, uid, prov, uow, include_movies=True, include_tv_shows=True
+        )
+        pc = out["pairing_code"]
+        rec = await uow.rooms.get_room(pc)
+        assert rec is not None
+
+        deck = json.loads(rec.movie_data_json or "[]")
+        assert len(deck) == 50  # 25 movies + 25 TV shows
+
+        # Verify round-robin interleaving: movie, tv, movie, tv, ...
+        for i in range(len(deck)):
+            if i % 2 == 0:
+                assert deck[i]["media_type"] == "movie", f"Position {i} should be movie"
+            else:
+                assert deck[i]["media_type"] == "tv_show", (
+                    f"Position {i} should be tv_show"
+                )
+
+        assert rec.include_movies is True
+        assert rec.include_tv_shows is True
+        await session.commit()
+
+
+@pytest.mark.anyio
+async def test_create_room_with_tv_shows_only(runtime_sessionmaker):
+    """Test that when only TV shows are requested, deck contains only TV shows."""
+    svc = RoomLifecycleService()
+    prov = FakeProvider()
+    uid = prov._user_id
+
+    sess: dict = {}
+    async with runtime_sessionmaker() as session:
+        uow = DatabaseUnitOfWork(session)
+        out = await svc.create_room(
+            sess, uid, prov, uow, include_movies=False, include_tv_shows=True
+        )
+        pc = out["pairing_code"]
+        rec = await uow.rooms.get_room(pc)
+        assert rec is not None
+
+        deck = json.loads(rec.movie_data_json or "[]")
+        assert len(deck) == 25
+        for card in deck:
+            assert card["media_type"] == "tv_show"
+
+        assert rec.include_movies is False
+        assert rec.include_tv_shows is True
+        await session.commit()
 
 
 @pytest.mark.anyio
@@ -155,7 +223,9 @@ async def test_quit_session_ended_archives_matches_to_history(runtime_sessionmak
         room = await uow.rooms.get_room(pc)
         assert room is None
         archived = await uow.matches.list_history_for_user(uid)
-        assert any(isinstance(r, MatchRecord) and r.room_code == "HISTORY" for r in archived)
+        assert any(
+            isinstance(r, MatchRecord) and r.room_code == "HISTORY" for r in archived
+        )
 
 
 @pytest.mark.anyio
@@ -175,7 +245,9 @@ async def test_deck_genre_status_matches_semantics(runtime_sessionmaker):
 
         lm = {"type": "match", "ts": 999.9}
         await session.execute(
-            update(Room).where(Room.pairing_code == pc).values(last_match_data=json.dumps(lm))
+            update(Room)
+            .where(Room.pairing_code == pc)
+            .values(last_match_data=json.dumps(lm))
         )
 
         genre_deck = await svc.set_genre(pc, "Action", prov, uow)

--- a/tests/test_routes_room.py
+++ b/tests/test_routes_room.py
@@ -610,3 +610,47 @@ def test_swipe_right_updates_last_match_data(client, app):
     match_data = json.loads(row["last_match_data"])
     assert match_data["type"] == "match"
     assert "ts" in match_data
+
+
+def test_set_genre_empty_deck_returns_400(client, app, mocker):
+    """POST /room/{code}/genre returns 400 when genre filter results in empty deck."""
+    from tests.conftest import FakeProvider
+
+    # Seed a room
+    _seed_room("TEST1", ready=1, solo_mode=0)
+    _set_session(
+        client,
+        os.environ["FLASK_SECRET"],
+        active_room="TEST1",
+        user_id="verified-user",
+        authenticated=True,
+    )
+
+    # Mock provider to return empty deck for a specific genre
+    fake_provider = FakeProvider()
+    original_fetch = fake_provider.fetch_deck
+
+    def mock_fetch(media_types=None, genre_name=None):
+        if genre_name == "NonExistent":
+            return []
+        return original_fetch(media_types, genre_name)
+
+    fake_provider.fetch_deck = mock_fetch
+
+    # Override the provider in the router module
+    import jellyswipe.routers.rooms as rooms_router_module
+
+    original_get_provider = rooms_router_module.get_provider
+    rooms_router_module.get_provider = lambda: fake_provider
+
+    try:
+        response = client.post(
+            "/room/TEST1/genre",
+            json={"genre": "NonExistent"},
+        )
+
+        assert response.status_code == 400
+        assert "No media found" in response.json()["error"]
+    finally:
+        # Restore original get_provider
+        rooms_router_module.get_provider = original_get_provider


### PR DESCRIPTION
## Build mixed deck with round-robin interleaving and empty-genre validation

Update `RoomLifecycleService.create_room()` to build a mixed deck when both `include_movies` and `include_tv_shows` are true. Use round-robin interleaving.

**Files to modify:**
- `jellyswipe/services/room_lifecycle.py`
- `jellyswipe/services/swipe_match.py`

### Acceptance Criteria

- When both media types requested, deck interleaves movie and TV cards.
- When only one type, deck contains only that type.
- Empty genre validation returns 400.
- All existing tests pass; new tests cover mixed deck creation.

---
Ticket: `ORCH-005`