### PR TITLE
ticket/ORCH-004: Expand provider interfaces with hide_watched parameter

### DIFF
--- a/jellyswipe/base.py
+++ b/jellyswipe/base.py
@@ -22,7 +22,12 @@ class LibraryMediaProvider(abc.ABC):
         """Genre labels for UI (includes Sci-Fi vs Science Fiction normalization)."""
 
     @abc.abstractmethod
-    def fetch_deck(self, media_types: List[str], genre_name: Optional[str] = None) -> List[dict]:
+    def fetch_deck(
+        self,
+        media_types: List[str],
+        genre_name: Optional[str] = None,
+        hide_watched: bool = False,
+    ) -> List[dict]:
         """Media cards: id, title, summary, thumb, rating, duration, year, media_type."""
 
     @abc.abstractmethod

--- a/jellyswipe/jellyfin_library.py
+++ b/jellyswipe/jellyfin_library.py
@@ -343,13 +343,17 @@ class JellyfinLibraryProvider(LibraryMediaProvider):
         }
 
     def fetch_deck(
-        self, media_types: List[str], genre_name: Optional[str] = None
+        self,
+        media_types: List[str],
+        genre_name: Optional[str] = None,
+        hide_watched: bool = False,
     ) -> List[dict]:
         """Fetch deck cards for the specified media types.
 
         Args:
             media_types: List of media types to fetch ("movie", "tv_show").
             genre_name: Optional genre filter.
+            hide_watched: When True, filter out watched items via Jellyfin's Filters=IsNotPlayed.
 
         Returns:
             List of card dicts with media_type field set.
@@ -366,6 +370,7 @@ class JellyfinLibraryProvider(LibraryMediaProvider):
                     uid=uid,
                     item_type="Movie",
                     genre_name=genre_name,
+                    hide_watched=hide_watched,
                 )
                 all_items.extend(items)
 
@@ -378,6 +383,7 @@ class JellyfinLibraryProvider(LibraryMediaProvider):
                     uid=uid,
                     item_type="Series",
                     genre_name=genre_name,
+                    hide_watched=hide_watched,
                 )
                 all_items.extend(items)
 
@@ -403,6 +409,7 @@ class JellyfinLibraryProvider(LibraryMediaProvider):
         uid: str,
         item_type: str,
         genre_name: Optional[str],
+        hide_watched: bool = False,
     ) -> List[dict]:
         """Fetch items from a single library."""
         params: Dict[str, Any] = {
@@ -412,6 +419,10 @@ class JellyfinLibraryProvider(LibraryMediaProvider):
             "Recursive": "true",
             "Fields": "Overview,RunTimeTicks,ProductionYear,CommunityRating,CriticRating,ChildCount",
         }
+
+        # Add Filters=IsNotPlayed when hide_watched is True
+        if hide_watched:
+            params["Filters"] = "IsNotPlayed"
 
         search_genre = "Science Fiction" if genre_name == "Sci-Fi" else genre_name
 

--- a/jellyswipe/services/room_lifecycle.py
+++ b/jellyswipe/services/room_lifecycle.py
@@ -19,7 +19,10 @@ class UniqueRoomCodeExhaustedError(Exception):
 
 class DeckProvider(Protocol):
     def fetch_deck(
-        self, media_types: list[str], genre_name: str | None = None
+        self,
+        media_types: list[str],
+        genre_name: str | None = None,
+        hide_watched: bool = False,
     ) -> list[dict[str, Any]]: ...
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -233,13 +233,14 @@ class FakeProvider:
     def add_to_user_favorites(self, user_token, movie_id):
         self.favorites_added.append((user_token, movie_id))
 
-    def fetch_deck(self, media_types=None, genre_name=None):
+    def fetch_deck(self, media_types=None, genre_name=None, hide_watched=False):
         """Return a list of fake movie/TV cards for deck testing.
 
         Args:
             media_types: List of media types to fetch ("movie", "tv_show").
                         Defaults to ["movie"] if not specified.
             genre_name: Optional genre filter (ignored in fake implementation).
+            hide_watched: Optional boolean to hide watched items (ignored in fake implementation).
 
         Returns:
             List of card dicts with media_type field set.


### PR DESCRIPTION
## Expand provider interfaces with hide_watched parameter

Expand the provider interface chain to accept a `hide_watched` boolean parameter and implement server-side watched filtering via Jellyfin's `Filters=IsNotPlayed` API parameter.

**Files to change:**
- `jellyswipe/services/room_lifecycle.py` — update `DeckProvider` protocol: add `hide_watched: bool = False` to `fetch_deck`
- `jellyswipe/base.py` — update `LibraryMediaProvider.fetch_deck` abstract method: add `hide_watched: bool = False`
- `jellyswipe/jellyfin_library.py` — update `JellyfinLibraryProvider.fetch_deck` and `_fetch_items_for_library` to pass and apply `hide_watched` via Jellyfin's `Filters=IsNotPlayed` query parameter
- `tests/conftest.py` or wherever `FakeProvider` is defined — update to accept the new parameter

When `hide_watched=True`, add `"Filters": "IsNotPlayed"` to the `/Items` query params in `_fetch_items_for_library`. Watched state is per-user; the app uses the shared admin identity, so `IsNotPlayed` filters against that user's watched state.


### Acceptance Criteria

- `DeckProvider` protocol in `room_lifecycle.py` updated: `fetch_deck(self, media_types, genre_name=None, hide_watched=False)`
- `LibraryMediaProvider` ABC in `base.py` updated: `fetch_deck(self, media_types, genre_name=None, hide_watched=False)`
- `JellyfinLibraryProvider.fetch_deck` in `jellyfin_library.py` passes `Filters=IsNotPlayed` to Jellyfin `/Items` when `hide_watched=True`
- When `hide_watched=False`, no `Filters` parameter is added (current behavior preserved)
- `_fetch_items_for_library` accepts and applies the `hide_watched` flag
- `FakeProvider` in test fixtures updated to accept `hide_watched` parameter (can be a no-op that returns full deck, or simulates filtering if needed)
- All existing tests pass with `uv run pytest`


---
Ticket: `ORCH-004`