### PR TITLE
feat(ORCH-006): Frontend setup panel and merged session creation

### DIFF
--- a/jellyswipe/static/app.js
+++ b/jellyswipe/static/app.js
@@ -155,19 +155,81 @@
             }
         }
 
-        async function handleSoloToggle(checkbox) {
-            const track = document.getElementById('solo-toggle-track');
-            const thumb = document.getElementById('solo-toggle-thumb');
-            if (checkbox.checked) {
-                track.style.background = '#e5a00d';
-                thumb.style.transform = 'translateX(18px)';
-                thumb.style.background = '#000';
-                await activateSoloMode();
-            } else {
-                track.style.background = '#333';
-                thumb.style.transform = 'translateX(0)';
-                thumb.style.background = '#888';
+        function showSetupPanel() {
+            document.getElementById('setup-movies').checked = true;
+            document.getElementById('setup-tv-shows').checked = false;
+            document.getElementById('setup-solo').checked = false;
+            document.getElementById('setup-error').classList.add('hidden');
+            updateConfirmButtonState();
+            document.getElementById('setup-panel-overlay').classList.remove('hidden');
+            document.getElementById('setup-panel').classList.remove('hidden');
+        }
+
+        function updateConfirmButtonState() {
+            const moviesOn = document.getElementById('setup-movies').checked;
+            const tvShowsOn = document.getElementById('setup-tv-shows').checked;
+            const confirmBtn = document.getElementById('setup-confirm-btn');
+            confirmBtn.disabled = !(moviesOn || tvShowsOn);
+        }
+
+        function getScopeSummary() {
+            const moviesOn = document.getElementById('setup-movies').checked;
+            const tvShowsOn = document.getElementById('setup-tv-shows').checked;
+            if (moviesOn && tvShowsOn) return 'Movies + TV Shows';
+            if (moviesOn) return 'Movies';
+            if (tvShowsOn) return 'TV Shows';
+            return '';
+        }
+
+        async function confirmSetup() {
+            const moviesOn = document.getElementById('setup-movies').checked;
+            const tvShowsOn = document.getElementById('setup-tv-shows').checked;
+            const soloOn = document.getElementById('setup-solo').checked;
+            const errorEl = document.getElementById('setup-error');
+
+            if (!moviesOn && !tvShowsOn) {
+                errorEl.textContent = 'Select at least one media type';
+                errorEl.classList.remove('hidden');
+                return;
             }
+
+            try {
+                const res = await apiFetch('/room', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({ movies: moviesOn, tv_shows: tvShowsOn, solo: soloOn })
+                });
+
+                if (res.status === 422) {
+                    errorEl.textContent = 'No titles found for the selected media types';
+                    errorEl.classList.remove('hidden');
+                    return;
+                }
+
+                if (!res.ok) {
+                    errorEl.textContent = 'Failed to create session';
+                    errorEl.classList.remove('hidden');
+                    return;
+                }
+
+                const data = await res.json();
+                currentRoomCode = data.pairing_code;
+                document.getElementById('session-display').innerText = data.pairing_code;
+                document.getElementById('session-scope').innerText = getScopeSummary();
+                document.getElementById('host-btn').classList.add('hidden');
+                document.getElementById('session-info').classList.remove('hidden');
+                document.getElementById('setup-panel-overlay').classList.add('hidden');
+                document.getElementById('setup-panel').classList.add('hidden');
+                startPolling();
+            } catch (err) {
+                errorEl.textContent = 'Network error - please try again';
+                errorEl.classList.remove('hidden');
+            }
+        }
+
+        function cancelSetup() {
+            document.getElementById('setup-panel-overlay').classList.add('hidden');
+            document.getElementById('setup-panel').classList.add('hidden');
         }
 
         const loadMovies = async (solo = false) => {
@@ -404,8 +466,20 @@
             const genrePill = document.getElementById('genre-pill');
             if (genrePill) genrePill.onclick = () => toggleGenreModal();
 
-            const soloToggle = document.getElementById('solo-toggle');
-            if (soloToggle) soloToggle.addEventListener('change', function() { handleSoloToggle(this); });
+            const setupMovies = document.getElementById('setup-movies');
+            if (setupMovies) setupMovies.addEventListener('change', updateConfirmButtonState);
+
+            const setupTvShows = document.getElementById('setup-tv-shows');
+            if (setupTvShows) setupTvShows.addEventListener('change', updateConfirmButtonState);
+
+            const setupConfirmBtn = document.getElementById('setup-confirm-btn');
+            if (setupConfirmBtn) setupConfirmBtn.addEventListener('click', confirmSetup);
+
+            const setupCancelBtn = document.getElementById('setup-cancel-btn');
+            if (setupCancelBtn) setupCancelBtn.addEventListener('click', cancelSetup);
+
+            const setupOverlay = document.getElementById('setup-panel-overlay');
+            if (setupOverlay) setupOverlay.addEventListener('click', cancelSetup);
 
             const genreCancelBtn = document.querySelector('.genre-cancel-btn');
             if (genreCancelBtn) genreCancelBtn.addEventListener('click', () => toggleGenreModal());
@@ -667,14 +741,8 @@
             };
         }
 
