### PR TITLE
ticket/ORCH-004: Expand provider interfaces with hide_watched parameter

### DIFF
--- a/alembic/versions/0003_add_hide_watched.py
+++ b/alembic/versions/0003_add_hide_watched.py
@@ -1,0 +1,23 @@
+"""Add hide_watched column to rooms table."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0003_add_hide_watched"
+down_revision = "0002_add_media_type"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "rooms",
+        sa.Column("hide_watched", sa.Integer(), nullable=False, server_default="0"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("rooms", "hide_watched")

--- a/jellyswipe/base.py
+++ b/jellyswipe/base.py
@@ -22,7 +22,12 @@ class LibraryMediaProvider(abc.ABC):
         """Genre labels for UI (includes Sci-Fi vs Science Fiction normalization)."""
 
     @abc.abstractmethod
-    def fetch_deck(self, media_types: List[str], genre_name: Optional[str] = None) -> List[dict]:
+    def fetch_deck(
+        self,
+        media_types: List[str],
+        genre_name: Optional[str] = None,
+        hide_watched: bool = False,
+    ) -> List[dict]:
         """Media cards: id, title, summary, thumb, rating, duration, year, media_type."""
 
     @abc.abstractmethod

--- a/jellyswipe/jellyfin_library.py
+++ b/jellyswipe/jellyfin_library.py
@@ -343,13 +343,17 @@ class JellyfinLibraryProvider(LibraryMediaProvider):
         }
 
     def fetch_deck(
-        self, media_types: List[str], genre_name: Optional[str] = None
+        self,
+        media_types: List[str],
+        genre_name: Optional[str] = None,
+        hide_watched: bool = False,
     ) -> List[dict]:
         """Fetch deck cards for the specified media types.
 
         Args:
             media_types: List of media types to fetch ("movie", "tv_show").
             genre_name: Optional genre filter.
+            hide_watched: If True, filter out watched items via Jellyfin's Filters=IsNotPlayed.
 
         Returns:
             List of card dicts with media_type field set.
@@ -366,6 +370,7 @@ class JellyfinLibraryProvider(LibraryMediaProvider):
                     uid=uid,
                     item_type="Movie",
                     genre_name=genre_name,
+                    hide_watched=hide_watched,
                 )
                 all_items.extend(items)
 
@@ -378,6 +383,7 @@ class JellyfinLibraryProvider(LibraryMediaProvider):
                     uid=uid,
                     item_type="Series",
                     genre_name=genre_name,
+                    hide_watched=hide_watched,
                 )
                 all_items.extend(items)
 
@@ -403,6 +409,7 @@ class JellyfinLibraryProvider(LibraryMediaProvider):
         uid: str,
         item_type: str,
         genre_name: Optional[str],
+        hide_watched: bool = False,
     ) -> List[dict]:
         """Fetch items from a single library."""
         params: Dict[str, Any] = {
@@ -412,6 +419,10 @@ class JellyfinLibraryProvider(LibraryMediaProvider):
             "Recursive": "true",
             "Fields": "Overview,RunTimeTicks,ProductionYear,CommunityRating,CriticRating,ChildCount",
         }
+
+        # Add watched filter if requested
+        if hide_watched:
+            params["Filters"] = "IsNotPlayed"
 
         search_genre = "Science Fiction" if genre_name == "Sci-Fi" else genre_name
 

--- a/jellyswipe/models/room.py
+++ b/jellyswipe/models/room.py
@@ -27,6 +27,7 @@ class Room(Base):
     deck_order: Mapped[str | None] = mapped_column(Text, nullable=True)
     include_movies: Mapped[int] = mapped_column(nullable=False, server_default="1")
     include_tv_shows: Mapped[int] = mapped_column(nullable=False, server_default="0")
