### PR TITLE
ticket/ORCH-002: Create post-commit SessionNotifier with Future-based pub/sub

### DIFF
--- a/jellyswipe/notifier.py
+++ b/jellyswipe/notifier.py
@@ -1,0 +1,81 @@
+"""Future-based pub/sub for waking SSE subscribers after committed events.
+
+Single-process asyncio only. The event ledger is the source of truth;
+this module is a latency optimization.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+
+class SessionNotifier:
+    """Future-based pub/sub for waking SSE subscribers after committed events.
+
+    Single-process asyncio only. The event ledger is the source of truth;
+    this module is a latency optimization.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the notifier with an empty subscriber registry."""
+        self._subscribers: dict[str, set[asyncio.Future]] = {}
+
+    def subscribe(self, room_code: str) -> asyncio.Future:
+        """Register a subscriber and return a Future that resolves on notify().
+
+        The caller awaits this Future. When notify() fires, the Future
+        resolves with None. The caller must then re-subscribe for the
+        next event cycle.
+
+        Args:
+            room_code: The room code to subscribe to.
+
+        Returns:
+            An asyncio.Future that resolves when notify() is called for this room.
+        """
+        future: asyncio.Future = asyncio.Future()
+        if room_code not in self._subscribers:
+            self._subscribers[room_code] = set()
+        self._subscribers[room_code].add(future)
+        return future
+
+    def notify(self, room_code: str) -> None:
+        """Resolve all registered Futures for the given room code.
+
+        Called ONLY after the event-append transaction commits successfully.
+        Subscribers wake, read new events from the ledger, and re-subscribe.
+
+        Args:
+            room_code: The room code to notify.
+        """
+        if room_code not in self._subscribers:
+            return
+
+        futures = self._subscribers.pop(room_code)
+        for future in futures:
+            if not future.done():
+                future.set_result(None)
+
+    def unsubscribe(self, room_code: str, future: asyncio.Future) -> None:
+        """Remove a subscriber's Future without resolving it.
+
+        Called on SSE disconnect or stream exit to prevent leaks.
+
+        Args:
+            room_code: The room code to unsubscribe from.
+            future: The Future to remove.
+        """
+        if room_code not in self._subscribers:
+            return
+
+        self._subscribers[room_code].discard(future)
+        if not future.done():
+            future.cancel()
+
+        # Clean up empty sets to prevent memory leaks
+        if not self._subscribers[room_code]:
+            del self._subscribers[room_code]
+
+
+# Module-level singleton instance
+notifier = SessionNotifier()

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,0 +1,179 @@
+"""Unit tests for SessionNotifier."""
+
+import asyncio
+
+import pytest
+
+from jellyswipe.notifier import SessionNotifier
+
+
+@pytest.mark.anyio
+async def test_subscribe_and_notify_resolves_future():
+    """Test that subscribe + notify: subscriber's Future resolves."""
+    notifier = SessionNotifier()
+    future = notifier.subscribe("room123")
+
+    assert not future.done()
+
+    notifier.notify("room123")
+
+    assert future.done()
+    assert future.result() is None
+
+
+@pytest.mark.anyio
+async def test_multiple_subscribers_same_room_all_resolve():
+    """Test multiple subscribers on same room: all Futures resolve on single notify."""
+    notifier = SessionNotifier()
+    future1 = notifier.subscribe("room123")
+    future2 = notifier.subscribe("room123")
+    future3 = notifier.subscribe("room123")
+
+    assert not future1.done()
+    assert not future2.done()
+    assert not future3.done()
+
+    notifier.notify("room123")
+
+    assert future1.done()
+    assert future2.done()
+    assert future3.done()
+    assert future1.result() is None
+    assert future2.result() is None
+    assert future3.result() is None
+
+
+@pytest.mark.anyio
+async def test_subscribers_different_rooms_isolated():
+    """Test subscribers on different rooms: only the target room's Futures resolve."""
+    notifier = SessionNotifier()
+    future_room1 = notifier.subscribe("room1")
+    future_room2 = notifier.subscribe("room2")
+
+    notifier.notify("room1")
+
+    assert future_room1.done()
+    assert not future_room2.done()
+
+    notifier.notify("room2")
+    assert future_room2.done()
+
+
+@pytest.mark.anyio
+async def test_unsubscribe_removes_future_without_resolving():
+    """Test unsubscribe: removed Future does NOT resolve on subsequent notify."""
+    notifier = SessionNotifier()
+    future = notifier.subscribe("room123")
+
+    assert not future.done()
+
+    notifier.unsubscribe("room123", future)
+
+    assert future.cancelled()
+
+    notifier.notify("room123")
+    # Future should still be cancelled (not resolved with a result)
+    assert future.cancelled()
+
+
+@pytest.mark.anyio
+async def test_unsubscribe_cleanup_empty_dict_entry():
+    """Test unsubscribe cleanup: internal dict entry is cleaned up when last subscriber leaves."""
+    notifier = SessionNotifier()
+    future = notifier.subscribe("room123")
+
+    assert "room123" in notifier._subscribers
+
+    notifier.unsubscribe("room123", future)
+
+    assert "room123" not in notifier._subscribers
+
+
+@pytest.mark.anyio
+async def test_notify_with_no_subscribers_no_error():
+    """Test notify with no subscribers: no error raised."""
+    notifier = SessionNotifier()
+
+    # Should not raise
+    notifier.notify("nonexistent_room")
+
+
+@pytest.mark.anyio
+async def test_futures_cleared_after_notify():
+    """Test subscriber count after notify: Futures are cleared from the set after resolution."""
+    notifier = SessionNotifier()
+    notifier.subscribe("room123")
+    notifier.subscribe("room123")
+
+    assert "room123" in notifier._subscribers
+    assert len(notifier._subscribers["room123"]) == 2
+
+    notifier.notify("room123")
+
+    # After notify, the room should be removed from subscribers
+    assert "room123" not in notifier._subscribers
+
+
+@pytest.mark.anyio
+async def test_cancelled_future_handling():
+    """Test cancelled Future handling: if a Future is already cancelled, notify does not raise."""
+    notifier = SessionNotifier()
+    future = notifier.subscribe("room123")
+
+    # Cancel the future before notify
+    future.cancel()
+    assert future.cancelled()
+
+    # Should not raise
+    notifier.notify("room123")
+
+
+@pytest.mark.anyio
+async def test_unsubscribe_nonexistent_room_no_error():
+    """Test unsubscribe from nonexistent room does not raise."""
+    notifier = SessionNotifier()
+    future = asyncio.Future()
+
+    # Should not raise
+    notifier.unsubscribe("nonexistent_room", future)
+
+
+@pytest.mark.anyio
+async def test_multiple_notify_cycles():
+    """Test that subscribers must re-subscribe after each notify."""
+    notifier = SessionNotifier()
+
+    # First cycle
+    future1 = notifier.subscribe("room123")
+    notifier.notify("room123")
+    assert future1.done()
+
+    # Second cycle - must subscribe again
+    future2 = notifier.subscribe("room123")
+    assert not future2.done()
+
+    notifier.notify("room123")
+    assert future2.done()
+
+
+@pytest.mark.anyio
+async def test_unsubscribe_one_of_multiple_subscribers():
+    """Test unsubscribing one subscriber leaves others intact."""
+    notifier = SessionNotifier()
+    future1 = notifier.subscribe("room123")
+    future2 = notifier.subscribe("room123")
+    future3 = notifier.subscribe("room123")
+
+    notifier.unsubscribe("room123", future2)
+
+    assert "room123" in notifier._subscribers
+    assert len(notifier._subscribers["room123"]) == 2
+    assert future1 in notifier._subscribers["room123"]
+    assert future2 not in notifier._subscribers["room123"]
+    assert future3 in notifier._subscribers["room123"]
+
+    notifier.notify("room123")
+
+    assert future1.done()
+    assert future2.cancelled()  # Was cancelled
+    assert future3.done()