-        document.getElementById('host-btn').onclick = async () => {
-            const res = await apiFetch('/room', { method: 'POST' });
-            const data = await res.json();
-            currentRoomCode = data.pairing_code;
-            document.getElementById('session-display').innerText = data.pairing_code;
-            document.getElementById('host-btn').classList.add('hidden');
-            document.getElementById('session-info').classList.remove('hidden');
-            startPolling();
+        document.getElementById('host-btn').onclick = () => {
+            showSetupPanel();
         };
 
         async function joinRoom() {

--- a/jellyswipe/static/styles.css
+++ b/jellyswipe/static/styles.css
@@ -468,3 +468,80 @@ body::before {
     width: 100%;
     margin: 0;
 }
+
+/* --- Setup Panel styles --- */
+#setup-panel-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0,0,0,0.85);
+    z-index: 60000;
+    backdrop-filter: blur(5px);
+}
+#setup-panel {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: #1a1a1a;
+    border: 2px solid #e5a00d;
+    border-radius: 16px;
+    z-index: 60001;
+    padding: 30px 25px;
+    width: 280px;
+    box-shadow: 0 8px 40px rgba(229, 160, 13, 0.3);
+    text-align: center;
+}
+#setup-panel h2 {
+    margin: 0 0 25px;
+    font-size: 1.5rem;
+}
+.setup-toggles {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+    margin-bottom: 20px;
+}
+.setup-toggle-label {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    cursor: pointer;
+}
+.toggle-label-text {
+    font-size: 1rem;
+    color: #eee;
+}
+.setup-toggle-input {
+    width: 20px;
+    height: 20px;
+    cursor: pointer;
+}
+.setup-error {
+    color: #ff3131;
+    font-size: 0.85rem;
+    margin: 0 0 15px;
+    min-height: 20px;
+}
+.setup-buttons {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+.setup-buttons .menu-btn {
+    width: 100%;
+    margin: 0;
+}
+.setup-buttons .menu-btn:disabled {
+    background: #444;
+    color: #888;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+.scope-summary {
+    font-size: 0.9rem;
+    color: #888;
+    margin: 5px 0 0;
+}

--- a/jellyswipe/templates/index.html
+++ b/jellyswipe/templates/index.html
@@ -45,13 +45,7 @@
             <div id="session-info" class="hidden">
                 <div class="session-info-container">
                     <p>Code: <span id="session-display" class="plex-yellow session-code">----</span></p>
-                    <label class="solo-toggle-label">
-                        <span class="solo-label-text">SOLO</span>
-                        <div id="solo-toggle-track" class="solo-toggle-track">
-                            <div id="solo-toggle-thumb" class="solo-toggle-thumb"></div>
-                        </div>
-                        <input type="checkbox" id="solo-toggle" class="solo-toggle-input">
-                    </label>
+                    <p class="scope-summary">Scope: <span id="session-scope" class="plex-yellow"></span></p>
                 </div>
                 <p class="waiting-text">Waiting for partner...</p>
             </div>
@@ -78,6 +72,31 @@
             <div id="glow-right" class="glow-side"></div>
             <div id="swipe-deck"></div>
             <div id="game-instruction" class="match-instruction">Tap poster for full details</div>
+        </div>
+    </div>
+
+    <!-- Setup Panel Modal -->
+    <div id="setup-panel-overlay" class="hidden"></div>
+    <div id="setup-panel" class="hidden">
+        <h2 class="plex-yellow">Session Setup</h2>
+        <div class="setup-toggles">
+            <label class="setup-toggle-label">
+                <span class="toggle-label-text">Movies</span>
+                <input type="checkbox" id="setup-movies" class="setup-toggle-input" checked>
+            </label>
+            <label class="setup-toggle-label">
+                <span class="toggle-label-text">TV Shows</span>
+                <input type="checkbox" id="setup-tv-shows" class="setup-toggle-input">
+            </label>
+            <label class="setup-toggle-label">
+                <span class="toggle-label-text">Solo</span>
+                <input type="checkbox" id="setup-solo" class="setup-toggle-input">
+            </label>
+        </div>
+        <p id="setup-error" class="setup-error hidden"></p>
+        <div class="setup-buttons">
+            <button id="setup-cancel-btn" class="menu-btn">Cancel</button>
+            <button id="setup-confirm-btn" class="menu-btn glow-btn" disabled>Confirm</button>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary

Add a setup panel to the frontend that lets users choose media types and solo/hosted mode before creating a room.

## Changes

- Setup panel appears before room creation with Movies/TV Shows checkboxes
- At least one media type must be selected (client-side validation)
- Solo mode toggle present
- Room creation calls POST /room with correct body: { movies, tv_shows, solo }
- Display read-only scope summary after room creation
- Handle 422 error for no candidates

## Validation

- All 331 tests pass
- No uncommitted tracked changes