### PR TITLE
ticket/ORCH-006: Frontend typed event handling with cursor tracking and deduplication

### DIFF
--- a/jellyswipe/static/app.js
+++ b/jellyswipe/static/app.js
@@ -860,61 +860,128 @@
         }
 
         let sseSource = null;
+        let lastSeenEventId = 0;
+        let seenEventIds = new Set();  // Dedup set (bounded by session lifetime)
 
         const startPolling = () => {
             if (sseSource) { sseSource.close(); sseSource = null; }
-            sseSource = new EventSource(`/room/${currentRoomCode}/stream`);
+
+            // Build URL with cursor if we have one
+            let streamUrl = `/room/${currentRoomCode}/stream`;
+            if (lastSeenEventId > 0) {
+                streamUrl += `?after_event_id=${lastSeenEventId}`;
+            }
+
+            sseSource = new EventSource(streamUrl);
+
             sseSource.onmessage = async (event) => {
+                // Track event ID from SSE id field
+                if (event.lastEventId) {
+                    const eid = parseInt(event.lastEventId, 10);
+                    if (eid > lastSeenEventId) lastSeenEventId = eid;
+                }
+
                 const d = JSON.parse(event.data);
-                if (d.closed) {
-                    sseSource.close();
-                    sseSource = null;
-                    currentRoomCode = null;
-                    document.getElementById('game-area').classList.add('hidden');
-                    document.getElementById('branding').classList.remove('hidden');
-                    document.getElementById('controls-area').classList.remove('hidden');
-                    document.getElementById('quit-pill').classList.add('hidden');
-                    document.getElementById('matches-pill').classList.add('hidden');
-                    document.getElementById('undo-btn').classList.add('hidden');
-                    return;
-                }
-                if (d.genre && d.genre !== currentGenre) {
-                    currentGenre = d.genre;
-                    document.getElementById('genre-pill').innerText = currentGenre === 'All' ? 'Genres ▾' : currentGenre + ' ▾';
-                    const movieRes = await apiFetch(`/room/${currentRoomCode}/deck`);
-                    movieStack = await movieRes.json(); swipeHistory = []; renderInitialDeck();
-                }
-                if (d.hide_watched !== undefined && d.hide_watched !== hideWatched) {
-                    hideWatched = d.hide_watched;
-                    const pill = document.getElementById('hide-watched-pill');
-                    pill.innerText = hideWatched ? 'Hide Watched' : 'Show Watched';
-                    pill.classList.toggle('active', hideWatched);
-                    const movieRes = await apiFetch(`/room/${currentRoomCode}/deck`);
-                    movieStack = await movieRes.json(); swipeHistory = []; renderInitialDeck();
-                }
-                if (d.ready && document.getElementById('game-area').classList.contains('hidden')) {
-                    loadMovies(d.solo || false);
-                }
-                if (d.last_match) {
-                    document.getElementById('matched-movie-title').innerText = d.last_match.title;
-                    document.getElementById('match-popup-poster').src = d.last_match.thumb || '';
-                    const heading = document.getElementById('match-heading');
 
-                    // Update heading based on media type
-                    if (d.last_match.media_type === 'tv_show') {
-                        heading.innerText = "IT'S A TV MATCH!";
-                    } else {
-                        heading.innerText = "IT'S A MATCH!";
-                    }
+                // Dedup by event_id (if present — bootstrap/reset don't have one)
+                if (d.event_id) {
+                    if (seenEventIds.has(d.event_id)) return;
+                    seenEventIds.add(d.event_id);
+                }
 
-                    document.getElementById('match-solo-label').classList.add('hidden');
-                    showMatchMetadata(d.last_match);
-                    document.getElementById('match-overlay').classList.remove('hidden');
+                switch (d.event_type) {
+                    case 'session_bootstrap':
+                        // First attach — set initial state, no match popup
+                        currentGenre = d.genre || 'All';
+                        hideWatched = d.hide_watched || false;
+                        isSoloMode = d.solo || false;
+                        // Update genre pill UI
+                        document.getElementById('genre-pill').innerText =
+                            currentGenre === 'All' ? 'Genres ▾' : currentGenre + ' ▾';
+                        // Update hide_watched pill UI
+                        const pill = document.getElementById('hide-watched-pill');
+                        pill.innerText = hideWatched ? 'Hide Watched' : 'Show Watched';
+                        pill.classList.toggle('active', hideWatched);
+                        // Update solo badge UI
+                        document.getElementById('matches-pill').innerText = isSoloMode ? 'Shortlist' : 'Matches';
+                        document.getElementById('solo-badge').classList.toggle('hidden', !isSoloMode);
+                        // Don't trigger UI changes for bootstrap state —
+                        // the page already loaded via /me response
+                        break;
+
+                    case 'session_ready':
+                        currentGenre = d.genre || 'All';
+                        document.getElementById('genre-pill').innerText =
+                            currentGenre === 'All' ? 'Genres ▾' : currentGenre + ' ▾';
+                        if (document.getElementById('game-area').classList.contains('hidden')) {
+                            loadMovies(d.solo || false);
+                        }
+                        break;
+
+                    case 'match_found':
+                        document.getElementById('matched-movie-title').innerText = d.title;
+                        document.getElementById('match-popup-poster').src = d.thumb || '';
+                        const heading = document.getElementById('match-heading');
+                        heading.innerText = d.media_type === 'tv_show' ? "IT'S A TV MATCH!" : "IT'S A MATCH!";
+                        document.getElementById('match-solo-label').classList.add('hidden');
+                        showMatchMetadata(d);
+                        document.getElementById('match-overlay').classList.remove('hidden');
+                        break;
+
+                    case 'genre_changed':
+                        if (d.genre && d.genre !== currentGenre) {
+                            currentGenre = d.genre;
+                            document.getElementById('genre-pill').innerText =
+                                currentGenre === 'All' ? 'Genres ▾' : currentGenre + ' ▾';
+                            const movieRes = await apiFetch(`/room/${currentRoomCode}/deck`);
+                            movieStack = await movieRes.json();
+                            swipeHistory = [];
+                            renderInitialDeck();
+                        }
+                        break;
+
+                    case 'hide_watched_changed':
+                        if (d.hide_watched !== undefined && d.hide_watched !== hideWatched) {
+                            hideWatched = d.hide_watched;
+                            const pill = document.getElementById('hide-watched-pill');
+                            pill.innerText = hideWatched ? 'Hide Watched' : 'Show Watched';
+                            pill.classList.toggle('active', hideWatched);
+                            const movieRes = await apiFetch(`/room/${currentRoomCode}/deck`);
+                            movieStack = await movieRes.json();
+                            swipeHistory = [];
+                            renderInitialDeck();
+                        }
+                        break;
+
+                    case 'session_closed':
+                        sseSource.close();
+                        sseSource = null;
+                        lastSeenEventId = 0;
+                        seenEventIds.clear();
+                        currentRoomCode = null;
+                        document.getElementById('game-area').classList.add('hidden');
+                        document.getElementById('branding').classList.remove('hidden');
+                        document.getElementById('controls-area').classList.remove('hidden');
+                        document.getElementById('quit-pill').classList.add('hidden');
+                        document.getElementById('matches-pill').classList.add('hidden');
+                        document.getElementById('undo-btn').classList.add('hidden');
+                        break;
+
+                    case 'session_reset':
+                        // Cursor was rejected — reconnect fresh
+                        sseSource.close();
+                        sseSource = null;
+                        lastSeenEventId = 0;
+                        seenEventIds.clear();
+                        setTimeout(() => { if (currentRoomCode) startPolling(); }, 1000);
+                        break;
                 }
             };
+
             sseSource.onerror = () => {
                 sseSource.close();
                 sseSource = null;
+                // Reconnect with cursor if we have one
                 setTimeout(() => { if (currentRoomCode) startPolling(); }, 3000);
             };
         };


### PR DESCRIPTION
## Frontend typed event handling with cursor tracking and deduplication

Update the frontend SSE consumer in `jellyswipe/static/app.js` to handle typed session events, track event cursors, and deduplicate.

**What to change in `jellyswipe/static/app.js`:**

Replace the current `startPolling` / `sseSource.onmessage` handler with typed event handling:

```javascript
let sseSource = null;
let lastSeenEventId = 0;
let seenEventIds = new Set();  // Dedup set (bounded by session lifetime)

const startPolling = () => {
    if (sseSource) { sseSource.close(); sseSource = null; }
    
    // Build URL with cursor if we have one
    let streamUrl = `/room/${currentRoomCode}/stream`;
    if (lastSeenEventId > 0) {
        streamUrl += `?after_event_id=${lastSeenEventId}`;
    }
    
    sseSource = new EventSource(streamUrl);
    
    sseSource.onmessage = async (event) => {
        // Track event ID from SSE id field
        if (event.lastEventId) {
            const eid = parseInt(event.lastEventId, 10);
            if (eid > lastSeenEventId) lastSeenEventId = eid;
        }
        
        const d = JSON.parse(event.data);
        
        // Dedup by event_id (if present — bootstrap/reset don't have one)
        if (d.event_id) {
            if (seenEventIds.has(d.event_id)) return;
            seenEventIds.add(d.event_id);
        }
        
        switch (d.event_type) {
            case 'session_bootstrap':
                // First attach — set initial state, no match popup
                currentInstance = d.instance_id;
                // Don't trigger UI changes for bootstrap state — 
                // the page already loaded via /me response
                break;
                
            case 'session_ready':
                if (document.getElementById('game-area').classList.contains('hidden')) {
                    loadMovies(d.solo || false);
                }
                break;
                
            case 'match_found':
                document.getElementById('matched-movie-title').innerText = d.title;
                document.getElementById('match-popup-poster').src = d.thumb || '';
                const heading = document.getElementById('match-heading');
                heading.innerText = d.media_type === 'tv_show' ? "IT'S A TV MATCH!" : "IT'S A MATCH!";
                document.getElementById('match-solo-label').classList.add('hidden');
                showMatchMetadata(d);
                document.getElementById('match-overlay').classList.remove('hidden');
                break;
                
            case 'genre_changed':
                if (d.genre && d.genre !== currentGenre) {
                    currentGenre = d.genre;
                    document.getElementById('genre-pill').innerText = 
                        currentGenre === 'All' ? 'Genres ▾' : currentGenre + ' ▾';
                    const movieRes = await apiFetch(`/room/${currentRoomCode}/deck`);
                    movieStack = await movieRes.json();
                    swipeHistory = [];
                    renderInitialDeck();
                }
                break;
                
            case 'hide_watched_changed':
                if (d.hide_watched !== undefined && d.hide_watched !== hideWatched) {
                    hideWatched = d.hide_watched;
                    const pill = document.getElementById('hide-watched-pill');
                    pill.innerText = hideWatched ? 'Hide Watched' : 'Show Watched';
                    pill.classList.toggle('active', hideWatched);
                    const movieRes = await apiFetch(`/room/${currentRoomCode}/deck`);
                    movieStack = await movieRes.json();
                    swipeHistory = [];
                    renderInitialDeck();
                }
                break;
                
            case 'session_closed':
                sseSource.close();
                sseSource = null;
                lastSeenEventId = 0;
                seenEventIds.clear();
                currentRoomCode = null;
                document.getElementById('game-area').classList.add('hidden');
                document.getElementById('branding').classList.remove('hidden');
                document.getElementById('controls-area').classList.remove('hidden');
                document.getElementById('quit-pill').classList.add('hidden');
                document.getElementById('matches-pill').classList.add('hidden');
                document.getElementById('undo-btn').classList.add('hidden');
                break;
                
            case 'session_reset':
                // Cursor was rejected — reconnect fresh
                sseSource.close();
                sseSource = null;
                lastSeenEventId = 0;
                seenEventIds.clear();
                setTimeout(() => { if (currentRoomCode) startPolling(); }, 1000);
                break;
        }
    };
    
    sseSource.onerror = () => {
        sseSource.close();
        sseSource = null;
        // Reconnect with cursor if we have one
        setTimeout(() => { if (currentRoomCode) startPolling(); }, 3000);
    };
};
```

**Key changes from current code:**
- Old: `if (d.closed)`, `if (d.genre)`, `if (d.last_match)` → New: `switch (d.event_type)`
- Old: no cursor tracking → New: `lastSeenEventId` sent as `?after_event_id=` on reconnect
- Old: no deduplication → New: `seenEventIds` Set for at-least-once dedup
- Old: EventSource URL has no query params → New: includes `?after_event_id=` when reconnecting
- Old: `d.last_match.title` → New: `d.title` (flat payload, not nested under `last_match`)
- Old: `d.ready` (boolean in state diff) → New: `session_ready` event type
- Old: `d.closed` (boolean) → New: `session_closed` event type

**Important:** The `showMatchMetadata` function call and match popup logic remain the same — only the field access path changes from `d.last_match.title` to `d.title`.


### Acceptance Criteria

1. `sseSource.onmessage` handler parses `event.data` JSON and switches on `d.event_type` for all event handling
2. `lastSeenEventId` variable tracks the highest `event_id` seen; sent as `?after_event_id=` query param when reconnecting
3. `session_bootstrap` event: extracts `instance_id`, `ready`, `genre`, `solo`, `hide_watched`, stores them, and renders initial UI state. Does NOT trigger match popups.
4. `session_ready` event: triggers `loadMovies(d.solo || false)` — same behavior as current `d.ready` handling
5. `match_found` event: shows match popup with `d.title`, `d.thumb`, `d.media_id`, `d.media_type` (same visual as current `d.last_match` handling)
6. `genre_changed` event: updates `currentGenre`, refreshes deck (same as current `d.genre` handling)
7. `hide_watched_changed` event: updates `hideWatched` toggle, refreshes deck (same as current `d.hide_watched` handling)
8. `session_closed` event: closes EventSource, resets UI to lobby (same as current `d.closed` handling)
9. `session_reset` event: clears `lastSeenEventId`, closes EventSource, reconnects without cursor (first-attach behavior). Optionally shows a brief "Session updated, reconnecting..." toast.
10. Deduplication: events with an already-seen `event_id` are silently ignored (no UI side effects)
11. The old state-diff handling (`d.closed`, `d.genre !== currentGenre`, `d.hide_watched !== hideWatched`, `d.ready`, `d.last_match`) is fully replaced by the typed event handlers
12. EventSource reconnect: on `onerror`, close and reconnect with `?after_event_id=` + `lastSeenEventId` if available, or without cursor if not


---
Ticket: `ORCH-006`