### PR TITLE
ticket/ORCH-008: Carry media_type through matches, history, and deep-links

### DIFF
--- a/alembic/versions/0002_add_media_type.py
+++ b/alembic/versions/0002_add_media_type.py
@@ -1,0 +1,20 @@
+"""Add media_type column to matches table."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0002_add_media_type"
+down_revision = "0001_phase36"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("matches", sa.Column("media_type", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("matches", "media_type")

--- a/jellyswipe/models/match.py
+++ b/jellyswipe/models/match.py
@@ -30,6 +30,7 @@ class Match(Base):
     rating: Mapped[str | None] = mapped_column(Text, nullable=True)
     duration: Mapped[str | None] = mapped_column(Text, nullable=True)
     year: Mapped[str | None] = mapped_column(Text, nullable=True)
+    media_type: Mapped[str | None] = mapped_column(Text, nullable=True)
     __mapper_args__ = {
         "primary_key": [room_code, movie_id, user_id],
     }

--- a/jellyswipe/repositories/matches.py
+++ b/jellyswipe/repositories/matches.py
@@ -18,10 +18,16 @@ class MatchRepository:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
 
-    async def list_active_for_user(self, pairing_code: str, user_id: str) -> list[MatchRecord]:
+    async def list_active_for_user(
+        self, pairing_code: str, user_id: str
+    ) -> list[MatchRecord]:
         stmt = (
             select(Match, _ROWID_ORDER)
-            .where(Match.room_code == pairing_code, Match.status == "active", Match.user_id == user_id)
+            .where(
+                Match.room_code == pairing_code,
+                Match.status == "active",
+                Match.user_id == user_id,
+            )
             .order_by(_ROWID_ORDER.desc())
         )
         result = await self._session.execute(stmt)
@@ -98,5 +104,6 @@ class MatchRepository:
             rating=match.rating,
             duration=match.duration,
             year=match.year,
+            media_type=match.media_type,
             match_order=mo,
         )

--- a/jellyswipe/room_types.py
+++ b/jellyswipe/room_types.py
@@ -48,6 +48,7 @@ class MatchRecord:
     rating: str | None
     duration: str | None
     year: str | None
+    media_type: str | None
     match_order: int | None
 
 

--- a/jellyswipe/services/room_lifecycle.py
+++ b/jellyswipe/services/room_lifecycle.py
@@ -50,7 +50,7 @@ class RoomLifecycleService:
             "title": record.title,
             "thumb": record.thumb,
             "media_id": record.movie_id,
-            "media_type": "movie",
+            "media_type": record.media_type or "movie",
             "deep_link": record.deep_link,
             "rating": record.rating or "",
             "duration": record.duration or "",

--- a/jellyswipe/services/swipe_match.py
+++ b/jellyswipe/services/swipe_match.py
@@ -1,8 +1,8 @@
 """Dedicated swipe/match mutation service — Phase 39 (D-14).
 