### PR DESCRIPTION
## Create post-commit SessionNotifier with Future-based pub/sub

Create the in-process post-commit notifier that wakes connected SSE subscribers immediately after committed events.

**What to build:**

Create `jellyswipe/notifier.py` with a `SessionNotifier` class:

```python
class SessionNotifier:
    """Future-based pub/sub for waking SSE subscribers after committed events.
    
    Single-process asyncio only. The event ledger is the source of truth;
    this module is a latency optimization.
    """
    
    def subscribe(self, room_code: str) -> asyncio.Future:
        """Register a subscriber and return a Future that resolves on notify().
        
        The caller awaits this Future. When notify() fires, the Future
        resolves with None. The caller must then re-subscribe for the
        next event cycle.
        """
        ...
    
    def notify(self, room_code: str) -> None:
        """Resolve all registered Futures for the given room code.
        
        Called ONLY after the event-append transaction commits successfully.
        Subscribers wake, read new events from the ledger, and re-subscribe.
        """
        ...
    
    def unsubscribe(self, room_code: str, future: asyncio.Future) -> None:
        """Remove a subscriber's Future without resolving it.
        
        Called on SSE disconnect or stream exit to prevent leaks.
        """
        ...
```

**Design decisions (from grilling):**
- Module-level singleton instance (or a class instance that the app holds)
- Internally: `dict[str, set[asyncio.Future]]` mapping room_code → registered futures
- `subscribe()` creates a new `asyncio.Future` and adds it to the set for that room_code
- `notify()` iterates the set, calls `future.set_result(None)` on each, then clears the set
- `unsubscribe()` removes the future from the set (and cancels it if still pending)
- No external dependencies — pure asyncio primitives
- This module does NOT read or write the database — it only signals wakeups

**Integration points:**
- Service methods (`RoomLifecycleService`, `SwipeMatchService`) call `notifier.notify(room_code)` AFTER the session commit
- SSE stream generator calls `notifier.subscribe(room_code)` to await wakeups, then reads events from the ledger
- SSE stream calls `notifier.unsubscribe(room_code, future)` on disconnect/exit


### Acceptance Criteria

1. `SessionNotifier.subscribe(room_code)` returns an `asyncio.Future` that resolves when `notify(room_code)` is called
2. `SessionNotifier.notify(room_code)` resolves all registered Futures for that room
3. `SessionNotifier.unsubscribe(room_code, future)` removes the future without resolving it
4. Multiple subscribers on the same room code all wake on notify
5. Subscribers on different room codes do NOT wake when an unrelated room is notified
6. Unsubscribed futures are cleaned up and do not leak
7. notify() on a room with no subscribers is a no-op (no error)
8. All public methods are safe for single-process asyncio (no threading primitives needed)


---
Ticket: `ORCH-002`