### PR TITLE
ticket/ORCH-008: Frontend Hide Watched toggle pill with SSE sync

### DIFF
--- a/jellyswipe/static/app.js
+++ b/jellyswipe/static/app.js
@@ -4,6 +4,7 @@
         let swipeHistory = [];
         let globalCurrentX = 0;
         let currentGenre = "All";
+        let hideWatched = false;
         let isHistoryView = false;
         let isSoloMode = false;
         let currentRoomCode = null;
@@ -121,6 +122,48 @@
             document.getElementById('genre-pill').innerText = genre === 'All' ? 'Genres ▾' : genre + ' ▾';
             swipeHistory = [];
             renderInitialDeck();
+        }
+
+        async function toggleHideWatched() {
+            const newHideWatched = !hideWatched;
+            const pill = document.getElementById('hide-watched-pill');
+            const previousState = hideWatched;
+
+            pill.innerText = newHideWatched ? 'Hiding Watched...' : 'Showing Watched...';
+
+            try {
+                const res = await apiFetch(`/room/${currentRoomCode}/watched-filter`, {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({ hide_watched: newHideWatched })
+                });
+
+                if (res.status === 422) {
+                    const errorData = await res.json();
+                    alert(errorData.error || 'No unwatched items available');
+                    hideWatched = previousState;
+                    pill.innerText = hideWatched ? 'Hide Watched' : 'Show Watched';
+                    return;
+                }
+
+                if (!res.ok) {
+                    alert('Failed to update watched filter');
+                    hideWatched = previousState;
+                    pill.innerText = hideWatched ? 'Hide Watched' : 'Show Watched';
+                    return;
+                }
+
+                movieStack = await res.json();
+                hideWatched = newHideWatched;
+                pill.innerText = hideWatched ? 'Hide Watched' : 'Show Watched';
+                pill.classList.toggle('active', hideWatched);
+                swipeHistory = [];
+                renderInitialDeck();
+            } catch (err) {
+                console.error('Toggle hide watched failed', err);
+                hideWatched = previousState;
+                pill.innerText = hideWatched ? 'Hide Watched' : 'Show Watched';
+            }
         }
 
         async function addToWatchlist(event, id) {
@@ -249,6 +292,20 @@
             } else {
                 document.getElementById('matches-pill').innerText = 'Matches';
                 document.getElementById('solo-badge').classList.add('hidden');
+            }
+
+            // Load initial hide_watched state from room status
+            try {
+                const statusRes = await apiFetch(`/room/${currentRoomCode}/status`);
+                if (statusRes.ok) {
+                    const statusData = await statusRes.json();
+                    hideWatched = statusData.hide_watched || false;
+                    const pill = document.getElementById('hide-watched-pill');
+                    pill.innerText = hideWatched ? 'Hide Watched' : 'Show Watched';
+                    pill.classList.toggle('active', hideWatched);
+                }
+            } catch (err) {
+                console.error('Failed to load room status', err);
             }
 
             renderInitialDeck();
@@ -483,6 +540,9 @@
 
             const genrePill = document.getElementById('genre-pill');
             if (genrePill) genrePill.onclick = () => toggleGenreModal();
+
+            const hideWatchedPill = document.getElementById('hide-watched-pill');
+            if (hideWatchedPill) hideWatchedPill.onclick = () => toggleHideWatched();
 
             const setupMovies = document.getElementById('setup-movies');
             if (setupMovies) setupMovies.addEventListener('change', updateConfirmButtonState);
@@ -824,6 +884,14 @@
                     const movieRes = await apiFetch(`/room/${currentRoomCode}/deck`);
                     movieStack = await movieRes.json(); swipeHistory = []; renderInitialDeck();
                 }
+                if (d.hide_watched !== undefined && d.hide_watched !== hideWatched) {
+                    hideWatched = d.hide_watched;
+                    const pill = document.getElementById('hide-watched-pill');
+                    pill.innerText = hideWatched ? 'Hide Watched' : 'Show Watched';
+                    pill.classList.toggle('active', hideWatched);
+                    const movieRes = await apiFetch(`/room/${currentRoomCode}/deck`);
+                    movieStack = await movieRes.json(); swipeHistory = []; renderInitialDeck();
+                }
                 if (d.ready && document.getElementById('game-area').classList.contains('hidden')) {
                     loadMovies(d.solo || false);
                 }
@@ -831,14 +899,14 @@
                     document.getElementById('matched-movie-title').innerText = d.last_match.title;
                     document.getElementById('match-popup-poster').src = d.last_match.thumb || '';
                     const heading = document.getElementById('match-heading');
-                    
+
                     // Update heading based on media type
                     if (d.last_match.media_type === 'tv_show') {
                         heading.innerText = "IT'S A TV MATCH!";
                     } else {
                         heading.innerText = "IT'S A MATCH!";
                     }
