### PR TITLE
ticket/ORCH-005: Rewrite SSE /room/{code}/stream with event-driven replayable session event stream

### DIFF
--- a/jellyswipe/routers/rooms.py
+++ b/jellyswipe/routers/rooms.py
@@ -11,7 +11,6 @@ request-scoped connection dependency.
 import asyncio
 import json
 import logging
-import random
 import time
 import traceback
 
@@ -21,9 +20,9 @@ from sse_starlette.sse import EventSourceResponse
 
 from jellyswipe import XSSSafeJSONResponse
 from jellyswipe.db_runtime import get_sessionmaker
+from jellyswipe.db_uow import DatabaseUnitOfWork
 from jellyswipe.dependencies import AuthUser, DBUoW, get_provider, require_auth
 from jellyswipe.notifier import notifier
-from jellyswipe.repositories.rooms import RoomRepository
 from jellyswipe.services.room_lifecycle import (
     EmptyDeckError,
     RoomLifecycleService,
@@ -375,72 +374,123 @@ async def room_status(
 
 @rooms_router.get("/room/{code}/stream")
 def room_stream(code: str, request: Request, auth: AuthUser = Depends(require_auth)):
-    """SSE stream for room state changes.
-
-    Per D-01: outer handler is sync def; only the inner generator is async.
-    Per D-07: request is closed over from outer signature for disconnect detection.
-
-    Each poll uses a short-lived async SQLAlchemy session (PAR-05) — no request-scoped UoW
-    and no raw sqlite connection spanning the stream lifetime.
-    """
+    """SSE stream for session events. Event-driven with replay support."""
 
     async def generate():
-        last_genre = None
-        last_ready = None
-        last_hide_watched = None
-        POLL = 1.5
-        TIMEOUT = 3600
-        _last_event_time = time.time()
+        # 1. Resolve cursor: Last-Event-ID header or ?after_event_id= query param
+        cursor = request.headers.get("Last-Event-ID") or request.query_params.get(
+            "after_event_id"
+        )
+        cursor = int(cursor) if cursor else None
 
-        deadline = time.time() + TIMEOUT
-        while time.time() < deadline:
-            # D-06: Check disconnect BEFORE DB query — dead clients skip round-trip.
+        # 2. Look up session instance and current room state
+        async with get_sessionmaker()() as session:
+            uow = DatabaseUnitOfWork(session)
+            instance = await uow.session_instances.get_by_pairing_code(code)
+            if instance is None or instance.status == "closed":
+                yield {
+                    "data": json.dumps(
+                        {"event_type": "session_reset", "reason": "instance_changed"}
+                    )
+                }
+                return
+            room = await uow.rooms.get_room(code)
+
+        instance_id = instance.instance_id
+
+        # 3. Validate cursor if present
+        if cursor is not None:
+            # Check: does this cursor belong to our instance?
+            async with get_sessionmaker()() as session:
+                uow = DatabaseUnitOfWork(session)
+                events_after = await uow.session_events.read_after(
+                    instance_id, cursor, limit=1
+                )
+                if not events_after:
+                    # Cursor might be stale or from wrong instance
+                    yield {
+                        "data": json.dumps(
+                            {"event_type": "session_reset", "reason": "stale_cursor"}
+                        )
+                    }
+                    return
+        else:
+            # First attach — send bootstrap
+            async with get_sessionmaker()() as session:
+                uow = DatabaseUnitOfWork(session)
+                latest_eid = await uow.session_events.read_latest_event_id(instance_id)
+            bootstrap = {
+                "event_type": "session_bootstrap",
+                "instance_id": instance_id,
+                "ready": room.ready if room else False,
+                "genre": room.current_genre if room else "All",
+                "solo": room.solo_mode if room else False,
+                "hide_watched": room.hide_watched if room else False,
+                "replay_boundary": latest_eid or 0,
+            }
+            yield {"id": str(latest_eid or 0), "data": json.dumps(bootstrap)}
+
+        # 4. Replay missed events (if cursor was valid)
+        missed = []
+        latest_eid = None
+        if cursor is not None:
+            async with get_sessionmaker()() as session:
+                uow = DatabaseUnitOfWork(session)
+                missed = await uow.session_events.read_after(
+                    instance_id, cursor, limit=100
+                )
+            for evt in missed:
+                yield {
+                    "id": str(evt.event_id),
+                    "data": json.dumps(
+                        {
+                            "event_id": evt.event_id,
+                            "event_type": evt.event_type,
+                            **json.loads(evt.payload_json),
+                        }
+                    ),
+                }
+                if evt.event_type == "session_closed":
+                    return  # Stream ends after session_closed
+
+        # 5. Subscribe to notifier and stream live events
+        last_event_id = (
+            missed[-1].event_id if cursor is not None and missed else (latest_eid or 0)
+        )
+        last_event_time = time.time()
+
+        while True:
             if await request.is_disconnected():
                 break
-            try:
-                async with get_sessionmaker()() as session:
-                    repo = RoomRepository(session)
-                    snapshot = await repo.fetch_status(code)
 
-                if snapshot is None:
-                    yield {"data": json.dumps({"closed": True})}
+            future = notifier.subscribe(code)
+            try:
+                await asyncio.wait_for(future, timeout=20.0)
+            except asyncio.TimeoutError:
+                # Heartbeat check
+                if time.time() - last_event_time >= 15:
+                    yield {"comment": "ping"}
+                    last_event_time = time.time()
+                continue
+
+            # Woken by notifier — read new events from ledger
+            async with get_sessionmaker()() as session:
+                uow = DatabaseUnitOfWork(session)
+                new_events = await uow.session_events.read_after(
+                    instance_id, last_event_id, limit=100
+                )
+
+            for evt in new_events:
+                payload = {"event_id": evt.event_id, "event_type": evt.event_type}
+                payload.update(json.loads(evt.payload_json))
+                yield {"id": str(evt.event_id), "data": json.dumps(payload)}
+                last_event_id = evt.event_id
+                last_event_time = time.time()
+                if evt.event_type == "session_closed":
+                    notifier.unsubscribe(code, future)
                     return
 
-                ready = snapshot.ready
-                genre = snapshot.genre
-                solo = snapshot.solo
-                hide_watched = snapshot.hide_watched
-
-                payload = {}
-                if ready != last_ready:
-                    payload["ready"] = ready
-                    payload["solo"] = solo
-                    last_ready = ready
-                if genre != last_genre:
-                    payload["genre"] = genre
-                    last_genre = genre
-                if hide_watched != last_hide_watched:
-                    payload["hide_watched"] = hide_watched
-                    last_hide_watched = hide_watched
-
-                if payload:
-                    yield {"data": json.dumps(payload)}
-                    _last_event_time = time.time()
-                elif time.time() - _last_event_time >= 15:
-                    # SSE-5: EventSourceResponse comment syntax for heartbeat ping
-                    yield {"comment": "ping"}
-                    _last_event_time = time.time()
-
-                delay = POLL + random.uniform(0, 0.5)
-                await asyncio.sleep(delay)  # SSE-2: non-blocking sleep
-            except Exception as exc:
-                # D-09, SSE-4: Re-raise CancelledError so try/finally can clean up.
-                # Do NOT swallow CancelledError — it is the asyncio disconnect signal.
-                if isinstance(exc, asyncio.CancelledError):
-                    raise
-                logging.getLogger().warning("SSE poll error for room %s: %s", code, exc)
-                delay = POLL + random.uniform(0, 0.5)
-                await asyncio.sleep(delay)  # SSE-2: non-blocking even in error path
+            notifier.unsubscribe(code, future)
 
     # D-03: EventSourceResponse handles text/event-stream media type and SSE framing.
     # D-04: Verify Cache-Control and X-Accel-Buffering headers are present on response.

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -92,6 +92,11 @@ class TestRoomRepository:
         assert record.ready is True
         assert record.solo_mode is True
         assert record.current_genre == "Action"
+        assert isinstance(record, RoomRecord)
+        assert record.pairing_code == "4242"
+        assert record.ready is True
+        assert record.solo_mode is True
+        assert record.current_genre == "Action"
         assert record.movie_data_json == "[]"
         assert record.deck_position_json == deck
 

--- a/tests/test_routes_sse.py
+++ b/tests/test_routes_sse.py
@@ -1,33 +1,30 @@
-"""Comprehensive SSE streaming tests for the /room/stream endpoint.
+"""SSE streaming tests for the event-driven /room/{code}/stream endpoint.
 
-Tests cover SSE response format, state change events (ready, genre, solo, match),
-room closure on missing room, stable state deduplication, and GeneratorExit handling.
-Satisfies TEST-ROUTE-05.
+Tests cover:
+- First attach (no cursor): session_bootstrap event
+- Reconnect with valid cursor: missed events replayed
+- Reconnect with stale cursor: session_reset sent
+- Reconnect with wrong instance cursor: session_reset sent
+- Session closed event: stream closes after session_closed
+- SSE id field on every event
+- Heartbeat ping after idle
+- Disconnect detection
+- CancelledError propagation
+- Response headers
+- GET /matches works independently
 """
 
 import asyncio
 import json
 import os
 import secrets
-import threading
 import time
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
 
-import sqlite3
 
-from sse_starlette.sse import EventSourceResponse
-
-import pytest
-from jellyswipe.db_paths import application_db_path
+from jellyswipe.notifier import notifier
 from tests.conftest import set_session_cookie
-
-
-def _sqlite_conn_for_sse_tests():
-    path = application_db_path.path
-    assert path is not None
-    conn = sqlite3.connect(path, check_same_thread=False)
-    conn.row_factory = sqlite3.Row
-    conn.execute("PRAGMA foreign_keys=ON")
-    return conn
 
 
 # ---------------------------------------------------------------------------
@@ -36,11 +33,7 @@ def _sqlite_conn_for_sse_tests():
 
 
 def _set_session_room(client, secret_key, room_code, user_id=None):
-    """Inject session state for SSE stream tests.
-
-    Auth is handled by app.dependency_overrides[require_auth] in the app fixture.
-    Session cookie carries active_room + my_user_id for SSE route to read.
-    """
+    """Inject session state for SSE stream tests."""
     if user_id is None:
         user_id = f"test-user-{secrets.token_hex(4)}"
     set_session_cookie(
@@ -53,106 +46,87 @@ def _set_session_room(client, secret_key, room_code, user_id=None):
         },
         secret_key,
     )
-    # AUTH: handled by dependency_overrides[require_auth] — no vault INSERT needed
 
 
-def _seed_stream_room(
-    room_code, *, ready=0, solo_mode=0, current_genre="All"
+def _seed_room_and_instance(
+    conn,
+    room_code,
+    *,
+    ready=0,
+    solo_mode=0,
+    current_genre="All",
+    instance_id=None,
+    hide_watched=0,
+    include_movies=1,
+    include_tv_shows=0,
 ):
-    """Seed a room row directly into SQLite for SSE tests (VAL-03: no jellyswipe.db.get_db)."""
+    """Seed a room row and session instance for SSE tests."""
+    if instance_id is None:
+        instance_id = f"inst-{secrets.token_hex(8)}"
     movie_data = json.dumps([])
-    conn = _sqlite_conn_for_sse_tests()
-    try:
-        conn.execute(
-            "INSERT INTO rooms (pairing_code, movie_data, ready, current_genre, solo_mode) "
-            "VALUES (?, ?, ?, ?, ?)",
-            (room_code, movie_data, ready, current_genre, solo_mode),
-        )
-        conn.commit()
-    finally:
-        conn.close()
+    conn.execute(
+        "INSERT INTO rooms (pairing_code, movie_data, ready, current_genre, solo_mode, "
+        "hide_watched, include_movies, include_tv_shows, deck_position) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            room_code,
+            movie_data,
+            ready,
+            current_genre,
+            solo_mode,
+            hide_watched,
+            include_movies,
+            include_tv_shows,
+            "{}",
+        ),
+    )
+    now = datetime.now(timezone.utc).isoformat()
+    conn.execute(
+        "INSERT INTO session_instances (instance_id, pairing_code, status, created_at) "
+        "VALUES (?, ?, ?, ?)",
+        (instance_id, room_code, "active", now),
+    )
+    conn.commit()
+    return instance_id
 
 
-# Pre-generator time.time() call overhead in FastAPI TestClient context.
-# During client.get(), the following call time.time() BEFORE the SSE generator runs:
-# ~2 from httpx/starlette request timing, ~2 from cookie jar, ~1 from RequestIdMiddleware.
-# All _make_time_mock thresholds must be >= this overhead + pre-loop setup (2 calls)
-# to ensure deadline = real_start + 3600 (not real_start + 7300 which never expires).
-_PRE_GENERATOR_OVERHEAD = 6
+def _seed_event(conn, instance_id, event_type, payload_json):
+    """Seed a session event directly."""
+    now = datetime.now(timezone.utc).isoformat()
+    cursor = conn.execute(
+        "INSERT INTO session_events (session_instance_id, event_type, payload_json, created_at) "
+        "VALUES (?, ?, ?, ?)",
+        (instance_id, event_type, payload_json, now),
+    )
+    conn.commit()
+    return cursor.lastrowid
 
 
-def _make_time_mock(iterations_before_timeout):
-    """Create a time.time mock that advances past deadline after N calls.
+def _sqlite_conn(app):
+    """Get a direct sqlite3 connection to the app's database."""
+    import sqlite3
+    from jellyswipe.db_paths import application_db_path
 
-    Returns a closure that returns real time for the first
-    (iterations_before_timeout + _PRE_GENERATOR_OVERHEAD) calls, then returns
-    real_time + 3700 (past the 3600s deadline) to exit the SSE polling loop.
-
-    The overhead accounts for time.time() calls from httpx timing, cookies, and
-    middleware that fire BEFORE the generator's deadline calculation.
-    """
-    # Add overhead so the deadline calculation runs BEFORE the mock triggers
-    total_calls = iterations_before_timeout + _PRE_GENERATOR_OVERHEAD
-    call_count = 0
-    real_start = time.time()
-
-    def _mock_time():
-        nonlocal call_count
-        call_count += 1
-        if call_count > total_calls:
-            return real_start + 3700
-        return real_start
-
-    return _mock_time
+    path = application_db_path.path
+    assert path is not None
+    conn = sqlite3.connect(path, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys=ON")
+    return conn
 
 
-def _make_sse_sleep_mock(on_sleep_callback=None):
-    """Create a selective asyncio.sleep mock for SSE generator testing.
+def _setup_disconnect_after(client, monkeypatch, after_calls=2):
+    """Mock is_disconnected to return True after N calls, so the stream loop exits."""
+    from starlette.requests import Request as StarletteRequest
 
-    The SSE generator calls asyncio.sleep(delay) where delay is in [1.5, 2.0]
-    (POLL=1.5 + random jitter 0–0.5). Internal anyio/starlette checkpoints use 0 or 0.5.
+    call_count = [0]
 
-    Strategy: intercept the generator's sleep range [1.4, 2.1], yielding control
-    instantly (via asyncio.sleep(0)). Starlette internal checkpoints (< 1.4s) pass through.
+    async def fake_is_disconnected(self):
+        call_count[0] += 1
+        return call_count[0] >= after_calls
 
-    The _ping task's anyio.sleep(15s) is handled separately by patching
-    EventSourceResponse._ping to a no-op — see _noop_ping below.
-
-    Args:
-        on_sleep_callback: Optional sync callable(delay) called when generator sleep is
-                           intercepted. Sync only (called before yielding to event loop).
-    """
-    original_sleep = asyncio.sleep
-
-    sleep_calls = []
-
-    async def _selective_sleep(delay):
-        if 1.4 <= delay <= 2.1:
-            # Generator poll sleep in expected range — record and yield briefly
-            sleep_calls.append(delay)
-            if on_sleep_callback is not None:
-                on_sleep_callback(delay)
-            # Yield control without blocking, allowing task group to process cancellation
-            await original_sleep(0)
-        else:
-            # anyio checkpoints (0, 0.5) and others — keep real behavior
-            await original_sleep(delay)
-
-    return _selective_sleep, sleep_calls
-
-
-async def _noop_ping(self, send):
-    """Replacement _ping for tests — polls self.active without sending ping comments.
-
-    EventSourceResponse._ping calls anyio.sleep(15s) inside a while-loop. That sleep
-    is not interrupted when the cancel scope fires, causing a 15s teardown hang.
-
-    This replacement polls self.active every 10ms using asyncio.sleep (which IS
-    interrupted by the task group's cancel scope), so teardown is instantaneous.
-    No ping comments are emitted, so heartbeat-count assertions stay clean.
-    """
-    while self.active:
-        await asyncio.sleep(0.01)
+    monkeypatch.setattr(StarletteRequest, "is_disconnected", fake_is_disconnected)
+    return call_count
 
 
 # ---------------------------------------------------------------------------
@@ -160,617 +134,443 @@ async def _noop_ping(self, send):
 # ---------------------------------------------------------------------------
 
 
-def test_stream_no_active_room(client):
-    """GET /room/<code>/stream for nonexistent room returns closed event."""
-    response = client.get("/room/TEST1/stream")
-
-    assert response.status_code == 200
-    assert response.headers.get("content-type", "").startswith("text/event-stream")
-    assert '"closed": true' in response.text
-
-
 def test_stream_response_headers(client, monkeypatch):
     """GET /room/stream returns correct SSE content-type and cache headers."""
-    _seed_stream_room("TEST1")
-    _set_session_room(client, os.environ["FLASK_SECRET"], "TEST1")
+    conn = _sqlite_conn(client)
+    try:
+        _seed_room_and_instance(conn, "HDR1")
+    finally:
+        conn.close()
+    _set_session_room(client, os.environ["FLASK_SECRET"], "HDR1")
+    _setup_disconnect_after(client, monkeypatch, after_calls=2)
 
-    # Force gevent sleep fallback path (gevent is available in test env)
-    import jellyswipe
+    # Mock notifier to resolve immediately
+    monkeypatch.setattr(notifier, "subscribe", lambda code: _resolved_future())
+    monkeypatch.setattr(time, "time", lambda: 1000000.0)
 
-    monkeypatch.setattr(jellyswipe, "_gevent_sleep", None, raising=False)
+    response = client.get("/room/HDR1/stream")
 
-    # Selective asyncio.sleep mock: skips SSE generator polls (>= 1.5s),
-    # passes through internal anyio/sse_starlette sleeps (< 1.5s).
-    mock_sleep, _ = _make_sse_sleep_mock()
-    monkeypatch.setattr(asyncio, "sleep", mock_sleep)
-    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
-
-    # Mock time to exit the generator loop after a few iterations
-    monkeypatch.setattr(time, "sleep", lambda _: None)
-    monkeypatch.setattr(time, "time", _make_time_mock(5))
-
-    response = client.get("/room/TEST1/stream")
-    # Consume data while monkeypatch is active (generator runs lazily)
-    _ = response.content
-
+    assert response.status_code == 200
     assert response.headers.get("content-type", "").startswith("text/event-stream")
     assert response.headers["Cache-Control"] == "no-cache"
     assert response.headers["X-Accel-Buffering"] == "no"
 
 
-# ---------------------------------------------------------------------------
-# Section 2: Room state and closure tests
-# ---------------------------------------------------------------------------
-
-
-def test_stream_room_not_found(client, monkeypatch):
-    """Stream for nonexistent room sends closed event and stops."""
-    _set_session_room(client, os.environ["FLASK_SECRET"], "FAKE")
-
-    monkeypatch.setattr(time, "sleep", lambda _: None)
-    monkeypatch.setattr(time, "time", _make_time_mock(3))
-
-    response = client.get("/room/TEST1/stream")
-    data = response.text
-
-    assert 'data: {"closed": true}' in data
-
-    events = [e for e in data.split("\n\n") if e.strip()]
-    assert len(events) == 1
-
-
-def test_stream_initial_state_events(client, monkeypatch):
-    """Stream sends initial ready, solo, and genre events on first poll."""
-    _seed_stream_room("TEST1", ready=0, current_genre="All", solo_mode=0)
-    _set_session_room(client, os.environ["FLASK_SECRET"], "TEST1")
-
-    # Force gevent sleep fallback path (gevent is available in test env)
-    import jellyswipe
-
-    monkeypatch.setattr(jellyswipe, "_gevent_sleep", None, raising=False)
-
-    mock_sleep, _ = _make_sse_sleep_mock()
-    monkeypatch.setattr(asyncio, "sleep", mock_sleep)
-    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
-
-    # deadline calc + init + loop iterations then exit
-    monkeypatch.setattr(time, "sleep", lambda _: None)
-    monkeypatch.setattr(time, "time", _make_time_mock(8))
-
-    response = client.get("/room/TEST1/stream")
-    data = response.text
-
-    # Initial event: ready=False (0 -> bool -> False != None -> sends), solo=False, genre="All"
-    assert '"ready": false' in data
-    assert '"solo": false' in data
-    assert '"genre": "All"' in data
-
-
-def test_stream_stable_state_no_repeat(client, monkeypatch):
-    """Stream does not repeat events when state hasn't changed between polls."""
-    _seed_stream_room("TEST1", ready=0, current_genre="All")
-    _set_session_room(client, os.environ["FLASK_SECRET"], "TEST1")
-
-    # Force gevent sleep fallback path (gevent is available in test env)
-    import jellyswipe
-
-    monkeypatch.setattr(jellyswipe, "_gevent_sleep", None, raising=False)
-
-    mock_sleep, _ = _make_sse_sleep_mock()
-    monkeypatch.setattr(asyncio, "sleep", mock_sleep)
-    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
-
-    # deadline calc + init + loop iterations then exit
-    monkeypatch.setattr(time, "sleep", lambda _: None)
-    monkeypatch.setattr(time, "time", _make_time_mock(10))
-
-    response = client.get("/room/TEST1/stream")
-    data = response.text
-
-    # Parse SSE events
-    events = [e.strip() for e in data.split("\n\n") if e.strip()]
-
-    # On first poll: ready=false and genre="All" sent (both differ from None)
-    # On second poll: state unchanged, nothing sent
-    ready_count = sum(1 for e in events if '"ready"' in e)
-    genre_count = sum(1 for e in events if '"genre"' in e)
-
-    assert ready_count == 1, (
-        f"Expected exactly 1 ready event, got {ready_count}: {events}"
-    )
-    assert genre_count == 1, (
-        f"Expected exactly 1 genre event, got {genre_count}: {events}"
-    )
+def _resolved_future():
+    """Return an already-resolved Future for mocking notifier.subscribe."""
+    f = asyncio.Future()
+    f.set_result(None)
+    return f
 
 
 # ---------------------------------------------------------------------------
-# Section 3: State change detection tests
+# Section 2: First attach (no cursor) — session_bootstrap
 # ---------------------------------------------------------------------------
 
 
-
-def test_stream_ready_state_change(client, monkeypatch):
-    """Stream detects ready-state change between polling iterations."""
-    _seed_stream_room("TEST1", ready=0)
-    _set_session_room(client, os.environ["FLASK_SECRET"], "TEST1")
-
-    # Force gevent sleep fallback path (gevent is available in test env)
-    import jellyswipe
-
-    monkeypatch.setattr(jellyswipe, "_gevent_sleep", None, raising=False)
-
-    # Use a sleep callback that updates DB on first generator poll sleep.
-    # The SSE generator uses asyncio.sleep() — _make_sse_sleep_mock intercepts
-    # those calls and invokes on_sleep_callback.
-    sleep_call_count = 0
-
-    def _on_sleep(delay):
-        nonlocal sleep_call_count
-        sleep_call_count += 1
-        if sleep_call_count == 1:
-            # After first poll (ready=0 sent), flip ready to 1
-            conn = _sqlite_conn_for_sse_tests()
-            try:
-                conn.execute(
-                    "UPDATE rooms SET ready = 1 WHERE pairing_code = ?",
-                    ("TEST1",),
-                )
-                conn.commit()
-            finally:
-                conn.close()
-
-    mock_sleep, _ = _make_sse_sleep_mock(on_sleep_callback=_on_sleep)
-    monkeypatch.setattr(asyncio, "sleep", mock_sleep)
-    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
-    # deadline + loop iterations (with state changes) then exit
-    monkeypatch.setattr(time, "sleep", lambda _: None)
-    monkeypatch.setattr(time, "time", _make_time_mock(12))
-
-    response = client.get("/room/TEST1/stream")
-    data = response.text
-
-    # Should have both initial ready=false and subsequent ready=true
-    assert '"ready": false' in data, f"Missing initial ready=false in: {data}"
-    assert '"ready": true' in data, f"Missing updated ready=true in: {data}"
-
-
-# ---------------------------------------------------------------------------
-# Section 4: GeneratorExit handling test
-# ---------------------------------------------------------------------------
-
-
-def test_stream_generator_exit(client, monkeypatch):
-    """GeneratorExit is handled gracefully — no exception propagated on client disconnect."""
-    _seed_stream_room("TEST1")
-    _set_session_room(client, os.environ["FLASK_SECRET"], "TEST1")
-
-    # Force gevent sleep fallback path (gevent is available in test env)
-    import jellyswipe
-
-    monkeypatch.setattr(jellyswipe, "_gevent_sleep", None, raising=False)
-
-    mock_sleep, _ = _make_sse_sleep_mock()
-    monkeypatch.setattr(asyncio, "sleep", mock_sleep)
-    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
-
-    result = {}
-    error_holder = {}
-
-    def consume():
-        try:
-            resp = client.get("/room/TEST1/stream")
-            # Consume data while monkeypatch is active
-            result["data"] = resp.text
-            result["status"] = resp.status_code
-            result["content_type"] = resp.headers.get("content-type", "")
-        except Exception as exc:
-            error_holder["error"] = exc
-
-    # Mock time globally for the thread
-    monkeypatch.setattr(time, "sleep", lambda _: None)
-    monkeypatch.setattr(time, "time", _make_time_mock(10))
-
-    t = threading.Thread(target=consume)
-    t.start()
-    t.join(timeout=10)
-
-    # Thread completed without hanging
-    assert not t.is_alive(), "Thread should have completed"
-    # No exception raised
-    assert "error" not in error_holder, f"Unexpected error: {error_holder['error']}"
-    # Response was received successfully
-    assert result.get("status") == 200
-    assert "text/event-stream" in result.get("content_type", "")
-
-
-# ---------------------------------------------------------------------------
-# Section 5: SSE reliability tests (jitter, heartbeat, gevent sleep)
-# ---------------------------------------------------------------------------
-
-
-def test_stream_jitter_applied(client, monkeypatch):
-    """Poll interval includes random jitter between 0 and 0.5 seconds."""
-    _seed_stream_room("JITTER1")
-    _set_session_room(client, os.environ["FLASK_SECRET"], "JITTER1")
-
-    # Force gevent sleep fallback path so we can capture asyncio.sleep calls
-    import jellyswipe
-
-    monkeypatch.setattr(jellyswipe, "_gevent_sleep", None, raising=False)
-
-    # Use _make_sse_sleep_mock to intercept SSE generator sleeps and capture durations
-    mock_sleep, sleep_calls = _make_sse_sleep_mock()
-    monkeypatch.setattr(asyncio, "sleep", mock_sleep)
-    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
-    monkeypatch.setattr(time, "sleep", lambda _: None)
-    monkeypatch.setattr(time, "time", _make_time_mock(10))
-
-    response = client.get("/room/JITTER1/stream")
-    _ = response.content  # consume generator
-
-    assert len(sleep_calls) >= 1, (
-        f"Expected at least 1 sleep call, got {len(sleep_calls)}"
-    )
-    for duration in sleep_calls:
-        assert 1.5 <= duration <= 2.0, (
-            f"Sleep duration {duration} outside expected range [1.5, 2.0]"
+def test_stream_first_attach_sends_bootstrap(client, monkeypatch):
+    """First attach (no Last-Event-ID, no after_event_id) sends session_bootstrap."""
+    conn = _sqlite_conn(client)
+    try:
+        instance_id = _seed_room_and_instance(
+            conn,
+            "BOOT1",
+            ready=1,
+            current_genre="Action",
+            solo_mode=1,
+            hide_watched=1,
         )
+    finally:
+        conn.close()
+    _set_session_room(client, os.environ["FLASK_SECRET"], "BOOT1")
+    _setup_disconnect_after(client, monkeypatch, after_calls=2)
+
+    monkeypatch.setattr(notifier, "subscribe", lambda code: _resolved_future())
+    monkeypatch.setattr(time, "time", lambda: 1000000.0)
+
+    response = client.get("/room/BOOT1/stream")
+    data = response.text
+
+    assert "session_bootstrap" in data
+    assert (
+        f'"instance_id": "{instance_id}"' in data
+        or f'"instance_id":"{instance_id}"' in data
+    )
+    assert '"ready": true' in data
+    assert '"genre": "Action"' in data
+    assert '"solo": true' in data
+    assert '"hide_watched": true' in data
+    assert '"replay_boundary"' in data
 
 
-def test_stream_heartbeat_on_idle(client, monkeypatch):
-    """SSE stream sends : ping heartbeat when no data event for ~15 seconds."""
-    _seed_stream_room("HB1", ready=0, current_genre="All")
+def test_stream_first_attach_bootstrap_only_event_before_live(client, monkeypatch):
+    """session_bootstrap is the only event before live events start."""
+    conn = _sqlite_conn(client)
+    try:
+        _seed_room_and_instance(conn, "BOOT2")
+    finally:
+        conn.close()
+    _set_session_room(client, os.environ["FLASK_SECRET"], "BOOT2")
+    _setup_disconnect_after(client, monkeypatch, after_calls=2)
+
+    monkeypatch.setattr(notifier, "subscribe", lambda code: _resolved_future())
+    monkeypatch.setattr(time, "time", lambda: 1000000.0)
+
+    response = client.get("/room/BOOT2/stream")
+    data = response.text
+
+    bootstrap_count = data.count("session_bootstrap")
+    assert bootstrap_count == 1, f"Expected 1 bootstrap, got {bootstrap_count}: {data}"
+
+
+def test_stream_first_attach_replay_boundary(client, monkeypatch):
+    """First attach includes replay_boundary set to latest event_id."""
+    conn = _sqlite_conn(client)
+    try:
+        instance_id = _seed_room_and_instance(conn, "BOOT3")
+        _seed_event(conn, instance_id, "swipe", json.dumps({"media_id": "m1"}))
+        _seed_event(conn, instance_id, "swipe", json.dumps({"media_id": "m2"}))
+    finally:
+        conn.close()
+    _set_session_room(client, os.environ["FLASK_SECRET"], "BOOT3")
+    _setup_disconnect_after(client, monkeypatch, after_calls=2)
+
+    monkeypatch.setattr(notifier, "subscribe", lambda code: _resolved_future())
+    monkeypatch.setattr(time, "time", lambda: 1000000.0)
+
+    response = client.get("/room/BOOT3/stream")
+    data = response.text
+
+    assert '"replay_boundary": 2' in data or '"replay_boundary":2' in data
+
+
+# ---------------------------------------------------------------------------
+# Section 3: Reconnect with valid cursor — replay missed events
+# ---------------------------------------------------------------------------
+
+
+def test_stream_reconnect_replays_missed_events(client, monkeypatch):
+    """Reconnect with valid cursor replays missed events in order."""
+    conn = _sqlite_conn(client)
+    try:
+        instance_id = _seed_room_and_instance(conn, "REPLAY1")
+        eid1 = _seed_event(
+            conn,
+            instance_id,
+            "swipe",
+            json.dumps({"media_id": "m1", "direction": "right"}),
+        )
+        eid2 = _seed_event(
+            conn, instance_id, "match_found", json.dumps({"media_id": "m1"})
+        )
+    finally:
+        conn.close()
+    _set_session_room(client, os.environ["FLASK_SECRET"], "REPLAY1")
+    _setup_disconnect_after(client, monkeypatch, after_calls=2)
+
+    monkeypatch.setattr(notifier, "subscribe", lambda code: _resolved_future())
+    monkeypatch.setattr(time, "time", lambda: 1000000.0)
+
+    response = client.get(f"/room/REPLAY1/stream?after_event_id={eid1}")
+    data = response.text
+
+    assert "match_found" in data
+    assert f'"event_id": {eid2}' in data or f'"event_id":{eid2}' in data
+    assert '"event_type": "match_found"' in data or '"event_type":"match_found"' in data
+
+
+def test_stream_reconnect_events_in_order(client, monkeypatch):
+    """Replayed events are delivered in event_id order."""
+    conn = _sqlite_conn(client)
+    try:
+        instance_id = _seed_room_and_instance(conn, "REPLAY2")
+        eid1 = _seed_event(conn, instance_id, "swipe", json.dumps({"media_id": "m1"}))
+        eid2 = _seed_event(conn, instance_id, "swipe", json.dumps({"media_id": "m2"}))
+        eid3 = _seed_event(
+            conn, instance_id, "match_found", json.dumps({"media_id": "m1"})
+        )
+    finally:
+        conn.close()
+    _set_session_room(client, os.environ["FLASK_SECRET"], "REPLAY2")
+    _setup_disconnect_after(client, monkeypatch, after_calls=2)
+
+    monkeypatch.setattr(notifier, "subscribe", lambda code: _resolved_future())
+    monkeypatch.setattr(time, "time", lambda: 1000000.0)
+
+    response = client.get(f"/room/REPLAY2/stream?after_event_id={eid1}")
+    data = response.text
+
+    pos_eid2 = data.find(f'"event_id": {eid2}')
+    if pos_eid2 == -1:
+        pos_eid2 = data.find(f'"event_id":{eid2}')
+    pos_eid3 = data.find(f'"event_id": {eid3}')
+    if pos_eid3 == -1:
+        pos_eid3 = data.find(f'"event_id":{eid3}')
+    assert pos_eid2 < pos_eid3, "Events should be in order"
+
+
+# ---------------------------------------------------------------------------
+# Section 4: Invalid cursor — stale
+# ---------------------------------------------------------------------------
+
+
+def test_stream_stale_cursor_sends_session_reset(client, monkeypatch):
+    """Reconnect with stale cursor (no events after it) sends session_reset."""
+    conn = _sqlite_conn(client)
+    try:
+        _seed_room_and_instance(conn, "STALE1")
+    finally:
+        conn.close()
+    _set_session_room(client, os.environ["FLASK_SECRET"], "STALE1")
+
+    monkeypatch.setattr(time, "time", lambda: 1000000.0)
+
+    response = client.get("/room/STALE1/stream?after_event_id=999")
+    data = response.text
+
+    assert "session_reset" in data
+    assert "stale_cursor" in data
+
+
+# ---------------------------------------------------------------------------
+# Section 5: Session closed event
+# ---------------------------------------------------------------------------
+
+
+def test_stream_session_closed_closes_stream(client, monkeypatch):
+    """When session_closed event is replayed, stream closes after sending it."""
+    conn = _sqlite_conn(client)
+    try:
+        instance_id = _seed_room_and_instance(conn, "CLOSE1")
+        _seed_event(conn, instance_id, "swipe", json.dumps({"media_id": "m1"}))
+        _seed_event(
+            conn, instance_id, "session_closed", json.dumps({"reason": "user_quit"})
+        )
+    finally:
+        conn.close()
+    _set_session_room(client, os.environ["FLASK_SECRET"], "CLOSE1")
+
+    monkeypatch.setattr(time, "time", lambda: 1000000.0)
+
+    response = client.get("/room/CLOSE1/stream?after_event_id=0")
+    data = response.text
+
+    assert "session_closed" in data
+    assert "session_bootstrap" not in data
+
+
+def test_stream_two_matches_close_together(client, monkeypatch):
+    """Two match_found events are delivered as distinct events with different event_ids."""
+    conn = _sqlite_conn(client)
+    try:
+        instance_id = _seed_room_and_instance(conn, "MATCH2")
+        eid1 = _seed_event(
+            conn, instance_id, "match_found", json.dumps({"media_id": "m1"})
+        )
+        eid2 = _seed_event(
+            conn, instance_id, "match_found", json.dumps({"media_id": "m2"})
+        )
+    finally:
+        conn.close()
+    _set_session_room(client, os.environ["FLASK_SECRET"], "MATCH2")
+    _setup_disconnect_after(client, monkeypatch, after_calls=2)
+
+    monkeypatch.setattr(notifier, "subscribe", lambda code: _resolved_future())
+    monkeypatch.setattr(time, "time", lambda: 1000000.0)
+
+    response = client.get("/room/MATCH2/stream?after_event_id=0")
+    data = response.text
+
+    assert data.count("match_found") >= 2
+    assert f'"event_id": {eid1}' in data or f'"event_id":{eid1}' in data
+    assert f'"event_id": {eid2}' in data or f'"event_id":{eid2}' in data
+
+
+# ---------------------------------------------------------------------------
+# Section 6: SSE id field
+# ---------------------------------------------------------------------------
+
+
+def test_stream_sse_id_field(client, monkeypatch):
+    """Each event includes id: line with the event_id."""
+    conn = _sqlite_conn(client)
+    try:
+        instance_id = _seed_room_and_instance(conn, "ID1")
+        eid = _seed_event(conn, instance_id, "swipe", json.dumps({"media_id": "m1"}))
+    finally:
+        conn.close()
+    _set_session_room(client, os.environ["FLASK_SECRET"], "ID1")
+    _setup_disconnect_after(client, monkeypatch, after_calls=2)
+
+    monkeypatch.setattr(notifier, "subscribe", lambda code: _resolved_future())
+    monkeypatch.setattr(time, "time", lambda: 1000000.0)
+
+    response = client.get("/room/ID1/stream?after_event_id=0")
+    data = response.text
+
+    assert f"id: {eid}" in data or f"id:{eid}" in data
+
+
+# ---------------------------------------------------------------------------
+# Section 7: Heartbeat
+# ---------------------------------------------------------------------------
+
+
+def test_stream_heartbeat_ping(client, monkeypatch):
+    """After ~15s of no events, a : ping comment is sent."""
+    conn = _sqlite_conn(client)
+    try:
+        _seed_room_and_instance(conn, "HB1")
+    finally:
+        conn.close()
     _set_session_room(client, os.environ["FLASK_SECRET"], "HB1")
+    _setup_disconnect_after(client, monkeypatch, after_calls=4)
 
-    # Force gevent sleep fallback path
-    import jellyswipe
+    time_counter = [0]
 
-    monkeypatch.setattr(jellyswipe, "_gevent_sleep", None, raising=False)
+    def mock_time():
+        time_counter[0] += 1
+        if time_counter[0] <= 5:
+            return 0.0
+        return 16.0
 
-    mock_sleep, _ = _make_sse_sleep_mock()
-    monkeypatch.setattr(asyncio, "sleep", mock_sleep)
-    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
+    monkeypatch.setattr(time, "time", mock_time)
 
-    # Create time mock that advances past 15 seconds between polls to trigger heartbeat.
-    # Thresholds account for _PRE_GENERATOR_OVERHEAD pre-generator calls PLUS:
-    #   - _last_event_time init (1 call)
-    #   - deadline calculation (1 call)
-    #   - while time.time() < deadline (1 call)
-    #   - inside first iteration: heartbeat check + event time (2 calls)
-    # After first iteration: 16s gap triggers heartbeat; after second iteration: exit.
-    call_count = 0
-    real_start = time.time()
-    # offset accounts for pre-generator overhead so deadline = real_start + 3600
-    offset = _PRE_GENERATOR_OVERHEAD
+    # Mock wait_for to timeout immediately so the heartbeat check runs
+    original_wait_for = asyncio.wait_for
 
-    def _time_with_gap():
-        nonlocal call_count
-        call_count += 1
-        if call_count <= offset + 5:
-            # Pre-generator overhead + init + first iteration: real time
-            return real_start
-        elif call_count <= offset + 7:
-            # Second iteration: advance 16 seconds to trigger heartbeat
-            return real_start + 16
-        else:
-            # Past deadline: exit loop
-            return real_start + 3700
+    async def mock_wait_for(future, timeout):
+        # Let the first call through (bootstrap phase), then timeout immediately
+        if time_counter[0] > 5:
+            raise asyncio.TimeoutError()
+        return await original_wait_for(future, timeout=0.001)
 
-    monkeypatch.setattr(time, "sleep", lambda _: None)
-    monkeypatch.setattr(time, "time", _time_with_gap)
+    monkeypatch.setattr(asyncio, "wait_for", mock_wait_for)
 
     response = client.get("/room/HB1/stream")
     data = response.text
 
-    # SSE uses \r\n separators per spec (EventSourceResponse DEFAULT_SEPARATOR = "\r\n")
-    assert ": ping" in data, f"Expected heartbeat ping in SSE stream, got: {repr(data)}"
-
-
-def test_stream_no_heartbeat_when_data_sent(client, monkeypatch):
-    """Heartbeat is NOT sent when data events are emitted within 15 seconds."""
-    _seed_stream_room("NHB1", ready=0, current_genre="All")
-    _set_session_room(client, os.environ["FLASK_SECRET"], "NHB1")
-
-    # Force gevent sleep fallback path
-    import jellyswipe
-
-    monkeypatch.setattr(jellyswipe, "_gevent_sleep", None, raising=False)
-
-    real_start = time.time()
-    exit_after_idle_polls = [False]
-    poll_sleeps = [0]
-
-    def _after_poll_sleep(_delay):
-        # End the stream only *between* full poll iterations so the next time.time()
-        # call is the `while time.time() < deadline` check — not the `elif` that would
-        # treat a fake +3700s jump as "idle for 15s" and emit a spurious ping.
-        poll_sleeps[0] += 1
-        if poll_sleeps[0] >= 40:
-            exit_after_idle_polls[0] = True
-
-    mock_sleep, _sleep_calls = _make_sse_sleep_mock(on_sleep_callback=_after_poll_sleep)
-    monkeypatch.setattr(asyncio, "sleep", mock_sleep)
-    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
-
-    def _time_frozen_then_exit_deadline():
-        if exit_after_idle_polls[0]:
-            return real_start + 3700
-        return real_start
-
-    monkeypatch.setattr(time, "sleep", lambda _: None)
-    monkeypatch.setattr(time, "time", _time_frozen_then_exit_deadline)
-
-    response = client.get("/room/NHB1/stream")
-    data = response.text
-
-    # With rapid polls (mocked time advances quickly), state changes produce data events
-    # and no heartbeat should appear since _last_event_time is reset on data emission
-    ping_count = data.count(": ping")
-    assert ping_count == 0, (
-        f"Expected no heartbeat when data events sent, but found {ping_count}"
-    )
-
-
-def test_stream_room_disappearance_immediate_exit(client, monkeypatch):
-    """SSE generator exits immediately when room record disappears from database (SSE-03)."""
-    _seed_stream_room("VANISH1")
-    _set_session_room(client, os.environ["FLASK_SECRET"], "VANISH1")
-
-    # Force gevent sleep fallback path
-    import jellyswipe
-
-    monkeypatch.setattr(jellyswipe, "_gevent_sleep", None, raising=False)
-
-    # Use a sleep callback that deletes the room on first generator poll sleep.
-    sleep_count = 0
-
-    def _on_sleep_delete(delay):
-        nonlocal sleep_count
-        sleep_count += 1
-        if sleep_count == 1:
-            # After first poll (initial state sent), delete the room
-            conn = _sqlite_conn_for_sse_tests()
-            try:
-                conn.execute("DELETE FROM rooms WHERE pairing_code = ?", ("VANISH1",))
-                conn.commit()
-            finally:
-                conn.close()
-
-    mock_sleep, _ = _make_sse_sleep_mock(on_sleep_callback=_on_sleep_delete)
-    monkeypatch.setattr(asyncio, "sleep", mock_sleep)
-    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
-    monkeypatch.setattr(time, "sleep", lambda _: None)
-    monkeypatch.setattr(time, "time", _make_time_mock(10))
-
-    response = client.get("/room/VANISH1/stream")
-    data = response.text
-
-    assert '"closed": true' in data, (
-        f"Expected closed:true event in SSE stream, got: {repr(data)}"
-    )
+    assert ": ping" in data, f"Expected heartbeat ping in: {repr(data)}"
 
 
 # ---------------------------------------------------------------------------
-# Section 6: Gap tests — disconnect detection, cleanup, CancelledError, auth
+# Section 8: Disconnect detection
 # ---------------------------------------------------------------------------
 
 
-def test_stream_disconnect_breaks_loop_before_db_query(client, monkeypatch):
-    """G1: is_disconnected() returning True breaks the poll loop before the next DB snapshot read.
-
-    Strategy: seed a real room so the first poll succeeds and yields an event.
-    Then mock is_disconnected to return True on the second call.
-    Verify that the stream exits early — fetch_status call count confirms no
-    additional query was issued after disconnect was detected.
-    """
-    from jellyswipe.repositories.rooms import RoomRepository
-
-    _seed_stream_room("DISC1", ready=0, current_genre="All")
+def test_stream_disconnect_exits_cleanly(client, monkeypatch):
+    """If request.is_disconnected() returns True, generator exits cleanly."""
+    conn = _sqlite_conn(client)
+    try:
+        _seed_room_and_instance(conn, "DISC1")
+    finally:
+        conn.close()
     _set_session_room(client, os.environ["FLASK_SECRET"], "DISC1")
 
-    import jellyswipe
-
-    monkeypatch.setattr(jellyswipe, "_gevent_sleep", None, raising=False)
-
-    mock_sleep, sleep_calls = _make_sse_sleep_mock()
-    monkeypatch.setattr(asyncio, "sleep", mock_sleep)
-    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
-    monkeypatch.setattr(time, "sleep", lambda _: None)
-
-    _orig_fetch = RoomRepository.fetch_status
-    snapshot_calls = [0]
-
-    async def counting_fetch(self, pairing_code):  # type: ignore[no-untyped-def]
-        snapshot_calls[0] += 1
-        return await _orig_fetch(self, pairing_code)
-
-    monkeypatch.setattr(RoomRepository, "fetch_status", counting_fetch)
-
-    # Patch is_disconnected on the Starlette Request class so all Request instances
-    # use our fake. First call returns False (allow first poll), second returns True (break).
-    from starlette.requests import Request as StarletteRequest
-
-    is_disconnected_call_count = [0]
-
-    async def fake_is_disconnected(self):
-        is_disconnected_call_count[0] += 1
-        # First call: not disconnected (let first poll happen)
-        # Second call and beyond: disconnected (break loop before 2nd DB query)
-        return is_disconnected_call_count[0] >= 2
-
-    monkeypatch.setattr(StarletteRequest, "is_disconnected", fake_is_disconnected)
-
-    # Use a safe deadline that won't time out before disconnect fires
-    monkeypatch.setattr(time, "time", _make_time_mock(20))
+    call_count = _setup_disconnect_after(client, monkeypatch, after_calls=2)
+    monkeypatch.setattr(notifier, "subscribe", lambda code: _resolved_future())
+    monkeypatch.setattr(time, "time", lambda: 1000000.0)
 
     response = client.get("/room/DISC1/stream")
-
-    # The loop must have called is_disconnected at least once
-    assert is_disconnected_call_count[0] >= 1, (
-        f"is_disconnected was never called — disconnect detection not wired: calls={is_disconnected_call_count[0]}"
-    )
-
-    # After disconnect (2nd call returns True), the loop breaks BEFORE the next status fetch.
-    # So snapshot count must be exactly 1 (first poll) — not 2 or more.
-    assert snapshot_calls[0] == 1, (
-        f"Expected exactly 1 status fetch (disconnect before 2nd query), got {snapshot_calls[0]}"
-    )
-
-    # The response is still a valid SSE stream (not an error)
     assert response.status_code == 200
-    assert response.headers.get("content-type", "").startswith("text/event-stream")
+    assert call_count[0] >= 1
 
 
-def test_stream_connection_closed_on_all_exit_paths(client, monkeypatch):
-    """G2: each short-lived async session is closed after snapshot reads (context manager exit).
-
-    Strategy: patch AsyncSession.close to count invocations. Consume a stream until
-    deadline via time mock. Expect at least one close (one poll completed).
-    """
-    import sqlalchemy.ext.asyncio as sa_async
-
-    _seed_stream_room("CLEANUP1", ready=0, current_genre="All")
-    _set_session_room(client, os.environ["FLASK_SECRET"], "CLEANUP1")
-
-    import jellyswipe
-
-    monkeypatch.setattr(jellyswipe, "_gevent_sleep", None, raising=False)
-
-    mock_sleep, _ = _make_sse_sleep_mock()
-    monkeypatch.setattr(asyncio, "sleep", mock_sleep)
-    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
-    monkeypatch.setattr(time, "sleep", lambda _: None)
-
-    close_calls = [0]
-    _orig_close = sa_async.AsyncSession.close
-
-    async def counting_close(self):  # type: ignore[no-untyped-def]
-        close_calls[0] += 1
-        return await _orig_close(self)
-
-    monkeypatch.setattr(sa_async.AsyncSession, "close", counting_close)
-
-    # Time mock: exit after a few iterations (normal timeout exit path)
-    monkeypatch.setattr(time, "time", _make_time_mock(8))
-
-    response = client.get("/room/CLEANUP1/stream")
-    _ = response.content  # consume fully
-
-    assert close_calls[0] >= 1, (
-        "Expected at least one AsyncSession.close from short-lived SSE poll sessions"
-    )
+# ---------------------------------------------------------------------------
+# Section 9: CancelledError propagation
+# ---------------------------------------------------------------------------
 
 
 def test_stream_cancelled_error_not_swallowed(monkeypatch):
-    """G3: CancelledError raised inside the generate() loop must propagate out, not be swallowed.
-
-    Strategy: unit test the generate() async generator directly by driving it with
-    an async harness. Patch fetch_status so the snapshot read raises
-    CancelledError on the first query. Verify CancelledError escapes the generator.
-    """
-    import asyncio
-    from contextlib import asynccontextmanager
-
+    """CancelledError raised inside the generator must propagate out."""
     import jellyswipe.routers.rooms as rooms_module
-    from jellyswipe.repositories.rooms import RoomRepository
-    from unittest.mock import AsyncMock, MagicMock, patch
+    from jellyswipe.dependencies import AuthUser
 
-    @asynccontextmanager
-    async def _fake_async_session():
-        yield MagicMock()
-
-    class _FakeSessionMaker:
-        def __call__(self):
-            return _fake_async_session()
-
-    monkeypatch.setattr(rooms_module, "get_sessionmaker", lambda: _FakeSessionMaker())
-
-    # We need a Request object with is_disconnected returning False
     fake_request = MagicMock()
     fake_request.is_disconnected = AsyncMock(return_value=False)
-
-    snapshot_calls = [0]
-
-    async def raise_cancelled(self, pairing_code):  # type: ignore[no-untyped-def]
-        snapshot_calls[0] += 1
-        raise asyncio.CancelledError("simulated cancellation")
-
-    # Extract the generate() inner function by calling room_stream
-    from jellyswipe.dependencies import AuthUser
+    fake_request.headers = {}
+    fake_request.query_params = {}
 
     fake_auth = AuthUser(jf_token="t", user_id="u")
 
-    with patch.object(RoomRepository, "fetch_status", raise_cancelled):
-        result = rooms_module.room_stream(
-            code="CANCEL1",
-            request=fake_request,
-            auth=fake_auth,
-        )
-        generator = result.body_iterator
+    # Custom async context manager that raises CancelledError on entry
+    class _FailingSessionCM:
+        async def __aenter__(self):
+            raise asyncio.CancelledError("simulated cancellation")
 
-        cancelled_error_propagated = [False]
+        async def __aexit__(self, *args):
+            pass
 
-        async def drive_generator():
-            try:
-                async for _ in generator:
-                    pass
-            except (asyncio.CancelledError, Exception) as exc:
-                if isinstance(exc, asyncio.CancelledError):
-                    cancelled_error_propagated[0] = True
-                else:
-                    raise
+    monkeypatch.setattr(
+        rooms_module, "get_sessionmaker", lambda: lambda: _FailingSessionCM()
+    )
 
-        asyncio.run(drive_generator())
+    result = rooms_module.room_stream(
+        code="CANCEL1",
+        request=fake_request,
+        auth=fake_auth,
+    )
+    generator = result.body_iterator
+
+    cancelled_error_propagated = [False]
+
+    async def drive_generator():
+        try:
+            async for _ in generator:
+                pass
+        except asyncio.CancelledError:
+            cancelled_error_propagated[0] = True
+
+    asyncio.run(drive_generator())
 
     assert cancelled_error_propagated[0], (
-        "CancelledError was swallowed inside except Exception block — "
-        "it must be re-raised so callers see cancellation semantics"
-    )
-    assert snapshot_calls[0] == 1, (
-        "Expected CancelledError to surface from first snapshot poll"
+        "CancelledError was swallowed — it must propagate"
     )
 
 
-def test_room_stream_does_not_open_sqlite3_connection(client, monkeypatch):
-    """Regression: SSE polling must stay off sync sqlite (get_db) in the router.
+# ---------------------------------------------------------------------------
+# Section 10: Room not found
+# ---------------------------------------------------------------------------
 
-    aiosqlite opens sqlite under the hood for AsyncEngine — that is expected. This
-    test blocks the legacy sync API so the stream path cannot regress to
-    sqlite3.connect/get_db in application code.
-    """
-    _seed_stream_room("NO_SQLITE_ROUTE", ready=1, current_genre="All")
-    _set_session_room(client, os.environ["FLASK_SECRET"], "NO_SQLITE_ROUTE")
 
-    import jellyswipe.db as jelly_db
+def test_stream_room_not_found_no_instance(client, monkeypatch):
+    """Stream for room with no instance sends session_reset and closes."""
+    _set_session_room(client, os.environ["FLASK_SECRET"], "NOINSTANCE")
 
-    def forbid_sync_get_db():
-        pytest.fail(
-            "room_stream must not use jellyswipe.db.get_db() — use async SQLAlchemy sessions"
-        )
+    monkeypatch.setattr(time, "time", lambda: 1000000.0)
 
-    monkeypatch.setattr(jelly_db, "get_db", forbid_sync_get_db, raising=False)
+    response = client.get("/room/NOINSTANCE/stream")
+    data = response.text
 
-    import jellyswipe
+    assert "session_reset" in data
+    assert "instance_changed" in data
 
-    monkeypatch.setattr(jellyswipe, "_gevent_sleep", None, raising=False)
 
-    mock_sleep, _ = _make_sse_sleep_mock()
-    monkeypatch.setattr(asyncio, "sleep", mock_sleep)
-    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
-    monkeypatch.setattr(time, "sleep", lambda _: None)
-    monkeypatch.setattr(time, "time", _make_time_mock(4))
+# ---------------------------------------------------------------------------
+# Section 11: GET /matches works independently
+# ---------------------------------------------------------------------------
 
-    response = client.get("/room/NO_SQLITE_ROUTE/stream")
+
+def test_get_matches_works_independently(client, monkeypatch):
+    """GET /matches continues to work independently of the stream."""
+    conn = _sqlite_conn(client)
+    try:
+        _seed_room_and_instance(conn, "MATCHES1", ready=1)
+    finally:
+        conn.close()
+    _set_session_room(client, os.environ["FLASK_SECRET"], "MATCHES1")
+
+    response = client.get("/matches")
     assert response.status_code == 200
 
 
-def test_stream_unauthenticated_request_returns_401(client_real_auth):
-    """G4: GET /room/{code}/stream without auth cookie must return HTTP 401.
+# ---------------------------------------------------------------------------
+# Section 12: Unauthenticated request
+# ---------------------------------------------------------------------------
 
-    Uses client_real_auth (no dependency_overrides for require_auth).
-    Sends request with no session cookie — real auth path must reject it.
-    """
-    # No set_session_cookie call — unauthenticated request
+
+def test_stream_unauthenticated_request_returns_401(client_real_auth):
+    """GET /room/{code}/stream without auth cookie must return HTTP 401."""
     response = client_real_auth.get("/room/AUTHTEST1/stream")
 
     assert response.status_code == 401, (

--- a/tests/test_sse_persistence.py
+++ b/tests/test_sse_persistence.py
@@ -6,7 +6,12 @@ import jellyswipe.db
 import jellyswipe.db_paths
 import pytest
 
-from jellyswipe.db_runtime import build_async_sqlite_url, dispose_runtime, get_sessionmaker, initialize_runtime
+from jellyswipe.db_runtime import (
+    build_async_sqlite_url,
+    dispose_runtime,
+    get_sessionmaker,
+    initialize_runtime,
+)
 from jellyswipe.db_uow import DatabaseUnitOfWork
 from jellyswipe.migrations import build_sqlite_url, upgrade_to_head
 from jellyswipe.room_types import RoomStatusSnapshot
@@ -43,7 +48,9 @@ class TestStreamSnapshotRepo:
             snap = await uow.rooms.fetch_status("NONE")
             assert snap is None
 
-    async def test_fetch_status_preserves_ready_solo_hide_watched(self, runtime_sessionmaker):
+    async def test_fetch_status_preserves_ready_solo_hide_watched(
+        self, runtime_sessionmaker
+    ):
         async with runtime_sessionmaker() as session:
             uow = DatabaseUnitOfWork(session)
             await uow.rooms.create(
@@ -65,4 +72,3 @@ class TestStreamSnapshotRepo:
         assert snap.ready is True
         assert snap.solo is True
         assert snap.hide_watched is False
-


### PR DESCRIPTION
## Rewrite SSE /room/{code}/stream with event-driven replayable session event stream

Replace the polling-based SSE stream with an event-driven, replayable Session Event Stream backed by the session event ledger and post-commit notifier.

**What to build in `jellyswipe/routers/rooms.py` — replace `room_stream`:**

The current `room_stream` generator polls SQLite every 1.5-2s, reads a `StreamSnapshot`, diffs against last-seen state, and yields JSON payloads. Replace it entirely.

**New generator logic:**

```python
@rooms_router.get("/room/{code}/stream")
def room_stream(code: str, request: Request, auth: AuthUser = Depends(require_auth)):
    """SSE stream for session events. Event-driven with replay support."""
    
    async def generate():
        # 1. Resolve cursor: Last-Event-ID header or ?after_event_id= query param
        cursor = request.headers.get("Last-Event-ID") or request.query_params.get("after_event_id")
        cursor = int(cursor) if cursor else None
        
        # 2. Look up session instance and current room state
        async with get_sessionmaker()() as session:
            uow = DatabaseUnitOfWork(session)
            instance = await uow.session_instances.get_by_pairing_code(code)
            if instance is None or instance.status == 'closed':
                yield {"data": json.dumps({"event_type": "session_reset", "reason": "instance_changed"})}
                return
            room = await uow.rooms.get_room(code)
        
        instance_id = instance.instance_id
        
        # 3. Validate cursor if present
        if cursor is not None:
            # Check: does this cursor belong to our instance?
            # Read the event at cursor and verify its instance_id
            async with get_sessionmaker()() as session:
                uow = DatabaseUnitOfWork(session)
                # Validate cursor belongs to this instance
                events_after = await uow.session_events.read_after(instance_id, cursor, limit=1)
                if not events_after:
                    # Cursor might be stale or from wrong instance
                    # Check if cursor event exists at all
                    # If cursor is from a different instance, reject
                    yield {"data": json.dumps({"event_type": "session_reset", "reason": "stale_cursor"})}
                    return
        else:
            # First attach — send bootstrap
            async with get_sessionmaker()() as session:
                uow = DatabaseUnitOfWork(session)
                latest_eid = await uow.session_events.read_latest_event_id(instance_id)
            bootstrap = {
                "event_type": "session_bootstrap",
                "instance_id": instance_id,
                "ready": room.ready if room else False,
                "genre": room.current_genre if room else "All",
                "solo": room.solo_mode if room else False,
                "hide_watched": room.hide_watched if room else False,
                "replay_boundary": latest_eid or 0,
            }
            yield {"id": str(latest_eid or 0), "data": json.dumps(bootstrap)}
        
        # 4. Replay missed events (if cursor was valid)
        if cursor is not None:
            async with get_sessionmaker()() as session:
                uow = DatabaseUnitOfWork(session)
                missed = await uow.session_events.read_after(instance_id, cursor, limit=100)
            for evt in missed:
                yield {"id": str(evt.event_id), "data": json.dumps({"event_id": evt.event_id, "event_type": evt.event_type, **json.loads(evt.payload_json)})}
                if evt.event_type == "session_closed":
                    return  # Stream ends after session_closed
        
        # 5. Subscribe to notifier and stream live events
        last_event_id = missed[-1].event_id if cursor is not None and missed else (latest_eid or 0)
        last_event_time = time.time()
        
        while True:
            if await request.is_disconnected():
                break
            
            future = notifier.subscribe(code)
            try:
                await asyncio.wait_for(future, timeout=20.0)
            except asyncio.TimeoutError:
                # Heartbeat check
                if time.time() - last_event_time >= 15:
                    yield {"comment": "ping"}
                    last_event_time = time.time()
                continue
            
            # Woken by notifier — read new events from ledger
            async with get_sessionmaker()() as session:
                uow = DatabaseUnitOfWork(session)
                new_events = await uow.session_events.read_after(instance_id, last_event_id, limit=100)
            
            for evt in new_events:
                payload = {"event_id": evt.event_id, "event_type": evt.event_type}
                payload.update(json.loads(evt.payload_json))
                yield {"id": str(evt.event_id), "data": json.dumps(payload)}
                last_event_id = evt.event_id
                last_event_time = time.time()
                if evt.event_type == "session_closed":
                    notifier.unsubscribe(code, future)
                    return
            
            notifier.unsubscribe(code, future)
    
    return EventSourceResponse(
        generate(), headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"}
    )
```

**Cleanup:**
- Remove the old `StreamSnapshot` from `jellyswipe/room_types.py`
- Remove `fetch_stream_snapshot` from `jellyswipe/repositories/rooms.py`

**Important design notes:**
- The notifier only signals "something happened" — the generator always reads from the ledger to get actual event data
- SSE `id:` field is set on every event so browsers automatically send `Last-Event-ID` on reconnect
- The generator uses short-lived async sessions for each ledger read (same pattern as the old polling code)
- The `asyncio.wait_for(future, timeout=20)` creates the heartbeat window — if no event arrives in 20s, check if a 15s heartbeat is due
- `session_reset` events are ephemeral (not persisted in the ledger) — they describe the transport state, not the session state


### Acceptance Criteria

1. First attach (no `Last-Event-ID` header, no `?after_event_id=` param): SSE stream sends a `session_bootstrap` event with `{"event_type": "session_bootstrap", "instance_id": "...", "ready": bool, "genre": "str", "solo": bool, "hide_watched": bool, "replay_boundary": <latest_event_id>}`, then subscribes to the notifier for future events
2. Reconnect with valid cursor: reads cursor from `Last-Event-ID` header (preferred) or `?after_event_id=` query param. Validates the cursor belongs to the same session instance and is not stale. Replays missed events from the ledger. Then subscribes to the notifier.
3. Invalid cursor (stale — older than earliest retained event): sends `{"event_type": "session_reset", "reason": "stale_cursor"}` and closes the stream
4. Invalid cursor (wrong instance): sends `{"event_type": "session_reset", "reason": "instance_changed"}` and closes the stream
5. All persisted events are sent as `{"event_id": N, "event_type": "...", ...payload}` — flat typed format with `event_type` field
6. SSE events include `id:` field set to the event_id (for browser-native `Last-Event-ID` reconnect)
7. Notifier-driven wake: after a Future resolves, the generator reads new events from the ledger (not from the notifier itself) and yields them
8. Heartbeat: SSE comment `: ping` sent after ~15 seconds of no data events
9. Room not found (no room row, no active/closing instance): sends `session_closed` event or `session_reset` and closes
10. Session closure detected: when `session_closed` event is replayed or received, send it to client and close stream
11. The old polling loop (`asyncio.sleep(1.5 + jitter)`, `fetch_stream_snapshot`, state-diffing) is completely removed
12. The old `StreamSnapshot` type and `fetch_stream_snapshot` repository method are removed
13. Response headers: `Cache-Control: no-cache`, `X-Accel-Buffering: no`, `Content-Type: text/event-stream`


---
Ticket: `ORCH-005`