### PR TITLE
ticket/ORCH-003: Wire session instance lifecycle and event emission into RoomLifecycleService

### DIFF
--- a/jellyswipe/__init__.py
+++ b/jellyswipe/__init__.py
@@ -102,6 +102,35 @@ class RequestIdMiddleware(BaseHTTPMiddleware):
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     _logger.info("jellyswipe_startup")
+
+    # Clean up orphaned session instances from previous runs
+    try:
+        import datetime
+
+        from jellyswipe.db_runtime import get_sessionmaker
+        from jellyswipe.db_uow import DatabaseUnitOfWork
+
+        async with get_sessionmaker()() as session:
+            uow = DatabaseUnitOfWork(session)
+            # Find instances marked as "closing" for more than 5 minutes
+            cutoff = (
+                datetime.datetime.now(datetime.timezone.utc)
+                - datetime.timedelta(minutes=5)
+            ).isoformat()
+
+            # For each stale closing instance, complete the cleanup
+            closing_instances = await uow.session_instances.get_closing_before(cutoff)
+            for instance in closing_instances:
+                _logger.info("Cleaning up orphaned instance: %s", instance.instance_id)
+                await uow.session_instances.mark_closed(instance.instance_id)
+                await uow.session_events.delete_for_instance(instance.instance_id)
+                await uow.session_instances.delete(instance.instance_id)
+
+            await session.commit()
+    except Exception:
+        # If cleanup fails during startup, log and continue — the app should still start
+        _logger.exception("Failed to clean up orphaned session instances on startup")
+
     yield
     global _provider_singleton
     _provider_singleton = None

--- a/jellyswipe/repositories/session_events.py
+++ b/jellyswipe/repositories/session_events.py
@@ -46,19 +46,11 @@ class SessionInstanceRepository:
         """Mark a session instance as closing."""
         from datetime import datetime, timezone
 
-        await self._session.execute(
-            text("""
-                UPDATE session_instances
-                SET status = :status, closed_at = :closed_at
-                WHERE instance_id = :instance_id
-            """),
-            {
-                "status": "closing",
-                "closed_at": datetime.now(timezone.utc).isoformat(),
-                "instance_id": instance_id,
-            },
-        )
-        await self._session.flush()
+        instance = await self.get_by_instance_id(instance_id)
+        if instance:
+            instance.status = "closing"
+            instance.closed_at = datetime.now(timezone.utc).isoformat()
+            await self._session.flush()
 
     async def mark_closed(self, instance_id: str) -> None:
         """Mark a session instance as closed."""
@@ -99,6 +91,29 @@ class SessionInstanceRepository:
             {"cutoff": cutoff_iso},
         )
         return result.rowcount or 0
+
+    async def get_closing_before(self, cutoff_iso: str) -> list[SessionInstance]:
+        """Get instances marked as 'closing' before the cutoff time."""
+        result = await self._session.execute(
+            text("""
+                SELECT * FROM session_instances
+                WHERE status = 'closing' AND closed_at < :cutoff
+            """),
+            {"cutoff": cutoff_iso},
+        )
+        rows = result.mappings().all()
+        instances = []
+        for row in rows:
+            instances.append(
+                SessionInstance(
+                    instance_id=row["instance_id"],
+                    pairing_code=row["pairing_code"],
+                    status=row["status"],
+                    created_at=row["created_at"],
+                    closed_at=row["closed_at"],
+                )
+            )
+        return instances
 
 
 class SessionEventRepository:

--- a/jellyswipe/routers/rooms.py
+++ b/jellyswipe/routers/rooms.py
@@ -22,6 +22,7 @@ from sse_starlette.sse import EventSourceResponse
 from jellyswipe import XSSSafeJSONResponse
 from jellyswipe.db_runtime import get_sessionmaker
 from jellyswipe.dependencies import AuthUser, DBUoW, get_provider, require_auth