-                    
+
                     document.getElementById('match-solo-label').classList.add('hidden');
                     showMatchMetadata(d.last_match);
                     document.getElementById('match-overlay').classList.remove('hidden');

--- a/jellyswipe/static/styles.css
+++ b/jellyswipe/static/styles.css
@@ -133,6 +133,8 @@ body::before {
 #game-instruction { position: fixed; bottom: 75px; left: 50%; transform: translateX(-50%); width: 100%; }
 #modal-instruction { position: fixed; bottom: 85px; }
 #genre-pill { position: fixed; top: 15px; right: 15px; width: 100px; height: 35px; border-radius: 20px; border: 1px solid #e5a00d; background: rgba(0,0,0,0.6); color: #e5a00d; font-weight: bold; font-size: 0.8rem; z-index: 10001; cursor: pointer; display: flex; align-items: center; justify-content: center; backdrop-filter: blur(5px); }
+#hide-watched-pill { position: fixed; top: 15px; right: 125px; width: 130px; height: 35px; border-radius: 20px; border: 1px solid #e5a00d; background: rgba(0,0,0,0.6); color: #e5a00d; font-weight: bold; font-size: 0.8rem; z-index: 10001; cursor: pointer; display: flex; align-items: center; justify-content: center; backdrop-filter: blur(5px); }
+#hide-watched-pill.active { background: #e5a00d; color: black; }
 #genre-modal { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.95); z-index: 30000; display: flex; flex-direction: column; align-items: center; padding: 20px; box-sizing: border-box; overflow: hidden; }
 #genre-modal h1 { flex-shrink: 0; margin: 20px 0 15px; }
 #genre-modal .menu-btn { flex-shrink: 0; margin: 15px 0 10px; }

--- a/jellyswipe/templates/index.html
+++ b/jellyswipe/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <title>Jelly-Swipe</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-    
+
     <link rel="manifest" href="/manifest.json">
     <meta name="theme-color" content="#111111">
 
@@ -57,9 +57,9 @@
                 <br>
             </div>
             <div class="history-section">
-                <hr class="section-divider">    
+                <hr class="section-divider">
                 <button id="history-btn" class="menu-btn history-btn">
-                    Match History 
+                    Match History
                 </button>
                 <br>
                 <button class="logout-btn" id="logout-btn">Logout</button>
@@ -67,6 +67,7 @@
         </div>
         <div id="game-area" class="hidden">
             <button id="genre-pill">Genres ▾</button>
+            <button id="hide-watched-pill">Show Watched</button>
             <div id="solo-badge" class="hidden">Solo Mode</div>
             <div id="glow-left" class="glow-side"></div>
             <div id="glow-right" class="glow-side"></div>


### PR DESCRIPTION
## Frontend Hide Watched toggle pill with SSE sync

Add a frontend "Hide Watched" toggle pill next to the existing genre pill in the game area. Wire it to the watched-filter API endpoint and SSE stream for real-time sync across clients.

**Files to change:**
- `jellyswipe/templates/index.html` — add `hide-watched-pill` button element next to `genre-pill` in `game-area`
- `jellyswipe/static/app.js` — add toggle logic, API call, SSE handling, and status-restore logic
- `jellyswipe/static/style.css` (or wherever styles live) — add pill styling consistent with genre pill

**HTML element (next to genre-pill):**
```html
<button id="hide-watched-pill">Show Watched</button>
```

**JavaScript logic:**
1. On click: toggle state, call `POST /room/{code}/watched-filter` with `{"hide_watched": true/false}`
2. On success: update pill text ("Hide Watched" when active, "Show Watched" when inactive), refresh deck from response, reset card stack
3. On 422 error: show brief message (e.g., "No unwatched items"), revert pill to previous state
4. SSE handler: when receiving `hide_watched` delta, update pill state and refresh deck via `GET /room/{code}/deck`
5. On room join: check `GET /room/{code}/status` response for `hide_watched` and set initial pill state
6. Variable `let hideWatched = false;` tracks current state (mirrors `currentGenre` pattern)

Styling: pill should match the existing genre pill style. When active (hide_watched=true), apply an active/selected visual state.


### Acceptance Criteria

- A "Hide Watched" toggle pill appears next to the genre pill in `game-area`
- Clicking the pill toggles between "Hide Watched" (active/on) and "Show Watched" (inactive/off) states
- Toggling calls `POST /room/{code}/watched-filter` with `{"hide_watched": true/false}`
- On success, the frontend refreshes the card deck from the response (same as genre change)
- On empty-deck error (422), shows a user-friendly message and reverts the toggle to its previous state
- SSE `hide_watched` delta updates the toggle state for the other connected client
- On room join / reconnect, the toggle reflects the current `hide_watched` state from `GET /room/{code}/status`
- Toggle defaults to "off" (show watched) for new sessions
- The toggle is a separate pill element, not embedded inside the genre modal


---
Ticket: `ORCH-008`