+    hide_watched: Mapped[int] = mapped_column(nullable=False, server_default="0")
 
     swipes: Mapped[list["Swipe"]] = relationship(
         "Swipe",

--- a/jellyswipe/repositories/rooms.py
+++ b/jellyswipe/repositories/rooms.py
@@ -19,7 +19,11 @@ class RoomRepository:
         self._session = session
 
     async def pairing_code_exists(self, pairing_code: str) -> bool:
-        stmt = select(func.count()).select_from(Room).where(Room.pairing_code == pairing_code)
+        stmt = (
+            select(func.count())
+            .select_from(Room)
+            .where(Room.pairing_code == pairing_code)
+        )
         count = await self._session.scalar(stmt)
         return (count or 0) > 0
 
@@ -33,6 +37,7 @@ class RoomRepository:
         deck_position_json: str,
         include_movies: bool = True,
         include_tv_shows: bool = False,
+        hide_watched: bool = False,
     ) -> None:
         self._session.add(
             Room(
@@ -44,12 +49,15 @@ class RoomRepository:
                 deck_position=deck_position_json,
                 include_movies=1 if include_movies else 0,
                 include_tv_shows=1 if include_tv_shows else 0,
+                hide_watched=1 if hide_watched else 0,
             )
         )
 
     async def get_room(self, pairing_code: str) -> RoomRecord | None:
         row = (
-            await self._session.scalars(select(Room).where(Room.pairing_code == pairing_code))
+            await self._session.scalars(
+                select(Room).where(Room.pairing_code == pairing_code)
+            )
         ).first()
         if row is None:
             return None
@@ -63,31 +71,49 @@ class RoomRepository:
         )
         return result.rowcount or 0
 
-    async def set_deck_position(self, pairing_code: str, deck_position_json: str) -> int:
-        result = await self._session.execute(
-            update(Room).where(Room.pairing_code == pairing_code).values(deck_position=deck_position_json)
-        )
-        return result.rowcount or 0
-
-    async def set_genre_and_deck(
-        self, pairing_code: str, genre: str, movie_data_json: str, deck_position_json: str
+    async def set_deck_position(
+        self, pairing_code: str, deck_position_json: str
     ) -> int:
         result = await self._session.execute(
             update(Room)
             .where(Room.pairing_code == pairing_code)
-            .values(current_genre=genre, movie_data=movie_data_json, deck_position=deck_position_json)
+            .values(deck_position=deck_position_json)
         )
         return result.rowcount or 0
 
-    async def set_last_match_data(self, pairing_code: str, last_match_data_json: str | None) -> int:
+    async def set_genre_and_deck(
+        self,
+        pairing_code: str,
+        genre: str,
+        movie_data_json: str,
+        deck_position_json: str,
+    ) -> int:
         result = await self._session.execute(
-            update(Room).where(Room.pairing_code == pairing_code).values(last_match_data=last_match_data_json)
+            update(Room)
+            .where(Room.pairing_code == pairing_code)
+            .values(
+                current_genre=genre,
+                movie_data=movie_data_json,
+                deck_position=deck_position_json,
+            )
+        )
+        return result.rowcount or 0
+
+    async def set_last_match_data(
+        self, pairing_code: str, last_match_data_json: str | None
+    ) -> int:
+        result = await self._session.execute(
+            update(Room)
+            .where(Room.pairing_code == pairing_code)
+            .values(last_match_data=last_match_data_json)
         )
         return result.rowcount or 0
 
     async def fetch_status(self, pairing_code: str) -> RoomStatusSnapshot | None:
         row = (
-            await self._session.scalars(select(Room).where(Room.pairing_code == pairing_code))
+            await self._session.scalars(
+                select(Room).where(Room.pairing_code == pairing_code)
+            )
         ).first()
         if row is None:
             return None
@@ -104,6 +130,7 @@ class RoomRepository:
             genre=row.current_genre,
             solo=bool(row.solo_mode),
             last_match=last_match,
+            hide_watched=bool(row.hide_watched),
         )
 
     async def fetch_movie_data(self, pairing_code: str) -> str | None:
@@ -112,13 +139,23 @@ class RoomRepository:
         )
 
     async def fetch_stream_snapshot(self, pairing_code: str) -> StreamSnapshot | None:
-        stmt = select(Room.ready, Room.current_genre, Room.solo_mode, Room.last_match_data).where(
-            Room.pairing_code == pairing_code
-        )
+        stmt = select(
+            Room.ready,
+            Room.current_genre,
+            Room.solo_mode,
+            Room.last_match_data,
+            Room.hide_watched,
+        ).where(Room.pairing_code == pairing_code)
         row = (await self._session.execute(stmt)).one_or_none()
         if row is None:
             return None
-        ready_raw, genre, solo_raw, raw_last = row[0], row[1], row[2], row[3]
+        ready_raw, genre, solo_raw, raw_last, hide_watched_raw = (
+            row[0],
+            row[1],
+            row[2],
+            row[3],
+            row[4],
+        )
         last_match: dict[str, Any] | None = None
         last_match_ts: str | float | int | None = None
         if raw_last:
@@ -136,10 +173,13 @@ class RoomRepository:
             solo=bool(solo_raw),
             last_match=last_match,
             last_match_ts=last_match_ts,
+            hide_watched=bool(hide_watched_raw),
         )
 
     async def delete(self, pairing_code: str) -> int:
-        result = await self._session.execute(delete(Room).where(Room.pairing_code == pairing_code))
+        result = await self._session.execute(
+            delete(Room).where(Room.pairing_code == pairing_code)
+        )
         return result.rowcount or 0
 
     @staticmethod
@@ -155,4 +195,5 @@ class RoomRepository:
             deck_order_json=row.deck_order,
             include_movies=bool(row.include_movies),
             include_tv_shows=bool(row.include_tv_shows),
+            hide_watched=bool(row.hide_watched),
         )

--- a/jellyswipe/room_types.py
+++ b/jellyswipe/room_types.py
@@ -17,6 +17,7 @@ class RoomRecord:
     deck_order_json: str | None
     include_movies: bool
     include_tv_shows: bool
+    hide_watched: bool
 
 
 @dataclass(slots=True)
@@ -25,6 +26,7 @@ class RoomStatusSnapshot:
     genre: str
     solo: bool
     last_match: dict | None
+    hide_watched: bool
 
 
 @dataclass(slots=True)
@@ -34,6 +36,7 @@ class StreamSnapshot:
     solo: bool
     last_match: dict | None
     last_match_ts: str | float | int | None
+    hide_watched: bool
 
 
 @dataclass(slots=True)

--- a/jellyswipe/services/room_lifecycle.py
+++ b/jellyswipe/services/room_lifecycle.py
@@ -19,7 +19,10 @@ class UniqueRoomCodeExhaustedError(Exception):
 
 class DeckProvider(Protocol):
     def fetch_deck(
-        self, media_types: list[str], genre_name: str | None = None
+        self,
+        media_types: list[str],
+        genre_name: str | None = None,
+        hide_watched: bool = False,
     ) -> list[dict[str, Any]]: ...
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -233,13 +233,14 @@ class FakeProvider:
     def add_to_user_favorites(self, user_token, movie_id):
         self.favorites_added.append((user_token, movie_id))
 