+from jellyswipe.notifier import notifier
 from jellyswipe.repositories.rooms import RoomRepository
 from jellyswipe.services.room_lifecycle import (
     EmptyDeckError,
@@ -133,7 +134,7 @@ async def create_room(
         )
 
     try:
-        return await room_lifecycle_service.create_room(
+        result = await room_lifecycle_service.create_room(
             request.session,
             user.user_id,
             get_provider(),
@@ -142,6 +143,9 @@ async def create_room(
             include_tv_shows=include_tv_shows,
             solo=solo,
         )
+        # Commit the session to persist session_instances row
+        await uow.session.commit()
+        return result
     except UniqueRoomCodeExhaustedError:
         return XSSSafeJSONResponse(
             content={"error": "Could not generate unique room code"}, status_code=503
@@ -169,6 +173,9 @@ async def join_room_route(
     )
     if payload is None:
         return XSSSafeJSONResponse(content={"error": "Invalid Code"}, status_code=404)
+    # Commit before notifying to ensure events are persisted
+    await uow.session.commit()
+    notifier.notify(code)
     return payload
 
 
@@ -233,9 +240,13 @@ async def quit_room(
     code: str, request: Request, uow: DBUoW, user: AuthUser = Depends(require_auth)
 ):
     """Quit a room and archive matches."""
-    return await room_lifecycle_service.quit_room(
+    result = await room_lifecycle_service.quit_room(
         code, request.session, user.user_id, uow
     )
+    # Commit before notifying to ensure events are persisted
+    await uow.session.commit()
+    notifier.notify(code)
+    return result
 
 
 @rooms_router.post("/matches/delete")
@@ -311,6 +322,9 @@ async def set_genre(
         new_list = await room_lifecycle_service.set_genre(
             code, genre, get_provider(), uow
         )
+        # Commit before notifying to ensure events are persisted
+        await uow.session.commit()
+        notifier.notify(code)
         return new_list
     except EmptyDeckError as e:
         return XSSSafeJSONResponse(content={"error": str(e)}, status_code=400)
@@ -335,9 +349,13 @@ async def set_watched_filter_route(
             content={"error": "hide_watched must be a boolean"}, status_code=400
         )
     try:
-        return await room_lifecycle_service.set_watched_filter(
+        result = await room_lifecycle_service.set_watched_filter(
             code, hide_watched, get_provider(), uow
         )
+        # Commit before notifying to ensure events are persisted
+        await uow.session.commit()
+        notifier.notify(code)
+        return result
     except EmptyDeckError:
         return XSSSafeJSONResponse(
             content={"error": "No unwatched items available"}, status_code=422

--- a/jellyswipe/services/room_lifecycle.py
+++ b/jellyswipe/services/room_lifecycle.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import secrets
 from typing import Any, Protocol
+from uuid import uuid4
 
 from jellyswipe.db_uow import DatabaseUnitOfWork
+from jellyswipe.db_runtime import get_sessionmaker
 from jellyswipe.room_types import MatchRecord
 
 logger = logging.getLogger(__name__)
@@ -83,7 +86,10 @@ class RoomLifecycleService:
         for _ in range(10):
             pairing_code = str(secrets.randbelow(9000) + 1000)
             exists = await uow.rooms.pairing_code_exists(pairing_code)
-            if exists:
+            reserved = await uow.session_instances.is_pairing_code_reserved(
+                pairing_code
+            )
+            if exists or reserved:
                 continue
             # Build media_types list from boolean flags
             media_types = []
@@ -107,6 +113,7 @@ class RoomLifecycleService:
                 movie_list = interleaved
 
             deck_json = json.dumps({user_id: 0})
+            instance_id = uuid4().hex
             await uow.rooms.create(
                 pairing_code,
                 movie_data_json=json.dumps(movie_list),
@@ -117,9 +124,12 @@ class RoomLifecycleService:
                 include_movies=include_movies,
                 include_tv_shows=include_tv_shows,
             )
+            await uow.session_instances.create(
+                instance_id=instance_id, pairing_code=pairing_code
+            )
             session_dict["active_room"] = pairing_code
             session_dict["solo_mode"] = solo
-            return {"pairing_code": pairing_code}
+            return {"pairing_code": pairing_code, "instance_id": instance_id}
 
         raise UniqueRoomCodeExhaustedError()
 
@@ -133,12 +143,16 @@ class RoomLifecycleService:
         for _ in range(10):
             pairing_code = str(secrets.randbelow(9000) + 1000)
             exists = await uow.rooms.pairing_code_exists(pairing_code)
-            if exists:
+            reserved = await uow.session_instances.is_pairing_code_reserved(
+                pairing_code
+            )
+            if exists or reserved:
                 continue
             # Build media_types list from boolean flags - solo mode defaults to movies only
             media_types = ["movie"]
             movie_list = provider.fetch_deck(media_types=media_types)
             deck_json = json.dumps({user_id: 0})
+            instance_id = uuid4().hex
             await uow.rooms.create(
                 pairing_code,
                 movie_data_json=json.dumps(movie_list),
@@ -147,9 +161,12 @@ class RoomLifecycleService:
                 solo_mode=True,
                 deck_position_json=deck_json,
             )
+            await uow.session_instances.create(
+                instance_id=instance_id, pairing_code=pairing_code
+            )
             session_dict["active_room"] = pairing_code
             session_dict["solo_mode"] = True
-            return {"pairing_code": pairing_code}
+            return {"pairing_code": pairing_code, "instance_id": instance_id}
 
         raise UniqueRoomCodeExhaustedError()
 
@@ -177,6 +194,13 @@ class RoomLifecycleService:
         await uow.rooms.set_ready(code, True)
         await uow.rooms.set_deck_position(code, json.dumps(positions))
 
+        # Append session_ready event
+        instance = await uow.session_instances.get_by_pairing_code(code)
+        if instance:
+            await uow.session_events.append(
+                instance.instance_id, "session_ready", json.dumps({})
+            )
+
         session_dict["active_room"] = code
         session_dict["solo_mode"] = False
         return {"status": "success"}
@@ -188,12 +212,32 @@ class RoomLifecycleService:
         user_id: str,
         uow: DatabaseUnitOfWork,
     ) -> dict[str, str]:
+        # Look up instance and append session_closed event
+        instance = await uow.session_instances.get_by_pairing_code(code)
+        if instance:
+            await uow.session_events.append(
+                instance.instance_id, "session_closed", json.dumps({})
+            )
+            await uow.session_instances.mark_closing(instance.instance_id)
+            # Schedule background cleanup task
+            asyncio.create_task(self._cleanup_after_grace(instance.instance_id))
+
         await uow.rooms.delete(code)
         await uow.swipes.delete_room_swipes(code)
         await uow.matches.archive_active_for_room(code)
         session_dict.pop("active_room", None)
         session_dict.pop("solo_mode", None)
         return {"status": "session_ended"}
+
+    async def _cleanup_after_grace(self, instance_id: str) -> None:
+        """Clean up session instance after 60-second grace period."""
+        await asyncio.sleep(60)
+        async with get_sessionmaker()() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.session_instances.mark_closed(instance_id)
+            await uow.session_events.delete_for_instance(instance_id)
+            await uow.session_instances.delete(instance_id)
+            await session.commit()
 
     async def get_deck(
         self,
@@ -325,7 +369,14 @@ class RoomLifecycleService:
         uow: DatabaseUnitOfWork,
     ) -> list[dict[str, Any]]:
         """Set genre filter and rebuild deck."""
-        return await self._rebuild_deck(code, provider, uow, genre=genre)
+        new_deck = await self._rebuild_deck(code, provider, uow, genre=genre)
+        # Append genre_changed event on success
+        instance = await uow.session_instances.get_by_pairing_code(code)
+        if instance:
+            await uow.session_events.append(
+                instance.instance_id, "genre_changed", json.dumps({"genre": genre})
+            )
+        return new_deck
 
     async def set_watched_filter(
         self,
@@ -335,7 +386,18 @@ class RoomLifecycleService:
         uow: DatabaseUnitOfWork,
     ) -> list[dict[str, Any]]:
         """Set watched filter and rebuild deck."""
-        return await self._rebuild_deck(code, provider, uow, hide_watched=hide_watched)
+        new_deck = await self._rebuild_deck(
+            code, provider, uow, hide_watched=hide_watched
+        )
+        # Append hide_watched_changed event on success
+        instance = await uow.session_instances.get_by_pairing_code(code)
+        if instance:
+            await uow.session_events.append(
+                instance.instance_id,
+                "hide_watched_changed",
+                json.dumps({"hide_watched": hide_watched}),
+            )
+        return new_deck
 
     async def get_status(self, code: str, uow: DatabaseUnitOfWork) -> dict[str, Any]:
         snapshot = await uow.rooms.fetch_status(code)

--- a/tests/test_room_lifecycle.py
+++ b/tests/test_room_lifecycle.py
@@ -7,7 +7,6 @@ import json
 import jellyswipe.db
 import jellyswipe.db_runtime
 import pytest
-from sqlalchemy import update
 from jellyswipe.db_runtime import (
     build_async_sqlite_url,
     dispose_runtime,
@@ -17,7 +16,6 @@ from jellyswipe.db_runtime import (
 from jellyswipe.db_uow import DatabaseUnitOfWork
 from jellyswipe.migrations import build_sqlite_url, upgrade_to_head
 from jellyswipe.models.match import Match
-from jellyswipe.models.room import Room
 from jellyswipe.room_types import MatchRecord
 from jellyswipe.services.room_lifecycle import RoomLifecycleService
 from tests.conftest import FakeProvider
@@ -284,7 +282,6 @@ async def test_fetch_status_returns_hide_watched_false_for_new_room(
         snap = await uow.rooms.fetch_status(pc)
         assert snap is not None
         assert snap.hide_watched is False
-
 
 
 @pytest.mark.anyio
@@ -554,3 +551,274 @@ async def test_solo_session_watched_filter(runtime_sessionmaker):
         assert snap_after.solo is True
         assert isinstance(new_deck, list)
         assert len(new_deck) > 0
+
+
+# ============================================================================
+# Session instance lifecycle and event emission tests (ORCH-003)
+# ============================================================================
+
+
+@pytest.mark.anyio
+async def test_create_room_creates_session_instance(runtime_sessionmaker):
+    """Test create_room creates a session_instances row with status='active' and returns instance_id."""
+    svc = RoomLifecycleService()
+    prov = FakeProvider()
+    uid = prov._user_id
+    sess: dict = {}
+
+    async with runtime_sessionmaker() as session:
+        uow = DatabaseUnitOfWork(session)
+        result = await svc.create_room(sess, uid, prov, uow)
+
+        assert "instance_id" in result
+        instance_id = result["instance_id"]
+
+        # Verify session_instances row was created
+        instance = await uow.session_instances.get_by_instance_id(instance_id)
+        assert instance is not None
+        assert instance.status == "active"
+        assert instance.pairing_code == result["pairing_code"]
+
+        await session.commit()
+
+
+@pytest.mark.anyio
+async def test_create_room_retries_if_pairing_code_reserved(runtime_sessionmaker):
+    """Test create_room retries code generation if pairing code is reserved by an active instance."""
+    svc = RoomLifecycleService()
+    prov = FakeProvider()
+    uid = prov._user_id
+
+    async with runtime_sessionmaker() as session:
+        uow = DatabaseUnitOfWork(session)
+
+        # Manually reserve a pairing code with an active session instance
+        await uow.session_instances.create(
+            instance_id="reserved-instance-id", pairing_code="1234"
+        )
+        await session.commit()
+
+        # Now create a room - it should not use "1234"
+        sess: dict = {}
+        result = await svc.create_room(sess, uid, prov, uow)
+
+        # Verify the room was created with a different code
+        assert result["pairing_code"] != "1234"
+        assert result["instance_id"] is not None
+
+        # Verify the reserved instance is still there
+        reserved = await uow.session_instances.get_by_pairing_code("1234")
+        assert reserved is not None
+        assert reserved.instance_id == "reserved-instance-id"
+
+        await session.commit()
+
+
+@pytest.mark.anyio
+async def test_join_room_appends_session_ready_event(runtime_sessionmaker):
+    """Test join_room appends a session_ready event to the ledger for the correct instance."""
+    svc = RoomLifecycleService()
+    prov = FakeProvider()
+    creator = "user-a"
+    joiner = "user-b"
+
+    async with runtime_sessionmaker() as session:
+        uow = DatabaseUnitOfWork(session)
+        pc = await force_create_room(svc, prov, creator, uow)
+
+        # Get the instance_id for this room
+        instance = await uow.session_instances.get_by_pairing_code(pc)
+        assert instance is not None
+        instance_id = instance.instance_id
+
+        # Join the room
+        sess_join: dict = {}
+        resp = await svc.join_room(pc, sess_join, joiner, uow)
+        await session.commit()
+
+        assert resp == {"status": "success"}
+
+        # Verify session_ready event was appended
+        events = await uow.session_events.read_after(instance_id, 0)
+        assert len(events) == 1
+        assert events[0].event_type == "session_ready"
+        assert events[0].payload_json == "{}"
+
+
+@pytest.mark.anyio
+async def test_set_genre_appends_genre_changed_event(runtime_sessionmaker):
+    """Test set_genre on success appends genre_changed event with correct genre payload."""
+    svc = RoomLifecycleService()
+    prov = FakeProvider()
+    uid = prov._user_id
+
+    async with runtime_sessionmaker() as session:
+        uow = DatabaseUnitOfWork(session)
+        pc = await force_create_room(svc, prov, uid, uow)
+
+        # Get the instance_id
+        instance = await uow.session_instances.get_by_pairing_code(pc)
+        assert instance is not None
+        instance_id = instance.instance_id
+
+        # Set genre
+        await svc.set_genre(pc, "Action", prov, uow)
+        await session.commit()
+
+        # Verify genre_changed event was appended
+        events = await uow.session_events.read_after(instance_id, 0)
+        assert len(events) == 1
+        assert events[0].event_type == "genre_changed"
+        payload = json.loads(events[0].payload_json)
+        assert payload == {"genre": "Action"}
+
+
+@pytest.mark.anyio
+async def test_set_genre_empty_deck_no_event(runtime_sessionmaker):
+    """Test set_genre on EmptyDeckError does NOT append any event."""
+    svc = RoomLifecycleService()
+    prov = FakeProvider()
+    uid = prov._user_id
+
+    async with runtime_sessionmaker() as session:
+        uow = DatabaseUnitOfWork(session)
+        pc = await force_create_room(svc, prov, uid, uow)
+
+        # Get the instance_id
+        instance = await uow.session_instances.get_by_pairing_code(pc)
+        assert instance is not None
+        instance_id = instance.instance_id
+
+        # Mock provider to return empty deck
+        original_fetch = prov.fetch_deck
+
+        def mock_fetch(media_types=None, genre_name=None, hide_watched=False):
+            return []
+
+        prov.fetch_deck = mock_fetch
+
+        # Attempt to change genre (should raise EmptyDeckError)
+        from jellyswipe.services.room_lifecycle import EmptyDeckError
+
+        with pytest.raises(EmptyDeckError):
+            await svc.set_genre(pc, "Action", prov, uow)
+
+        # Verify NO event was appended
+        events = await uow.session_events.read_after(instance_id, 0)
+        assert len(events) == 0
+
+        prov.fetch_deck = original_fetch
+        await session.commit()
+
+
+@pytest.mark.anyio
+async def test_set_watched_filter_appends_event(runtime_sessionmaker):
+    """Test set_watched_filter on success appends hide_watched_changed event."""
+    svc = RoomLifecycleService()
+    prov = FakeProvider()
+    uid = prov._user_id
+
+    async with runtime_sessionmaker() as session:
+        uow = DatabaseUnitOfWork(session)
+        pc = await force_create_room(svc, prov, uid, uow)
+
+        # Get the instance_id
+        instance = await uow.session_instances.get_by_pairing_code(pc)
+        assert instance is not None
+        instance_id = instance.instance_id
+
+        # Set watched filter
+        await svc.set_watched_filter(pc, True, prov, uow)
+        await session.commit()
+
+        # Verify hide_watched_changed event was appended
+        events = await uow.session_events.read_after(instance_id, 0)
+        assert len(events) == 1
+        assert events[0].event_type == "hide_watched_changed"
+        payload = json.loads(events[0].payload_json)
+        assert payload == {"hide_watched": True}
+
+
+@pytest.mark.anyio
+async def test_quit_room_appends_session_closed_and_marks_closing(runtime_sessionmaker):
+    """Test quit_room appends session_closed event, marks instance 'closing' with closed_at."""
+    svc = RoomLifecycleService()
+    prov = FakeProvider()
+    uid = prov._user_id
+
+    async with runtime_sessionmaker() as session:
+        uow = DatabaseUnitOfWork(session)
+        pc = await force_create_room(svc, prov, uid, uow)
+
+        # Get the instance_id
+        instance = await uow.session_instances.get_by_pairing_code(pc)
+        assert instance is not None
+        instance_id = instance.instance_id
+
+        # Quit the room
+        sess: dict = {"active_room": pc, "solo_mode": False}
+        out = await svc.quit_room(pc, sess, uid, uow)
+        await session.commit()
+
+        assert out == {"status": "session_ended"}
+
+        # Verify session_closed event was appended
+        events = await uow.session_events.read_after(instance_id, 0)
+        assert len(events) == 1
+        assert events[0].event_type == "session_closed"
+
+        # Verify instance is marked as 'closing' with closed_at
+        instance_after = await uow.session_instances.get_by_instance_id(instance_id)
+        assert instance_after is not None
+        assert instance_after.status == "closing"
+        assert instance_after.closed_at is not None
+
+
+@pytest.mark.anyio
+async def test_quit_room_schedules_background_cleanup(runtime_sessionmaker):
+    """Test quit_room schedules background cleanup task."""
+    import asyncio
+
+    svc = RoomLifecycleService()
+    prov = FakeProvider()
+    uid = prov._user_id
+
+    async with runtime_sessionmaker() as session:
+        uow = DatabaseUnitOfWork(session)
+        pc = await force_create_room(svc, prov, uid, uow)
+
+        # Count tasks before quit
+        tasks_before = len(asyncio.all_tasks())
+
+        # Quit the room
+        sess: dict = {"active_room": pc, "solo_mode": False}
+        await svc.quit_room(pc, sess, uid, uow)
+        await session.commit()
+
+        # Count tasks after quit - should have one more (the cleanup task)
+        tasks_after = len(asyncio.all_tasks())
+        assert tasks_after > tasks_before, "Background cleanup task should be scheduled"
+
+
+@pytest.mark.anyio
+async def test_get_status_no_last_match_field(runtime_sessionmaker):
+    """Test get_status returns no last_match field."""
+    svc = RoomLifecycleService()
+    prov = FakeProvider()
+    uid = prov._user_id
+
+    async with runtime_sessionmaker() as session:
+        uow = DatabaseUnitOfWork(session)
+        pc = await force_create_room(svc, prov, uid, uow)
+        await session.commit()
+
+    async with runtime_sessionmaker() as session:
+        uow = DatabaseUnitOfWork(session)
+        status = await svc.get_status(pc, uow)
+        await session.commit()
+
+    assert "last_match" not in status
+    assert "ready" in status
+    assert "genre" in status
+    assert "solo" in status
+    assert "hide_watched" in status

--- a/tests/test_routes_room.py
+++ b/tests/test_routes_room.py
@@ -50,9 +50,7 @@ def _set_session(
         set_session_cookie(client, data, secret_key)
 
 
-def _seed_room(
-    room_code="TEST1", *, ready=0, solo_mode=0, movie_data=None
-):
+def _seed_room(room_code="TEST1", *, ready=0, solo_mode=0, movie_data=None):
     """Seed a room row directly into the database for testing."""
     if movie_data is None:
         movie_data = json.dumps([])
@@ -551,7 +549,6 @@ def test_swipe_right_no_match_yet(client, app):
     assert response.json() == {"accepted": True}
 
 
-
 def test_set_genre_empty_deck_returns_400(client, app, mocker):
     """POST /room/{code}/genre returns 400 when genre filter results in empty deck."""
     from tests.conftest import FakeProvider
@@ -749,3 +746,95 @@ def test_set_watched_filter_requires_auth(client_real_auth, app_real_auth):
         "/room/TEST1/watched-filter", json={"hide_watched": True}
     )
     assert response.status_code in (401, 403)
+
+
+# ---------------------------------------------------------------------------
+# Section: Notifier integration tests (ORCH-003)
+# ---------------------------------------------------------------------------
+
+
+def test_join_room_notifies_after_commit(client, app):
+    """POST /room/{code}/join calls notifier.notify(code) after commit."""
+    from unittest.mock import patch
+    from jellyswipe.notifier import notifier
+
+    # Create a room first
+    _set_session(client, os.environ["FLASK_SECRET"], authenticated=True)
+    create_resp = client.post("/room")
+    assert create_resp.status_code == 200
+    code = create_resp.json()["pairing_code"]
+
+    # Join with a different session
+    from tests.conftest import set_session_cookie
+
+    join_client_session = {"solo_mode": False}
+    set_session_cookie(client, join_client_session, os.environ["FLASK_SECRET"])
+
+    with patch.object(notifier, "notify") as mock_notify:
+        response = client.post(f"/room/{code}/join")
+        assert response.status_code == 200
+        mock_notify.assert_called_once_with(code)
+
+
+def test_quit_room_notifies_after_commit(client, app):
+    """POST /room/{code}/quit calls notifier.notify(code) after commit."""
+    from unittest.mock import patch
+    from jellyswipe.notifier import notifier
+
+    # Create a room
+    _set_session(client, os.environ["FLASK_SECRET"], authenticated=True)
+    create_resp = client.post("/room")
+    assert create_resp.status_code == 200
+    code = create_resp.json()["pairing_code"]
+
+    with patch.object(notifier, "notify") as mock_notify:
+        response = client.post(f"/room/{code}/quit")
+        assert response.status_code == 200
+        mock_notify.assert_called_once_with(code)
+
+
+def test_set_genre_notifies_after_commit(client, app):
+    """POST /room/{code}/genre calls notifier.notify(code) after commit."""
+    from unittest.mock import patch
+    from jellyswipe.notifier import notifier
+
+    # Create a room
+    _set_session(client, os.environ["FLASK_SECRET"], authenticated=True)
+    create_resp = client.post("/room")
+    assert create_resp.status_code == 200
+    code = create_resp.json()["pairing_code"]
+
+    with patch.object(notifier, "notify") as mock_notify:
+        response = client.post(f"/room/{code}/genre", json={"genre": "Action"})
+        assert response.status_code == 200
+        mock_notify.assert_called_once_with(code)
+
+
+def test_set_watched_filter_notifies_after_commit(client, app):
+    """POST /room/{code}/watched-filter calls notifier.notify(code) after commit."""
+    from unittest.mock import patch
+    from jellyswipe.notifier import notifier
+
+    # Create a room
+    _set_session(client, os.environ["FLASK_SECRET"], authenticated=True)
+    create_resp = client.post("/room")
+    assert create_resp.status_code == 200
+    code = create_resp.json()["pairing_code"]
+
+    with patch.object(notifier, "notify") as mock_notify:
+        response = client.post(
+            f"/room/{code}/watched-filter", json={"hide_watched": True}
+        )
+        assert response.status_code == 200
+        mock_notify.assert_called_once_with(code)
+
+
+def test_create_room_returns_instance_id(client, app):
+    """POST /room returns instance_id in response."""
+    _set_session(client, os.environ["FLASK_SECRET"], authenticated=True)
+    response = client.post("/room")
+    assert response.status_code == 200
+    data = response.json()
+    assert "instance_id" in data
+    assert data["instance_id"] is not None
+    assert len(data["instance_id"]) > 0  # UUID hex string


### PR DESCRIPTION
## Wire session instance lifecycle and event emission into RoomLifecycleService

Wire session instance lifecycle and non-swipe event emission into `RoomLifecycleService`.

**What to change in `jellyswipe/services/room_lifecycle.py`:**

1. **`create_room`**: After generating a unique pairing code and before returning, create a `session_instances` row via `uow.session_instances.create(instance_id=uuid4().hex, pairing_code=code)`. Return `instance_id` in the response alongside `pairing_code`. Also check `uow.session_instances.is_pairing_code_reserved(code)` alongside the existing `pairing_code_exists` check — if the code is reserved by an active/closing instance, retry with a new code.

2. **`join_room`**: After `set_ready(True)`, look up the session instance by `code` via `uow.session_instances.get_by_pairing_code(code)`. Append a `session_ready` event: `uow.session_events.append(instance.instance_id, "session_ready", json.dumps({}))`. This happens inside the same UoW transaction.

3. **`set_genre`**: On successful `_rebuild_deck` (no EmptyDeckError raised), look up the instance and append a `genre_changed` event: `uow.session_events.append(instance.instance_id, "genre_changed", json.dumps({"genre": genre}))`. Inside the same UoW transaction.

4. **`set_watched_filter`**: On successful `_rebuild_deck`, append `hide_watched_changed` event: `uow.session_events.append(instance.instance_id, "hide_watched_changed", json.dumps({"hide_watched": hide_watched}))`. Inside the same UoW transaction.

5. **`quit_room`**: Look up instance, append `session_closed` event, call `uow.session_instances.mark_closing(instance_id)`. Then delete room, swipes, archive matches (existing logic). After session commits, fire `notifier.notify(code)`. Schedule `asyncio.create_task` for cleanup after 60 seconds:
   ```python
   async def _cleanup_after_grace(instance_id):
       await asyncio.sleep(60)
       async with get_sessionmaker()() as session:
           uow = DatabaseUnitOfWork(session)
           await uow.session_instances.mark_closed(instance_id)
           await uow.session_events.delete_for_instance(instance_id)
           await uow.session_instances.delete(instance_id)
           await session.commit()
   ```

6. **`get_status`**: Remove the `last_match` field from the returned dict. The `fetch_status` repo method no longer needs to read `last_match_data`.

7. **Post-commit notifier calls**: After `await session.commit()` in the route handler (or wherever the UoW session is committed), call `notifier.notify(code)` for join_room, set_genre, set_watched_filter, and quit_room. The notifier call must happen AFTER commit to ensure subscribers never see uncommitted events.

**What to change in `jellyswipe/routers/rooms.py`:**
- Route handlers for join, genre, watched-filter, quit, and status need to call `notifier.notify(code)` after the UoW session commits. The service methods return enough info; the notifier call goes in the route.
- The `create_room` route handler should return `instance_id` in the response.

**What to change in `jellyswipe/repositories/rooms.py`:**
- Remove `set_last_match_data` method
- Remove `fetch_stream_snapshot` method (will be replaced by SSE rewrite in ORCH-005)
- Update `fetch_status` to not read `last_match_data` (column is gone)

**What to change in `jellyswipe/room_types.py`:**
- Remove `last_match` from `RoomStatusSnapshot`

**Important:** The notifier call happens in the route handler, not the service method, because the service doesn't own the commit boundary. The route handler controls when the UoW session commits.


### Acceptance Criteria

1. `create_room` creates a `session_instances` row (status='active', UUID instance_id) alongside the room row, and returns `instance_id` in the response
2. `create_room` checks `is_pairing_code_reserved` and retries code generation if the code is reserved by an active/closing instance
3. `join_room` appends a `session_ready` event to `session_events` for the room's instance, inside the same UoW transaction
4. `set_genre` (on success, no EmptyDeckError) appends a `genre_changed` event with `{"genre": "Action"}` payload
5. `set_watched_filter` (on success) appends a `hide_watched_changed` event with `{"hide_watched": true/false}` payload
6. `quit_room` appends a `session_closed` event, marks the instance as 'closing' with `closed_at`, then schedules a background cleanup task (~60s)
7. The background cleanup task: marks instance 'closed', deletes session_events for the instance, deletes the session_instance row, removes the pairing code reservation
8. All event-emitting methods call `notifier.notify(room_code)` AFTER the session commits (outside the UoW)
9. `get_status` returns `{"ready", "genre", "solo", "hide_watched"}` — no `last_match` field
10. Existing tests pass with the updated service methods (tests that relied on `last_match_data` or `last_match` in status should be updated)


---
Ticket: `ORCH-003`