- Serialized swipe mutations use `BEGIN IMMEDIATE` inside `uow.run_sync(...)`
- without owning commit/rollback. Undo/delete routes recompute room last-match sentinels
- from persisted active match rows (`match_order` / SQLite rowid).
+Serialized swipe mutations use `BEGIN IMMEDIATE` inside `uow.run_sync(...)`
+without owning commit/rollback. Undo/delete routes recompute room last-match sentinels
+from persisted active match rows (`match_order` / SQLite rowid).
 """
 
 from __future__ import annotations
@@ -37,7 +37,9 @@ def _execute(conn: Connection | object, query: str, params: tuple = ()) -> None:
 
 
 def _get_cursor(conn: Connection, code: str, user_id: str) -> int:
-    room = _fetchone(conn, "SELECT deck_position FROM rooms WHERE pairing_code = ?", (code,))
+    room = _fetchone(
+        conn, "SELECT deck_position FROM rooms WHERE pairing_code = ?", (code,)
+    )
     if room and room["deck_position"]:
         positions = json.loads(room["deck_position"])
         return int(positions.get(user_id, 0))
@@ -45,8 +47,12 @@ def _get_cursor(conn: Connection, code: str, user_id: str) -> int:
 
 
 def _set_cursor(conn: Connection, code: str, user_id: str, position: int) -> None:
-    room = _fetchone(conn, "SELECT deck_position FROM rooms WHERE pairing_code = ?", (code,))
-    positions = json.loads(room["deck_position"]) if room and room["deck_position"] else {}
+    room = _fetchone(
+        conn, "SELECT deck_position FROM rooms WHERE pairing_code = ?", (code,)
+    )
+    positions = (
+        json.loads(room["deck_position"]) if room and room["deck_position"] else {}
+    )
     positions[user_id] = position
     _execute(
         conn,
@@ -63,17 +69,21 @@ def _resolve_movie_meta(movie_data_json: str | None, movie_id: str) -> dict[str,
                 rating = m.get("rating")
                 duration = m.get("duration")
                 year = m.get("year")
+                media_type = m.get("media_type", "movie")
                 return {
                     "rating": str(rating) if rating is not None else "",
                     "duration": duration or "",
                     "year": str(year) if year is not None else "",
+                    "media_type": media_type,
                 }
     except (json.JSONDecodeError, TypeError):
         pass
-    return {"rating": "", "duration": "", "year": ""}
+    return {"rating": "", "duration": "", "year": "", "media_type": "movie"}
 
 
-def _match_sentinel_rowid(conn: Connection, pairing_code: str, movie_id: str) -> int | None:
+def _match_sentinel_rowid(
+    conn: Connection, pairing_code: str, movie_id: str
+) -> int | None:
     row = _fetchone(
         conn,
         "SELECT MAX(rowid) AS rid FROM matches WHERE room_code = ? AND movie_id = ?",
@@ -98,7 +108,7 @@ def _last_match_json(
         "title": title,
         "thumb": thumb,
         "media_id": movie_id,
-        "media_type": "movie",
+        "media_type": meta.get("media_type", "movie"),
         "rating": meta["rating"],
         "duration": meta["duration"],
         "year": meta["year"],
@@ -117,7 +127,7 @@ def match_record_as_last_match_json(rec: MatchRecord) -> str:
         "title": rec.title,
         "thumb": rec.thumb,
         "media_id": rec.movie_id,
-        "media_type": "movie",
+        "media_type": rec.media_type or "movie",
         "rating": rec.rating or "",
         "duration": rec.duration or "",
         "year": rec.year or "",
@@ -163,7 +173,9 @@ def _sync_run_swipe_transaction(
     if direction != "right" or title is None or thumb is None:
         return None
 
-    room = _fetchone(conn, "SELECT solo_mode, movie_data FROM rooms WHERE pairing_code = ?", (code,))
+    room = _fetchone(
+        conn, "SELECT solo_mode, movie_data FROM rooms WHERE pairing_code = ?", (code,)
+    )
     meta = (
         _resolve_movie_meta(room["movie_data"], movie_id)
         if room
@@ -174,7 +186,7 @@ def _sync_run_swipe_transaction(
     if room and room["solo_mode"]:
         _execute(
             conn,
-            'INSERT OR IGNORE INTO matches (room_code, movie_id, title, thumb, status, user_id, deep_link, rating, duration, year) VALUES (?, ?, ?, ?, "active", ?, ?, ?, ?, ?)',
+            'INSERT OR IGNORE INTO matches (room_code, movie_id, title, thumb, status, user_id, deep_link, rating, duration, year, media_type) VALUES (?, ?, ?, ?, "active", ?, ?, ?, ?, ?, ?)',
             (
                 code,
                 movie_id,
@@ -185,6 +197,7 @@ def _sync_run_swipe_transaction(
                 meta["rating"],
                 meta["duration"],
                 meta["year"],
+                meta["media_type"],
             ),
         )
         rid = _match_sentinel_rowid(conn, code, movie_id)
@@ -196,7 +209,11 @@ def _sync_run_swipe_transaction(
             deep_link=deep_link,
             sentinel_ts=rid,
         )
-        _execute(conn, "UPDATE rooms SET last_match_data = ? WHERE pairing_code = ?", (match_data, code))
+        _execute(
+            conn,
+            "UPDATE rooms SET last_match_data = ? WHERE pairing_code = ?",
+            (match_data, code),
+        )
         return None
 
     session_id = request_session.get("session_id")
@@ -218,7 +235,7 @@ def _sync_run_swipe_transaction(
 
     _execute(
         conn,
-        'INSERT OR IGNORE INTO matches (room_code, movie_id, title, thumb, status, user_id, deep_link, rating, duration, year) VALUES (?, ?, ?, ?, "active", ?, ?, ?, ?, ?)',
+        'INSERT OR IGNORE INTO matches (room_code, movie_id, title, thumb, status, user_id, deep_link, rating, duration, year, media_type) VALUES (?, ?, ?, ?, "active", ?, ?, ?, ?, ?, ?)',
         (
             code,
             movie_id,
@@ -229,13 +246,14 @@ def _sync_run_swipe_transaction(
             meta["rating"],
             meta["duration"],
             meta["year"],
+            meta["media_type"],
         ),
     )
 
     if other_swipe["user_id"] and other_swipe["user_id"] != user_id:
         _execute(
             conn,
-            'INSERT OR IGNORE INTO matches (room_code, movie_id, title, thumb, status, user_id, deep_link, rating, duration, year) VALUES (?, ?, ?, ?, "active", ?, ?, ?, ?, ?)',
+            'INSERT OR IGNORE INTO matches (room_code, movie_id, title, thumb, status, user_id, deep_link, rating, duration, year, media_type) VALUES (?, ?, ?, ?, "active", ?, ?, ?, ?, ?, ?)',
             (
                 code,
                 movie_id,
@@ -246,6 +264,7 @@ def _sync_run_swipe_transaction(
                 meta["rating"],
                 meta["duration"],
                 meta["year"],
+                meta["media_type"],
             ),
         )
 
@@ -258,7 +277,11 @@ def _sync_run_swipe_transaction(
         deep_link=deep_link,
         sentinel_ts=rid,
     )
-    _execute(conn, "UPDATE rooms SET last_match_data = ? WHERE pairing_code = ?", (match_data, code))
+    _execute(
+        conn,
+        "UPDATE rooms SET last_match_data = ? WHERE pairing_code = ?",
+        (match_data, code),
+    )
     return None
 
 
@@ -288,12 +311,16 @@ class SwipeMatchService:
             thumb=thumb,
         )
 
-    async def _recompute_last_match_for_room(self, uow: DatabaseUnitOfWork, pairing_code: str) -> None:
+    async def _recompute_last_match_for_room(
+        self, uow: DatabaseUnitOfWork, pairing_code: str
+    ) -> None:
         latest = await uow.matches.latest_active_for_room(pairing_code)
         if latest is None:
             await uow.rooms.set_last_match_data(pairing_code, None)
             return
-        await uow.rooms.set_last_match_data(pairing_code, match_record_as_last_match_json(latest))
+        await uow.rooms.set_last_match_data(
+            pairing_code, match_record_as_last_match_json(latest)
+        )
 
     async def undo_swipe(
         self,
@@ -304,7 +331,9 @@ class SwipeMatchService:
         movie_id: str,
         uow: DatabaseUnitOfWork,
     ) -> dict:
-        await uow.swipes.delete_by_room_movie_session(code, movie_id, request_session.get("session_id"))
+        await uow.swipes.delete_by_room_movie_session(
+            code, movie_id, request_session.get("session_id")
+        )
         await uow.matches.delete_active_for_room_movie_user(code, movie_id, user_id)
         if await uow.rooms.pairing_code_exists(code):
             await self._recompute_last_match_for_room(uow, code)

--- a/jellyswipe/static/app.js
+++ b/jellyswipe/static/app.js
@@ -332,6 +332,24 @@
                 const miniBack = document.createElement('div');
                 miniBack.className = 'mini-back';
 
+                // Media type badge
+                const mediaTypeBadge = document.createElement('div');
+                mediaTypeBadge.className = 'media-type-badge';
+                if (m.media_type === 'tv_show') {
+                    mediaTypeBadge.textContent = 'TV Show';
+                    mediaTypeBadge.style.background = '#9c27b0';
+                } else {
+                    mediaTypeBadge.textContent = 'Movie';
+                    mediaTypeBadge.style.background = '#e5a00d';
+                }
+                mediaTypeBadge.style.fontSize = '10px';
+                mediaTypeBadge.style.padding = '2px 6px';
+                mediaTypeBadge.style.borderRadius = '3px';
+                mediaTypeBadge.style.color = 'white';
+                mediaTypeBadge.style.display = 'inline-block';
+                mediaTypeBadge.style.marginBottom = '5px';
+                miniBack.appendChild(mediaTypeBadge);
+
                 // Title text
                 const titleText = document.createElement('div');
                 titleText.className = 'mini-title-text';
@@ -813,7 +831,14 @@
                     document.getElementById('matched-movie-title').innerText = d.last_match.title;
                     document.getElementById('match-popup-poster').src = d.last_match.thumb || '';
                     const heading = document.getElementById('match-heading');
-                    heading.innerText = "IT'S A MATCH!";
+                    
+                    // Update heading based on media type
+                    if (d.last_match.media_type === 'tv_show') {
+                        heading.innerText = "IT'S A TV MATCH!";
+                    } else {
+                        heading.innerText = "IT'S A MATCH!";
+                    }
+                    
                     document.getElementById('match-solo-label').classList.add('hidden');
                     showMatchMetadata(d.last_match);
                     document.getElementById('match-overlay').classList.remove('hidden');

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from jellyswipe.migrations import build_sqlite_url, upgrade_to_head
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-_EXPECTED_REVISION = "0001_phase36"
+_EXPECTED_REVISION = "0002_add_media_type"
 
 
 def _table_names(conn: sqlite3.Connection) -> set[str]:


### PR DESCRIPTION
## Carry media_type through matches, history, and deep-links

Ensure `media_type` is preserved in match records and match history.

**Files to modify:**
- `jellyswipe/services/swipe_match.py`
- `jellyswipe/services/room_lifecycle.py`
- `jellyswipe/static/app.js`

### Acceptance Criteria

- Match records include `media_type` field.
- Match history endpoint returns `media_type` for each match.
- Frontend displays different styling for movie vs TV matches.
- All existing tests pass.

---
Ticket: `ORCH-008`