-    def fetch_deck(self, media_types=None, genre_name=None):
+    def fetch_deck(self, media_types=None, genre_name=None, hide_watched=False):
         """Return a list of fake movie/TV cards for deck testing.
 
         Args:
             media_types: List of media types to fetch ("movie", "tv_show").
                         Defaults to ["movie"] if not specified.
             genre_name: Optional genre filter (ignored in fake implementation).
+            hide_watched: Optional flag to hide watched items (ignored in fake implementation).
 
         Returns:
             List of card dicts with media_type field set.

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -54,8 +54,7 @@ class TestAlembicBaseline:
                 "last_match_data",
                 "deck_position",
                 "deck_order",
-                "include_movies",
-                "include_tv_shows",
+                "hide_watched",
             }
             assert columns["movie_data"]["dflt_value"] in ("'[]'", '"[]"', "[]")
             assert columns["ready"]["dflt_value"] in ("0", "'0'")
@@ -63,13 +62,17 @@ class TestAlembicBaseline:
             assert columns["solo_mode"]["dflt_value"] in ("0", "'0'")
             assert columns["include_movies"]["dflt_value"] in ("1", "'1'")
             assert columns["include_tv_shows"]["dflt_value"] in ("0", "'0'")
+            assert columns["hide_watched"]["dflt_value"] in ("0", "'0'")
         finally:
             conn.close()
 
     def test_auth_sessions_table_has_expected_columns(self, db_path):
         conn = _migrate(db_path)
         try:
-            columns = [row["name"] for row in conn.execute("PRAGMA table_info(auth_sessions)").fetchall()]
+            columns = [
+                row["name"]
+                for row in conn.execute("PRAGMA table_info(auth_sessions)").fetchall()
+            ]
             assert columns == [
                 "session_id",
                 "jellyfin_token",
@@ -83,13 +86,18 @@ class TestAlembicBaseline:
         conn = _migrate(db_path)
         try:
             fk_rows = conn.execute("PRAGMA foreign_key_list(swipes)").fetchall()
-            fk_targets = sorted((row["table"], row["from"], row["to"]) for row in fk_rows)
+            fk_targets = sorted(
+                (row["table"], row["from"], row["to"]) for row in fk_rows
+            )
             assert fk_targets == [
                 ("auth_sessions", "session_id", "session_id"),
                 ("rooms", "room_code", "pairing_code"),
             ]
 
-            indexes = {row["name"] for row in conn.execute("PRAGMA index_list(swipes)").fetchall()}
+            indexes = {
+                row["name"]
+                for row in conn.execute("PRAGMA index_list(swipes)").fetchall()
+            }
             assert "ix_swipes_room_movie_direction" in indexes
             assert "ix_swipes_room_movie_session" in indexes
         finally:
@@ -123,7 +131,10 @@ class TestAlembicBaseline:
             )
             conn.commit()
 
-            room = conn.execute("SELECT movie_data, ready, current_genre, solo_mode, include_movies, include_tv_shows FROM rooms WHERE pairing_code = ?", ("ROOM1",)).fetchone()
+            room = conn.execute(
+                "SELECT movie_data, ready, current_genre, solo_mode, include_movies, include_tv_shows FROM rooms WHERE pairing_code = ?",
+                ("ROOM1",),
+            ).fetchone()
             assert room["movie_data"] == "[]"
             assert room["ready"] == 0
             assert room["current_genre"] == "All"
@@ -139,7 +150,12 @@ class TestAlembicBaseline:
 
         conn = sqlite3.connect(db_path)
         try:
-            tables = [row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()]
+            tables = [
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            ]
             assert "rooms" in tables
             assert "auth_sessions" in tables
         finally:
@@ -152,7 +168,9 @@ class TestRuntimeHelpersStillAvailable:
         assert hasattr(jellyswipe.db, "cleanup_expired_auth_sessions")
         assert inspect.iscoroutinefunction(jellyswipe.db.prepare_runtime_database_async)
         assert inspect.iscoroutinefunction(jellyswipe.db.cleanup_orphan_swipes_async)
-        assert inspect.iscoroutinefunction(jellyswipe.db.cleanup_expired_auth_sessions_async)
+        assert inspect.iscoroutinefunction(
+            jellyswipe.db.cleanup_expired_auth_sessions_async
+        )
 
     def test_db_module_has_no_sqlite3_import(self):
         source = inspect.getsource(jellyswipe.db)
@@ -163,7 +181,9 @@ class TestRuntimeHelpersStillAvailable:
         source = inspect.getsource(jellyswipe.db)
         assert "DELETE FROM swipes" not in source
 
-    def test_prepare_runtime_database_preserves_migrated_tables(self, db_path, monkeypatch):
+    def test_prepare_runtime_database_preserves_migrated_tables(
+        self, db_path, monkeypatch
+    ):
         upgrade_to_head(build_sqlite_url(db_path))
         monkeypatch.setattr(jellyswipe.db_paths.application_db_path, "path", db_path)
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from jellyswipe.migrations import build_sqlite_url, upgrade_to_head
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-_EXPECTED_REVISION = "0002_add_media_type"
+_EXPECTED_REVISION = "0003_add_hide_watched"
 
 
 def _table_names(conn: sqlite3.Connection) -> set[str]:

--- a/tests/test_room_lifecycle.py
+++ b/tests/test_room_lifecycle.py
@@ -272,3 +272,43 @@ async def test_deck_genre_status_matches_semantics(runtime_sessionmaker):
         missing_status = await svc.get_status("0000", uow)
         await session.commit()
     assert missing_status == {"ready": False}
+
+
+@pytest.mark.anyio
+async def test_fetch_status_returns_hide_watched_false_for_new_room(
+    runtime_sessionmaker,
+):
+    svc = RoomLifecycleService()
+    prov = FakeProvider()
+    uid = prov._user_id
+
+    async with runtime_sessionmaker() as session:
+        uow = DatabaseUnitOfWork(session)
+        pc = await force_create_room(svc, prov, uid, uow)
+        await session.commit()
+
+    async with runtime_sessionmaker() as session:
+        uow = DatabaseUnitOfWork(session)
+        snap = await uow.rooms.fetch_status(pc)
+        assert snap is not None
+        assert snap.hide_watched is False
+
+
+@pytest.mark.anyio
+async def test_fetch_stream_snapshot_returns_hide_watched_false_for_new_room(
+    runtime_sessionmaker,
+):
+    svc = RoomLifecycleService()
+    prov = FakeProvider()
+    uid = prov._user_id
+
+    async with runtime_sessionmaker() as session:
+        uow = DatabaseUnitOfWork(session)
+        pc = await force_create_room(svc, prov, uid, uow)
+        await session.commit()
+
+    async with runtime_sessionmaker() as session:
+        uow = DatabaseUnitOfWork(session)
+        snap = await uow.rooms.fetch_stream_snapshot(pc)
+        assert snap is not None
+        assert snap.hide_watched is False


### PR DESCRIPTION
## Expand provider interfaces with hide_watched parameter

Expand the provider interface chain to accept a `hide_watched` boolean parameter and implement server-side watched filtering via Jellyfin's `Filters=IsNotPlayed` API parameter.

**Files to change:**
- `jellyswipe/services/room_lifecycle.py` — update `DeckProvider` protocol: add `hide_watched: bool = False` to `fetch_deck`
- `jellyswipe/base.py` — update `LibraryMediaProvider.fetch_deck` abstract method: add `hide_watched: bool = False`
- `jellyswipe/jellyfin_library.py` — update `JellyfinLibraryProvider.fetch_deck` and `_fetch_items_for_library` to pass and apply `hide_watched` via Jellyfin's `Filters=IsNotPlayed` query parameter
- `tests/conftest.py` or wherever `FakeProvider` is defined — update to accept the new parameter

When `hide_watched=True`, add `"Filters": "IsNotPlayed"` to the `/Items` query params in `_fetch_items_for_library`. Watched state is per-user; the app uses the shared admin identity, so `IsNotPlayed` filters against that user's watched state.


### Acceptance Criteria

- `DeckProvider` protocol in `room_lifecycle.py` updated: `fetch_deck(self, media_types, genre_name=None, hide_watched=False)`
- `LibraryMediaProvider` ABC in `base.py` updated: `fetch_deck(self, media_types, genre_name=None, hide_watched=False)`
- `JellyfinLibraryProvider.fetch_deck` in `jellyfin_library.py` passes `Filters=IsNotPlayed` to Jellyfin `/Items` when `hide_watched=True`
- When `hide_watched=False`, no `Filters` parameter is added (current behavior preserved)
- `_fetch_items_for_library` accepts and applies the `hide_watched` flag
- `FakeProvider` in test fixtures updated to accept `hide_watched` parameter (can be a no-op that returns full deck, or simulates filtering if needed)
- All existing tests pass with `uv run pytest`


---
Ticket: `ORCH-004`