### PR TITLE
feat: SSE stream improvements

### DIFF
--- a/alembic/versions/0004_session_event_ledger.py
+++ b/alembic/versions/0004_session_event_ledger.py
@@ -1,0 +1,69 @@
+"""Add session_instances and session_events tables."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0004_session_event_ledger"
+down_revision = "0003_add_hide_watched"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Create session_instances table
+    op.create_table(
+        "session_instances",
+        sa.Column("instance_id", sa.Text(), nullable=False),
+        sa.Column("pairing_code", sa.Text(), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.Text(), nullable=False),
+        sa.Column("closed_at", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("instance_id"),
+    )
+
+    # Create session_events table
+    op.create_table(
+        "session_events",
+        sa.Column("event_id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("session_instance_id", sa.Text(), nullable=False),
+        sa.Column("event_type", sa.Text(), nullable=False),
+        sa.Column("payload_json", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.Text(), nullable=False),
+        sa.PrimaryKeyConstraint("event_id"),
+        sa.ForeignKeyConstraint(
+            ["session_instance_id"], ["session_instances.instance_id"]
+        ),
+    )
+
+    # Create index on (session_instance_id, event_id) for efficient replay reads
+    op.create_index(
+        "ix_session_events_session_instance_id_event_id",
+        "session_events",
+        ["session_instance_id", "event_id"],
+    )
+
+    # Drop rooms.last_match_data column
+    op.drop_column("rooms", "last_match_data")
+
+
+def downgrade() -> None:
+    # Re-add rooms.last_match_data column
+    op.add_column(
+        "rooms",
+        sa.Column("last_match_data", sa.Text(), nullable=True),
+    )
+
+    # Drop index
+    op.drop_index(
+        "ix_session_events_session_instance_id_event_id",
+        table_name="session_events",
+    )
+
+    # Drop session_events table
+    op.drop_table("session_events")
+
+    # Drop session_instances table
+    op.drop_table("session_instances")

--- a/jellyswipe/__init__.py
+++ b/jellyswipe/__init__.py
@@ -102,6 +102,35 @@ class RequestIdMiddleware(BaseHTTPMiddleware):
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     _logger.info("jellyswipe_startup")
+
+    # Clean up orphaned session instances from previous runs
+    try:
+        import datetime
+
+        from jellyswipe.db_runtime import get_sessionmaker
+        from jellyswipe.db_uow import DatabaseUnitOfWork
+
+        async with get_sessionmaker()() as session:
+            uow = DatabaseUnitOfWork(session)
+            # Find instances marked as "closing" for more than 5 minutes
+            cutoff = (
+                datetime.datetime.now(datetime.timezone.utc)
+                - datetime.timedelta(minutes=5)
+            ).isoformat()
+
+            # For each stale closing instance, complete the cleanup
+            closing_instances = await uow.session_instances.get_closing_before(cutoff)
+            for instance in closing_instances:
+                _logger.info("Cleaning up orphaned instance: %s", instance.instance_id)
+                await uow.session_instances.mark_closed(instance.instance_id)
+                await uow.session_events.delete_for_instance(instance.instance_id)
+                await uow.session_instances.delete(instance.instance_id)
+
+            await session.commit()
+    except Exception:
+        # If cleanup fails during startup, log and continue — the app should still start
+        _logger.exception("Failed to clean up orphaned session instances on startup")
+
     yield
     global _provider_singleton
     _provider_singleton = None

--- a/jellyswipe/db_uow.py
+++ b/jellyswipe/db_uow.py
@@ -12,6 +12,10 @@ from jellyswipe.auth_types import AuthRecord
 from jellyswipe.models.auth_session import AuthSession
 from jellyswipe.repositories.matches import MatchRepository
 from jellyswipe.repositories.rooms import RoomRepository
+from jellyswipe.repositories.session_events import (
+    SessionEventRepository,
+    SessionInstanceRepository,
+)
 from jellyswipe.repositories.swipes import SwipeRepository
 
 T = TypeVar("T")
@@ -70,6 +74,8 @@ class DatabaseUnitOfWork:
         self.rooms = RoomRepository(session)
         self.swipes = SwipeRepository(session)
         self.matches = MatchRepository(session)
+        self.session_instances = SessionInstanceRepository(session)
+        self.session_events = SessionEventRepository(session)
 
     async def run_sync(self, fn: Callable[..., T], /, *args: Any, **kwargs: Any) -> T:
         """Run legacy sync work on the managed session connection.
@@ -79,7 +85,9 @@ class DatabaseUnitOfWork:
         remains the single owner of transaction completion for this session.
         """
 
-        return await self.session.run_sync(lambda sync_session: fn(sync_session, *args, **kwargs))
+        return await self.session.run_sync(
+            lambda sync_session: fn(sync_session, *args, **kwargs)
+        )
 
 
 __all__ = [
@@ -87,5 +95,7 @@ __all__ = [
     "DatabaseUnitOfWork",
     "MatchRepository",
     "RoomRepository",
+    "SessionEventRepository",
+    "SessionInstanceRepository",
     "SwipeRepository",
 ]

--- a/jellyswipe/models/room.py
+++ b/jellyswipe/models/room.py
@@ -22,7 +22,6 @@ class Room(Base):
         Text, nullable=False, server_default="All"
     )
     solo_mode: Mapped[int] = mapped_column(nullable=False, server_default="0")
-    last_match_data: Mapped[str | None] = mapped_column(Text, nullable=True)
     deck_position: Mapped[str | None] = mapped_column(Text, nullable=True)
     deck_order: Mapped[str | None] = mapped_column(Text, nullable=True)
     include_movies: Mapped[int] = mapped_column(nullable=False, server_default="1")

--- a/jellyswipe/models/session_event.py
+++ b/jellyswipe/models/session_event.py
@@ -1,0 +1,50 @@
+"""Session instance and event models."""
+
+from sqlalchemy import ForeignKey, Index, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from jellyswipe.models.base import Base
+
+
+class SessionInstance(Base):
+    """Represents a session instance for event streaming."""
+
+    __tablename__ = "session_instances"
+
+    instance_id: Mapped[str] = mapped_column(Text, primary_key=True)
+    pairing_code: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[str] = mapped_column(Text, nullable=False)
+    closed_at: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    events: Mapped[list["SessionEvent"]] = relationship(
+        "SessionEvent",
+        back_populates="session_instance",
+        cascade="all, delete-orphan",
+    )
+
+
+class SessionEvent(Base):
+    """Represents an event in a session's event stream."""
+
+    __tablename__ = "session_events"
+
+    event_id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    session_instance_id: Mapped[str] = mapped_column(
+        Text, ForeignKey("session_instances.instance_id"), nullable=False
+    )
+    event_type: Mapped[str] = mapped_column(Text, nullable=False)
+    payload_json: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[str] = mapped_column(Text, nullable=False)
+
+    session_instance: Mapped["SessionInstance"] = relationship(
+        "SessionInstance", back_populates="events"
+    )
+
+    __table_args__ = (
+        Index(
+            "ix_session_events_session_instance_id_event_id",
+            "session_instance_id",
+            "event_id",
+        ),
+    )

--- a/jellyswipe/notifier.py
+++ b/jellyswipe/notifier.py
@@ -1,0 +1,81 @@
+"""Future-based pub/sub for waking SSE subscribers after committed events.
+
+Single-process asyncio only. The event ledger is the source of truth;
+this module is a latency optimization.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+
+class SessionNotifier:
+    """Future-based pub/sub for waking SSE subscribers after committed events.
+
+    Single-process asyncio only. The event ledger is the source of truth;
+    this module is a latency optimization.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the notifier with an empty subscriber registry."""
+        self._subscribers: dict[str, set[asyncio.Future]] = {}
+
+    def subscribe(self, room_code: str) -> asyncio.Future:
+        """Register a subscriber and return a Future that resolves on notify().
+
+        The caller awaits this Future. When notify() fires, the Future
+        resolves with None. The caller must then re-subscribe for the
+        next event cycle.
+
+        Args:
+            room_code: The room code to subscribe to.
+
+        Returns:
+            An asyncio.Future that resolves when notify() is called for this room.
+        """
+        future: asyncio.Future = asyncio.Future()
+        if room_code not in self._subscribers:
+            self._subscribers[room_code] = set()
+        self._subscribers[room_code].add(future)
+        return future
+
+    def notify(self, room_code: str) -> None:
+        """Resolve all registered Futures for the given room code.
+
+        Called ONLY after the event-append transaction commits successfully.
+        Subscribers wake, read new events from the ledger, and re-subscribe.
+
+        Args:
+            room_code: The room code to notify.
+        """
+        if room_code not in self._subscribers:
+            return
+
+        futures = self._subscribers.pop(room_code)
+        for future in futures:
+            if not future.done():
+                future.set_result(None)
+
+    def unsubscribe(self, room_code: str, future: asyncio.Future) -> None:
+        """Remove a subscriber's Future without resolving it.
+
+        Called on SSE disconnect or stream exit to prevent leaks.
+
+        Args:
+            room_code: The room code to unsubscribe from.
+            future: The Future to remove.
+        """
+        if room_code not in self._subscribers:
+            return
+
+        self._subscribers[room_code].discard(future)
+        if not future.done():
+            future.cancel()
+
+        # Clean up empty sets to prevent memory leaks
+        if not self._subscribers[room_code]:
+            del self._subscribers[room_code]
+
+
+# Module-level singleton instance
+notifier = SessionNotifier()

--- a/jellyswipe/repositories/rooms.py
+++ b/jellyswipe/repositories/rooms.py
@@ -2,14 +2,11 @@
 
 from __future__ import annotations
 
-import json
-from typing import Any
-
 from sqlalchemy import delete, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from jellyswipe.models.room import Room
-from jellyswipe.room_types import RoomRecord, RoomStatusSnapshot, StreamSnapshot
+from jellyswipe.room_types import RoomRecord, RoomStatusSnapshot
 
 
 class RoomRepository:
@@ -120,16 +117,6 @@ class RoomRepository:
         )
         return result.rowcount or 0
 
-    async def set_last_match_data(
-        self, pairing_code: str, last_match_data_json: str | None
-    ) -> int:
-        result = await self._session.execute(
-            update(Room)
-            .where(Room.pairing_code == pairing_code)
-            .values(last_match_data=last_match_data_json)
-        )
-        return result.rowcount or 0
-
     async def fetch_status(self, pairing_code: str) -> RoomStatusSnapshot | None:
         row = (
             await self._session.scalars(
@@ -138,63 +125,16 @@ class RoomRepository:
         ).first()
         if row is None:
             return None
-        last_match: dict[str, Any] | None = None
-        raw = row.last_match_data
-        if raw:
-            try:
-                parsed = json.loads(raw)
-                last_match = parsed if isinstance(parsed, dict) else None
-            except (json.JSONDecodeError, TypeError):
-                last_match = None
         return RoomStatusSnapshot(
             ready=bool(row.ready),
             genre=row.current_genre,
             solo=bool(row.solo_mode),
-            last_match=last_match,
             hide_watched=bool(row.hide_watched),
         )
 
     async def fetch_movie_data(self, pairing_code: str) -> str | None:
         return await self._session.scalar(
             select(Room.movie_data).where(Room.pairing_code == pairing_code)
-        )
-
-    async def fetch_stream_snapshot(self, pairing_code: str) -> StreamSnapshot | None:
-        stmt = select(
-            Room.ready,
-            Room.current_genre,
-            Room.solo_mode,
-            Room.last_match_data,
-            Room.hide_watched,
-        ).where(Room.pairing_code == pairing_code)
-        row = (await self._session.execute(stmt)).one_or_none()
-        if row is None:
-            return None
-        ready_raw, genre, solo_raw, raw_last, hide_watched_raw = (
-            row[0],
-            row[1],
-            row[2],
-            row[3],
-            row[4],
-        )
-        last_match: dict[str, Any] | None = None
-        last_match_ts: str | float | int | None = None
-        if raw_last:
-            try:
-                parsed = json.loads(raw_last)
-                if isinstance(parsed, dict):
-                    last_match = parsed
-                    last_match_ts = parsed.get("ts")
-            except (json.JSONDecodeError, TypeError):
-                last_match = None
-                last_match_ts = None
-        return StreamSnapshot(
-            ready=bool(ready_raw),
-            genre=genre or "",
-            solo=bool(solo_raw),
-            last_match=last_match,
-            last_match_ts=last_match_ts,
-            hide_watched=bool(hide_watched_raw),
         )
 
     async def delete(self, pairing_code: str) -> int:
@@ -211,7 +151,6 @@ class RoomRepository:
             ready=bool(row.ready),
             current_genre=row.current_genre,
             solo_mode=bool(row.solo_mode),
-            last_match_data_json=row.last_match_data,
             deck_position_json=row.deck_position,
             deck_order_json=row.deck_order,
             include_movies=bool(row.include_movies),

--- a/jellyswipe/repositories/session_events.py
+++ b/jellyswipe/repositories/session_events.py
@@ -58,6 +58,7 @@ class SessionInstanceRepository:
                 "instance_id": instance_id,
             },
         )
+        await self._session.flush()
 
     async def mark_closed(self, instance_id: str) -> None:
         """Mark a session instance as closed."""
@@ -69,6 +70,7 @@ class SessionInstanceRepository:
             """),
             {"status": "closed", "instance_id": instance_id},
         )
+        await self._session.flush()
 
     async def delete(self, instance_id: str) -> None:
         """Delete a session instance."""

--- a/jellyswipe/repositories/session_events.py
+++ b/jellyswipe/repositories/session_events.py
@@ -1,0 +1,178 @@
+"""Session instance and event repositories."""
+
+from __future__ import annotations
+
+from sqlalchemy import delete, func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncConnection as AsyncConnection
+
+from jellyswipe.models.session_event import SessionEvent, SessionInstance
+
+
+class SessionInstanceRepository:
+    """Repository for session instance persistence."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def create(self, instance_id: str, pairing_code: str) -> None:
+        """Create a new session instance."""
+        from datetime import datetime, timezone
+
+        self._session.add(
+            SessionInstance(
+                instance_id=instance_id,
+                pairing_code=pairing_code,
+                status="active",
+                created_at=datetime.now(timezone.utc).isoformat(),
+            )
+        )
+
+    async def get_by_pairing_code(self, code: str) -> SessionInstance | None:
+        """Get a session instance by pairing code."""
+        result = await self._session.execute(
+            select(SessionInstance).where(SessionInstance.pairing_code == code)
+        )
+        return result.scalar_one_or_none()
+
+    async def get_by_instance_id(self, instance_id: str) -> SessionInstance | None:
+        """Get a session instance by instance ID."""
+        result = await self._session.execute(
+            select(SessionInstance).where(SessionInstance.instance_id == instance_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def mark_closing(self, instance_id: str) -> None:
+        """Mark a session instance as closing."""
+        from datetime import datetime, timezone
+
+        await self._session.execute(
+            text("""
+                UPDATE session_instances
+                SET status = :status, closed_at = :closed_at
+                WHERE instance_id = :instance_id
+            """),
+            {
+                "status": "closing",
+                "closed_at": datetime.now(timezone.utc).isoformat(),
+                "instance_id": instance_id,
+            },
+        )
+
+    async def mark_closed(self, instance_id: str) -> None:
+        """Mark a session instance as closed."""
+        await self._session.execute(
+            text("""
+                UPDATE session_instances
+                SET status = :status
+                WHERE instance_id = :instance_id
+            """),
+            {"status": "closed", "instance_id": instance_id},
+        )
+
+    async def delete(self, instance_id: str) -> None:
+        """Delete a session instance."""
+        await self._session.execute(
+            delete(SessionInstance).where(SessionInstance.instance_id == instance_id)
+        )
+
+    async def is_pairing_code_reserved(self, code: str) -> bool:
+        """Check if a pairing code is reserved (active or closing)."""
+        result = await self._session.execute(
+            select(func.count()).where(
+                SessionInstance.pairing_code == code,
+                SessionInstance.status.in_(["active", "closing"]),
+            )
+        )
+        count = result.scalar()
+        return (count or 0) > 0
+
+    async def cleanup_closed_before(self, cutoff_iso: str) -> int:
+        """Delete closed instances created before the cutoff."""
+        result = await self._session.execute(
+            text("""
+                DELETE FROM session_instances
+                WHERE status = 'closed' AND created_at < :cutoff
+            """),
+            {"cutoff": cutoff_iso},
+        )
+        return result.rowcount or 0
+
+
+class SessionEventRepository:
+    """Repository for session event persistence."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def append(self, instance_id: str, event_type: str, payload_json: str) -> int:
+        """Append an event and return the new event_id."""
+        from datetime import datetime, timezone
+
+        event = SessionEvent(
+            session_instance_id=instance_id,
+            event_type=event_type,
+            payload_json=payload_json,
+            created_at=datetime.now(timezone.utc).isoformat(),
+        )
+        self._session.add(event)
+        await self._session.flush()
+        return event.event_id
+
+    async def read_after(
+        self, instance_id: str, after_event_id: int, limit: int = 100
+    ) -> list[SessionEvent]:
+        """Read events after a given event_id for an instance."""
+        result = await self._session.execute(
+            select(SessionEvent)
+            .where(
+                SessionEvent.session_instance_id == instance_id,
+                SessionEvent.event_id > after_event_id,
+            )
+            .order_by(SessionEvent.event_id.asc())
+            .limit(limit)
+        )
+        return list(result.scalars().all())
+
+    async def read_latest_event_id(self, instance_id: str) -> int | None:
+        """Get the latest event_id for an instance."""
+        result = await self._session.execute(
+            select(func.max(SessionEvent.event_id)).where(
+                SessionEvent.session_instance_id == instance_id
+            )
+        )
+        return result.scalar()
+
+    async def delete_for_instance(self, instance_id: str) -> int:
+        """Delete all events for an instance."""
+        result = await self._session.execute(
+            delete(SessionEvent).where(SessionEvent.session_instance_id == instance_id)
+        )
+        return result.rowcount or 0
+
+    async def append_raw_sql(
+        self,
+        conn: AsyncConnection,
+        instance_id: str,
+        event_type: str,
+        payload_json: str,
+    ) -> int:
+        """Append an event using raw SQL connection."""
+        from datetime import datetime, timezone
+
+        created_at = datetime.now(timezone.utc).isoformat()
+        await conn.execute(
+            text("""
+                INSERT INTO session_events (session_instance_id, event_type, payload_json, created_at)
+                VALUES (:instance_id, :event_type, :payload_json, :created_at)
+            """),
+            {
+                "instance_id": instance_id,
+                "event_type": event_type,
+                "payload_json": payload_json,
+                "created_at": created_at,
+            },
+        )
+        # Get the last inserted rowid
+        result = await conn.execute(text("SELECT last_insert_rowid()"))
+        return result.scalar()

--- a/jellyswipe/repositories/session_events.py
+++ b/jellyswipe/repositories/session_events.py
@@ -46,19 +46,11 @@ class SessionInstanceRepository:
         """Mark a session instance as closing."""
         from datetime import datetime, timezone
 
-        await self._session.execute(
-            text("""
-                UPDATE session_instances
-                SET status = :status, closed_at = :closed_at
-                WHERE instance_id = :instance_id
-            """),
-            {
-                "status": "closing",
-                "closed_at": datetime.now(timezone.utc).isoformat(),
-                "instance_id": instance_id,
-            },
-        )
-        await self._session.flush()
+        instance = await self.get_by_instance_id(instance_id)
+        if instance:
+            instance.status = "closing"
+            instance.closed_at = datetime.now(timezone.utc).isoformat()
+            await self._session.flush()
 
     async def mark_closed(self, instance_id: str) -> None:
         """Mark a session instance as closed."""
@@ -99,6 +91,29 @@ class SessionInstanceRepository:
             {"cutoff": cutoff_iso},
         )
         return result.rowcount or 0
+
+    async def get_closing_before(self, cutoff_iso: str) -> list[SessionInstance]:
+        """Get instances marked as 'closing' before the cutoff time."""
+        result = await self._session.execute(
+            text("""
+                SELECT * FROM session_instances
+                WHERE status = 'closing' AND closed_at < :cutoff
+            """),
+            {"cutoff": cutoff_iso},
+        )
+        rows = result.mappings().all()
+        instances = []
+        for row in rows:
+            instances.append(
+                SessionInstance(
+                    instance_id=row["instance_id"],
+                    pairing_code=row["pairing_code"],
+                    status=row["status"],
+                    created_at=row["created_at"],
+                    closed_at=row["closed_at"],
+                )
+            )
+        return instances
 
 
 class SessionEventRepository:

--- a/jellyswipe/room_types.py
+++ b/jellyswipe/room_types.py
@@ -6,13 +6,30 @@ from dataclasses import dataclass
 
 
 @dataclass(slots=True)
+class SessionInstanceRecord:
+    instance_id: str
+    pairing_code: str
+    status: str
+    created_at: str
+    closed_at: str | None
+
+
+@dataclass(slots=True)
+class SessionEventRecord:
+    event_id: int
+    session_instance_id: str
+    event_type: str
+    payload_json: str
+    created_at: str
+
+
+@dataclass(slots=True)
 class RoomRecord:
     pairing_code: str
     movie_data_json: str
     ready: bool
     current_genre: str
     solo_mode: bool
-    last_match_data_json: str | None
     deck_position_json: str | None
     deck_order_json: str | None
     include_movies: bool
@@ -25,17 +42,6 @@ class RoomStatusSnapshot:
     ready: bool
     genre: str
     solo: bool
-    last_match: dict | None
-    hide_watched: bool
-
-
-@dataclass(slots=True)
-class StreamSnapshot:
-    ready: bool
-    genre: str
-    solo: bool
-    last_match: dict | None
-    last_match_ts: str | float | int | None
     hide_watched: bool
 
 

--- a/jellyswipe/routers/rooms.py
+++ b/jellyswipe/routers/rooms.py
@@ -11,7 +11,6 @@ request-scoped connection dependency.
 import asyncio
 import json
 import logging
-import random
 import time
 import traceback
 
@@ -21,9 +20,9 @@ from sse_starlette.sse import EventSourceResponse
 
 from jellyswipe import XSSSafeJSONResponse
 from jellyswipe.db_runtime import get_sessionmaker
+from jellyswipe.db_uow import DatabaseUnitOfWork
 from jellyswipe.dependencies import AuthUser, DBUoW, get_provider, require_auth
 from jellyswipe.notifier import notifier
-from jellyswipe.repositories.rooms import RoomRepository
 from jellyswipe.services.room_lifecycle import (
     EmptyDeckError,
     RoomLifecycleService,
@@ -375,72 +374,123 @@ async def room_status(
 
 @rooms_router.get("/room/{code}/stream")
 def room_stream(code: str, request: Request, auth: AuthUser = Depends(require_auth)):
-    """SSE stream for room state changes.
-
-    Per D-01: outer handler is sync def; only the inner generator is async.
-    Per D-07: request is closed over from outer signature for disconnect detection.
-
-    Each poll uses a short-lived async SQLAlchemy session (PAR-05) — no request-scoped UoW
-    and no raw sqlite connection spanning the stream lifetime.
-    """
+    """SSE stream for session events. Event-driven with replay support."""
 
     async def generate():
-        last_genre = None
-        last_ready = None
-        last_hide_watched = None
-        POLL = 1.5
-        TIMEOUT = 3600
-        _last_event_time = time.time()
+        # 1. Resolve cursor: Last-Event-ID header or ?after_event_id= query param
+        cursor = request.headers.get("Last-Event-ID") or request.query_params.get(
+            "after_event_id"
+        )
+        cursor = int(cursor) if cursor else None
 
-        deadline = time.time() + TIMEOUT
-        while time.time() < deadline:
-            # D-06: Check disconnect BEFORE DB query — dead clients skip round-trip.
+        # 2. Look up session instance and current room state
+        async with get_sessionmaker()() as session:
+            uow = DatabaseUnitOfWork(session)
+            instance = await uow.session_instances.get_by_pairing_code(code)
+            if instance is None or instance.status == "closed":
+                yield {
+                    "data": json.dumps(
+                        {"event_type": "session_reset", "reason": "instance_changed"}
+                    )
+                }
+                return
+            room = await uow.rooms.get_room(code)
+
+        instance_id = instance.instance_id
+
+        # 3. Validate cursor if present
+        if cursor is not None:
+            # Check: does this cursor belong to our instance?
+            async with get_sessionmaker()() as session:
+                uow = DatabaseUnitOfWork(session)
+                events_after = await uow.session_events.read_after(
+                    instance_id, cursor, limit=1
+                )
+                if not events_after:
+                    # Cursor might be stale or from wrong instance
+                    yield {
+                        "data": json.dumps(
+                            {"event_type": "session_reset", "reason": "stale_cursor"}
+                        )
+                    }
+                    return
+        else:
+            # First attach — send bootstrap
+            async with get_sessionmaker()() as session:
+                uow = DatabaseUnitOfWork(session)
+                latest_eid = await uow.session_events.read_latest_event_id(instance_id)
+            bootstrap = {
+                "event_type": "session_bootstrap",
+                "instance_id": instance_id,
+                "ready": room.ready if room else False,
+                "genre": room.current_genre if room else "All",
+                "solo": room.solo_mode if room else False,
+                "hide_watched": room.hide_watched if room else False,
+                "replay_boundary": latest_eid or 0,
+            }
+            yield {"id": str(latest_eid or 0), "data": json.dumps(bootstrap)}
+
+        # 4. Replay missed events (if cursor was valid)
+        missed = []
+        latest_eid = None
+        if cursor is not None:
+            async with get_sessionmaker()() as session:
+                uow = DatabaseUnitOfWork(session)
+                missed = await uow.session_events.read_after(
+                    instance_id, cursor, limit=100
+                )
+            for evt in missed:
+                yield {
+                    "id": str(evt.event_id),
+                    "data": json.dumps(
+                        {
+                            "event_id": evt.event_id,
+                            "event_type": evt.event_type,
+                            **json.loads(evt.payload_json),
+                        }
+                    ),
+                }
+                if evt.event_type == "session_closed":
+                    return  # Stream ends after session_closed
+
+        # 5. Subscribe to notifier and stream live events
+        last_event_id = (
+            missed[-1].event_id if cursor is not None and missed else (latest_eid or 0)
+        )
+        last_event_time = time.time()
+
+        while True:
             if await request.is_disconnected():
                 break
-            try:
-                async with get_sessionmaker()() as session:
-                    repo = RoomRepository(session)
-                    snapshot = await repo.fetch_status(code)
 
-                if snapshot is None:
-                    yield {"data": json.dumps({"closed": True})}
+            future = notifier.subscribe(code)
+            try:
+                await asyncio.wait_for(future, timeout=20.0)
+            except asyncio.TimeoutError:
+                # Heartbeat check
+                if time.time() - last_event_time >= 15:
+                    yield {"comment": "ping"}
+                    last_event_time = time.time()
+                continue
+
+            # Woken by notifier — read new events from ledger
+            async with get_sessionmaker()() as session:
+                uow = DatabaseUnitOfWork(session)
+                new_events = await uow.session_events.read_after(
+                    instance_id, last_event_id, limit=100
+                )
+
+            for evt in new_events:
+                payload = {"event_id": evt.event_id, "event_type": evt.event_type}
+                payload.update(json.loads(evt.payload_json))
+                yield {"id": str(evt.event_id), "data": json.dumps(payload)}
+                last_event_id = evt.event_id
+                last_event_time = time.time()
+                if evt.event_type == "session_closed":
+                    notifier.unsubscribe(code, future)
                     return
 
-                ready = snapshot.ready
-                genre = snapshot.genre
-                solo = snapshot.solo
-                hide_watched = snapshot.hide_watched
-
-                payload = {}
-                if ready != last_ready:
-                    payload["ready"] = ready
-                    payload["solo"] = solo
-                    last_ready = ready
-                if genre != last_genre:
-                    payload["genre"] = genre
-                    last_genre = genre
-                if hide_watched != last_hide_watched:
-                    payload["hide_watched"] = hide_watched
-                    last_hide_watched = hide_watched
-
-                if payload:
-                    yield {"data": json.dumps(payload)}
-                    _last_event_time = time.time()
-                elif time.time() - _last_event_time >= 15:
-                    # SSE-5: EventSourceResponse comment syntax for heartbeat ping
-                    yield {"comment": "ping"}
-                    _last_event_time = time.time()
-
-                delay = POLL + random.uniform(0, 0.5)
-                await asyncio.sleep(delay)  # SSE-2: non-blocking sleep
-            except Exception as exc:
-                # D-09, SSE-4: Re-raise CancelledError so try/finally can clean up.
-                # Do NOT swallow CancelledError — it is the asyncio disconnect signal.
-                if isinstance(exc, asyncio.CancelledError):
-                    raise
-                logging.getLogger().warning("SSE poll error for room %s: %s", code, exc)
-                delay = POLL + random.uniform(0, 0.5)
-                await asyncio.sleep(delay)  # SSE-2: non-blocking even in error path
+            notifier.unsubscribe(code, future)
 
     # D-03: EventSourceResponse handles text/event-stream media type and SSE framing.
     # D-04: Verify Cache-Control and X-Accel-Buffering headers are present on response.

--- a/jellyswipe/routers/rooms.py
+++ b/jellyswipe/routers/rooms.py
@@ -222,6 +222,9 @@ async def swipe(
         body, status_code = result
         return XSSSafeJSONResponse(content=body, status_code=status_code)
 
+    # Commit before notifying to ensure events are persisted
+    await uow.session.commit()
+    notifier.notify(code)
     return {"accepted": True}
 
 

--- a/jellyswipe/routers/rooms.py
+++ b/jellyswipe/routers/rooms.py
@@ -366,7 +366,6 @@ def room_stream(code: str, request: Request, auth: AuthUser = Depends(require_au
     async def generate():
         last_genre = None
         last_ready = None
-        last_match_ts = None
         last_hide_watched = None
         POLL = 1.5
         TIMEOUT = 3600
@@ -380,7 +379,7 @@ def room_stream(code: str, request: Request, auth: AuthUser = Depends(require_au
             try:
                 async with get_sessionmaker()() as session:
                     repo = RoomRepository(session)
-                    snapshot = await repo.fetch_stream_snapshot(code)
+                    snapshot = await repo.fetch_status(code)
 
                 if snapshot is None:
                     yield {"data": json.dumps({"closed": True})}
@@ -389,8 +388,6 @@ def room_stream(code: str, request: Request, auth: AuthUser = Depends(require_au
                 ready = snapshot.ready
                 genre = snapshot.genre
                 solo = snapshot.solo
-                last_match = snapshot.last_match
-                match_ts = snapshot.last_match_ts
                 hide_watched = snapshot.hide_watched
 
                 payload = {}
@@ -404,9 +401,6 @@ def room_stream(code: str, request: Request, auth: AuthUser = Depends(require_au
                 if hide_watched != last_hide_watched:
                     payload["hide_watched"] = hide_watched
                     last_hide_watched = hide_watched
-                if match_ts and match_ts != last_match_ts:
-                    payload["last_match"] = last_match
-                    last_match_ts = match_ts
 
                 if payload:
                     yield {"data": json.dumps(payload)}

--- a/jellyswipe/routers/rooms.py
+++ b/jellyswipe/routers/rooms.py
@@ -22,6 +22,7 @@ from sse_starlette.sse import EventSourceResponse
 from jellyswipe import XSSSafeJSONResponse
 from jellyswipe.db_runtime import get_sessionmaker
 from jellyswipe.dependencies import AuthUser, DBUoW, get_provider, require_auth
+from jellyswipe.notifier import notifier
 from jellyswipe.repositories.rooms import RoomRepository
 from jellyswipe.services.room_lifecycle import (
     EmptyDeckError,
@@ -133,7 +134,7 @@ async def create_room(
         )
 
     try:
-        return await room_lifecycle_service.create_room(
+        result = await room_lifecycle_service.create_room(
             request.session,
             user.user_id,
             get_provider(),
@@ -142,6 +143,9 @@ async def create_room(
             include_tv_shows=include_tv_shows,
             solo=solo,
         )
+        # Commit the session to persist session_instances row
+        await uow.session.commit()
+        return result
     except UniqueRoomCodeExhaustedError:
         return XSSSafeJSONResponse(
             content={"error": "Could not generate unique room code"}, status_code=503
@@ -169,6 +173,9 @@ async def join_room_route(
     )
     if payload is None:
         return XSSSafeJSONResponse(content={"error": "Invalid Code"}, status_code=404)
+    # Commit before notifying to ensure events are persisted
+    await uow.session.commit()
+    notifier.notify(code)
     return payload
 
 
@@ -233,9 +240,13 @@ async def quit_room(
     code: str, request: Request, uow: DBUoW, user: AuthUser = Depends(require_auth)
 ):
     """Quit a room and archive matches."""
-    return await room_lifecycle_service.quit_room(
+    result = await room_lifecycle_service.quit_room(
         code, request.session, user.user_id, uow
     )
+    # Commit before notifying to ensure events are persisted
+    await uow.session.commit()
+    notifier.notify(code)
+    return result
 
 
 @rooms_router.post("/matches/delete")
@@ -311,6 +322,9 @@ async def set_genre(
         new_list = await room_lifecycle_service.set_genre(
             code, genre, get_provider(), uow
         )
+        # Commit before notifying to ensure events are persisted
+        await uow.session.commit()
+        notifier.notify(code)
         return new_list
     except EmptyDeckError as e:
         return XSSSafeJSONResponse(content={"error": str(e)}, status_code=400)
@@ -335,9 +349,13 @@ async def set_watched_filter_route(
             content={"error": "hide_watched must be a boolean"}, status_code=400
         )
     try:
-        return await room_lifecycle_service.set_watched_filter(
+        result = await room_lifecycle_service.set_watched_filter(
             code, hide_watched, get_provider(), uow
         )
+        # Commit before notifying to ensure events are persisted
+        await uow.session.commit()
+        notifier.notify(code)
+        return result
     except EmptyDeckError:
         return XSSSafeJSONResponse(
             content={"error": "No unwatched items available"}, status_code=422

--- a/jellyswipe/services/room_lifecycle.py
+++ b/jellyswipe/services/room_lifecycle.py
@@ -127,6 +127,10 @@ class RoomLifecycleService:
             await uow.session_instances.create(
                 instance_id=instance_id, pairing_code=pairing_code
             )
+            if solo:
+                await uow.session_events.append(
+                    instance_id, "session_ready", json.dumps({"solo": True})
+                )
             session_dict["active_room"] = pairing_code
             session_dict["solo_mode"] = solo
             return {"pairing_code": pairing_code, "instance_id": instance_id}

--- a/jellyswipe/services/room_lifecycle.py
+++ b/jellyswipe/services/room_lifecycle.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import secrets
 from typing import Any, Protocol
+from uuid import uuid4
 
 from jellyswipe.db_uow import DatabaseUnitOfWork
+from jellyswipe.db_runtime import get_sessionmaker
 from jellyswipe.room_types import MatchRecord
 
 logger = logging.getLogger(__name__)
@@ -83,7 +86,10 @@ class RoomLifecycleService:
         for _ in range(10):
             pairing_code = str(secrets.randbelow(9000) + 1000)
             exists = await uow.rooms.pairing_code_exists(pairing_code)
-            if exists:
+            reserved = await uow.session_instances.is_pairing_code_reserved(
+                pairing_code
+            )
+            if exists or reserved:
                 continue
             # Build media_types list from boolean flags
             media_types = []
@@ -107,6 +113,7 @@ class RoomLifecycleService:
                 movie_list = interleaved
 
             deck_json = json.dumps({user_id: 0})
+            instance_id = uuid4().hex
             await uow.rooms.create(
                 pairing_code,
                 movie_data_json=json.dumps(movie_list),
@@ -117,9 +124,12 @@ class RoomLifecycleService:
                 include_movies=include_movies,
                 include_tv_shows=include_tv_shows,
             )
+            await uow.session_instances.create(
+                instance_id=instance_id, pairing_code=pairing_code
+            )
             session_dict["active_room"] = pairing_code
             session_dict["solo_mode"] = solo
-            return {"pairing_code": pairing_code}
+            return {"pairing_code": pairing_code, "instance_id": instance_id}
 
         raise UniqueRoomCodeExhaustedError()
 
@@ -133,12 +143,16 @@ class RoomLifecycleService:
         for _ in range(10):
             pairing_code = str(secrets.randbelow(9000) + 1000)
             exists = await uow.rooms.pairing_code_exists(pairing_code)
-            if exists:
+            reserved = await uow.session_instances.is_pairing_code_reserved(
+                pairing_code
+            )
+            if exists or reserved:
                 continue
             # Build media_types list from boolean flags - solo mode defaults to movies only
             media_types = ["movie"]
             movie_list = provider.fetch_deck(media_types=media_types)
             deck_json = json.dumps({user_id: 0})
+            instance_id = uuid4().hex
             await uow.rooms.create(
                 pairing_code,
                 movie_data_json=json.dumps(movie_list),
@@ -147,9 +161,12 @@ class RoomLifecycleService:
                 solo_mode=True,
                 deck_position_json=deck_json,
             )
+            await uow.session_instances.create(
+                instance_id=instance_id, pairing_code=pairing_code
+            )
             session_dict["active_room"] = pairing_code
             session_dict["solo_mode"] = True
-            return {"pairing_code": pairing_code}
+            return {"pairing_code": pairing_code, "instance_id": instance_id}
 
         raise UniqueRoomCodeExhaustedError()
 
@@ -177,6 +194,13 @@ class RoomLifecycleService:
         await uow.rooms.set_ready(code, True)
         await uow.rooms.set_deck_position(code, json.dumps(positions))
 
+        # Append session_ready event
+        instance = await uow.session_instances.get_by_pairing_code(code)
+        if instance:
+            await uow.session_events.append(
+                instance.instance_id, "session_ready", json.dumps({})
+            )
+
         session_dict["active_room"] = code
         session_dict["solo_mode"] = False
         return {"status": "success"}
@@ -188,12 +212,32 @@ class RoomLifecycleService:
         user_id: str,
         uow: DatabaseUnitOfWork,
     ) -> dict[str, str]:
+        # Look up instance and append session_closed event
+        instance = await uow.session_instances.get_by_pairing_code(code)
+        if instance:
+            await uow.session_events.append(
+                instance.instance_id, "session_closed", json.dumps({})
+            )
+            await uow.session_instances.mark_closing(instance.instance_id)
+            # Schedule background cleanup task
+            asyncio.create_task(self._cleanup_after_grace(instance.instance_id))
+
         await uow.rooms.delete(code)
         await uow.swipes.delete_room_swipes(code)
         await uow.matches.archive_active_for_room(code)
         session_dict.pop("active_room", None)
         session_dict.pop("solo_mode", None)
         return {"status": "session_ended"}
+
+    async def _cleanup_after_grace(self, instance_id: str) -> None:
+        """Clean up session instance after 60-second grace period."""
+        await asyncio.sleep(60)
+        async with get_sessionmaker()() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.session_instances.mark_closed(instance_id)
+            await uow.session_events.delete_for_instance(instance_id)
+            await uow.session_instances.delete(instance_id)
+            await session.commit()
 
     async def get_deck(
         self,
@@ -325,7 +369,14 @@ class RoomLifecycleService:
         uow: DatabaseUnitOfWork,
     ) -> list[dict[str, Any]]:
         """Set genre filter and rebuild deck."""
-        return await self._rebuild_deck(code, provider, uow, genre=genre)
+        new_deck = await self._rebuild_deck(code, provider, uow, genre=genre)
+        # Append genre_changed event on success
+        instance = await uow.session_instances.get_by_pairing_code(code)
+        if instance:
+            await uow.session_events.append(
+                instance.instance_id, "genre_changed", json.dumps({"genre": genre})
+            )
+        return new_deck
 
     async def set_watched_filter(
         self,
@@ -335,7 +386,18 @@ class RoomLifecycleService:
         uow: DatabaseUnitOfWork,
     ) -> list[dict[str, Any]]:
         """Set watched filter and rebuild deck."""
-        return await self._rebuild_deck(code, provider, uow, hide_watched=hide_watched)
+        new_deck = await self._rebuild_deck(
+            code, provider, uow, hide_watched=hide_watched
+        )
+        # Append hide_watched_changed event on success
+        instance = await uow.session_instances.get_by_pairing_code(code)
+        if instance:
+            await uow.session_events.append(
+                instance.instance_id,
+                "hide_watched_changed",
+                json.dumps({"hide_watched": hide_watched}),
+            )
+        return new_deck
 
     async def get_status(self, code: str, uow: DatabaseUnitOfWork) -> dict[str, Any]:
         snapshot = await uow.rooms.fetch_status(code)

--- a/jellyswipe/services/room_lifecycle.py
+++ b/jellyswipe/services/room_lifecycle.py
@@ -346,7 +346,6 @@ class RoomLifecycleService:
             "genre": snapshot.genre,
             "solo": snapshot.solo,
             "hide_watched": snapshot.hide_watched,
-            "last_match": snapshot.last_match,
         }
 
     async def get_matches(

--- a/jellyswipe/services/swipe_match.py
+++ b/jellyswipe/services/swipe_match.py
@@ -201,7 +201,7 @@ def _sync_run_swipe_transaction(
             ),
         )
         rid = _match_sentinel_rowid(conn, code, movie_id)
-        match_data = _last_match_json(
+        _last_match_json(
             title=title,
             thumb=thumb,
             movie_id=movie_id,
@@ -209,11 +209,12 @@ def _sync_run_swipe_transaction(
             deep_link=deep_link,
             sentinel_ts=rid,
         )
-        _execute(
-            conn,
-            "UPDATE rooms SET last_match_data = ? WHERE pairing_code = ?",
-            (match_data, code),
-        )
+        # TODO(ORCH-001): Migrate to session events - for now, skip last_match_data update
+        # _execute(
+        #     conn,
+        #     "UPDATE rooms SET last_match_data = ? WHERE pairing_code = ?",
+        #     (match_data, code),
+        # )
         return None
 
     session_id = request_session.get("session_id")
@@ -269,7 +270,7 @@ def _sync_run_swipe_transaction(
         )
 
     rid = _match_sentinel_rowid(conn, code, movie_id)
-    match_data = _last_match_json(
+    _last_match_json(
         title=title,
         thumb=thumb,
         movie_id=movie_id,
@@ -277,11 +278,12 @@ def _sync_run_swipe_transaction(
         deep_link=deep_link,
         sentinel_ts=rid,
     )
-    _execute(
-        conn,
-        "UPDATE rooms SET last_match_data = ? WHERE pairing_code = ?",
-        (match_data, code),
-    )
+    # TODO(ORCH-001): Migrate to session events - for now, skip last_match_data update
+    # _execute(
+    #     conn,
+    #     "UPDATE rooms SET last_match_data = ? WHERE pairing_code = ?",
+    #     (match_data, code),
+    # )
     return None
 
 
@@ -314,13 +316,15 @@ class SwipeMatchService:
     async def _recompute_last_match_for_room(
         self, uow: DatabaseUnitOfWork, pairing_code: str
     ) -> None:
-        latest = await uow.matches.latest_active_for_room(pairing_code)
-        if latest is None:
-            await uow.rooms.set_last_match_data(pairing_code, None)
-            return
-        await uow.rooms.set_last_match_data(
-            pairing_code, match_record_as_last_match_json(latest)
-        )
+        # TODO(ORCH-001): Migrate to session events - for now, skip last_match_data recomputation
+        # latest = await uow.matches.latest_active_for_room(pairing_code)
+        # if latest is None:
+        #     await uow.rooms.set_last_match_data(pairing_code, None)
+        #     return
+        # await uow.rooms.set_last_match_data(
+        #     pairing_code, match_record_as_last_match_json(latest)
+        # )
+        pass
 
     async def undo_swipe(
         self,

--- a/jellyswipe/services/swipe_match.py
+++ b/jellyswipe/services/swipe_match.py
@@ -1,20 +1,20 @@
 """Dedicated swipe/match mutation service — Phase 39 (D-14).
 
 Serialized swipe mutations use `BEGIN IMMEDIATE` inside `uow.run_sync(...)`
-without owning commit/rollback. Undo/delete routes recompute room last-match sentinels
-from persisted active match rows (`match_order` / SQLite rowid).
+without owning commit/rollback. Match creation emits `match_found` events
+into the session event ledger atomically within the swipe transaction.
 """
 
 from __future__ import annotations
 
 import json
+import time
 
 from sqlalchemy.engine import Connection
 from sqlalchemy.orm import Session
 
 from jellyswipe.config import JELLYFIN_URL
 from jellyswipe.db_uow import DatabaseUnitOfWork
-from jellyswipe.room_types import MatchRecord
 
 
 def _run_query(conn: Connection | object, query: str, params: tuple = ()) -> object:
@@ -81,62 +81,6 @@ def _resolve_movie_meta(movie_data_json: str | None, movie_id: str) -> dict[str,
     return {"rating": "", "duration": "", "year": "", "media_type": "movie"}
 
 
-def _match_sentinel_rowid(
-    conn: Connection, pairing_code: str, movie_id: str
-) -> int | None:
-    row = _fetchone(
-        conn,
-        "SELECT MAX(rowid) AS rid FROM matches WHERE room_code = ? AND movie_id = ?",
-        (pairing_code, movie_id),
-    )
-    if not row or row.get("rid") is None:
-        return None
-    return int(row["rid"])
-
-
-def _last_match_json(
-    *,
-    title: str,
-    thumb: str,
-    movie_id: str,
-    meta: dict[str, str],
-    deep_link: str,
-    sentinel_ts: int | None,
-) -> str:
-    data = {
-        "type": "match",
-        "title": title,
-        "thumb": thumb,
-        "media_id": movie_id,
-        "media_type": meta.get("media_type", "movie"),
-        "rating": meta["rating"],
-        "duration": meta["duration"],
-        "year": meta["year"],
-        "deep_link": deep_link,
-        "ts": sentinel_ts,
-    }
-    return json.dumps(data)
-
-
-def match_record_as_last_match_json(rec: MatchRecord) -> str:
-    """Build `rooms.last_match_data` JSON from the newest persisted active match."""
-
-    ts_token = rec.match_order
-    payload = {
-        "type": "match",
-        "title": rec.title,
-        "thumb": rec.thumb,
-        "media_id": rec.movie_id,
-        "media_type": rec.media_type or "movie",
-        "rating": rec.rating or "",
-        "duration": rec.duration or "",
-        "year": rec.year or "",
-        "deep_link": rec.deep_link or "",
-        "ts": ts_token if ts_token is not None else 0,
-    }
-    return json.dumps(payload)
-
-
 def _sync_run_swipe_transaction(
     sync_session: Session,
     *,
@@ -200,21 +144,35 @@ def _sync_run_swipe_transaction(
                 meta["media_type"],
             ),
         )
-        rid = _match_sentinel_rowid(conn, code, movie_id)
-        _last_match_json(
-            title=title,
-            thumb=thumb,
-            movie_id=movie_id,
-            meta=meta,
-            deep_link=deep_link,
-            sentinel_ts=rid,
+        # Emit match_found event into session event ledger
+        inst = _fetchone(
+            conn,
+            "SELECT instance_id FROM session_instances WHERE pairing_code = ? AND status = 'active'",
+            (code,),
         )
-        # TODO(ORCH-001): Migrate to session events - for now, skip last_match_data update
-        # _execute(
-        #     conn,
-        #     "UPDATE rooms SET last_match_data = ? WHERE pairing_code = ?",
-        #     (match_data, code),
-        # )
+        if inst:
+            payload = json.dumps(
+                {
+                    "media_id": movie_id,
+                    "title": title,
+                    "thumb": thumb,
+                    "media_type": meta.get("media_type", "movie"),
+                    "rating": meta["rating"],
+                    "duration": meta["duration"],
+                    "year": meta["year"],
+                    "deep_link": deep_link,
+                }
+            )
+            _execute(
+                conn,
+                "INSERT INTO session_events (session_instance_id, event_type, payload_json, created_at) VALUES (?, ?, ?, ?)",
+                (
+                    inst["instance_id"],
+                    "match_found",
+                    payload,
+                    time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                ),
+            )
         return None
 
     session_id = request_session.get("session_id")
@@ -269,21 +227,35 @@ def _sync_run_swipe_transaction(
             ),
         )
 
-    rid = _match_sentinel_rowid(conn, code, movie_id)
-    _last_match_json(
-        title=title,
-        thumb=thumb,
-        movie_id=movie_id,
-        meta=meta,
-        deep_link=deep_link,
-        sentinel_ts=rid,
+    # Emit match_found event into session event ledger
+    inst = _fetchone(
+        conn,
+        "SELECT instance_id FROM session_instances WHERE pairing_code = ? AND status = 'active'",
+        (code,),
     )
-    # TODO(ORCH-001): Migrate to session events - for now, skip last_match_data update
-    # _execute(
-    #     conn,
-    #     "UPDATE rooms SET last_match_data = ? WHERE pairing_code = ?",
-    #     (match_data, code),
-    # )
+    if inst:
+        payload = json.dumps(
+            {
+                "media_id": movie_id,
+                "title": title,
+                "thumb": thumb,
+                "media_type": meta.get("media_type", "movie"),
+                "rating": meta["rating"],
+                "duration": meta["duration"],
+                "year": meta["year"],
+                "deep_link": deep_link,
+            }
+        )
+        _execute(
+            conn,
+            "INSERT INTO session_events (session_instance_id, event_type, payload_json, created_at) VALUES (?, ?, ?, ?)",
+            (
+                inst["instance_id"],
+                "match_found",
+                payload,
+                time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            ),
+        )
     return None
 
 
@@ -313,19 +285,6 @@ class SwipeMatchService:
             thumb=thumb,
         )
 
-    async def _recompute_last_match_for_room(
-        self, uow: DatabaseUnitOfWork, pairing_code: str
-    ) -> None:
-        # TODO(ORCH-001): Migrate to session events - for now, skip last_match_data recomputation
-        # latest = await uow.matches.latest_active_for_room(pairing_code)
-        # if latest is None:
-        #     await uow.rooms.set_last_match_data(pairing_code, None)
-        #     return
-        # await uow.rooms.set_last_match_data(
-        #     pairing_code, match_record_as_last_match_json(latest)
-        # )
-        pass
-
     async def undo_swipe(
         self,
         *,
@@ -339,8 +298,6 @@ class SwipeMatchService:
             code, movie_id, request_session.get("session_id")
         )
         await uow.matches.delete_active_for_room_movie_user(code, movie_id, user_id)
-        if await uow.rooms.pairing_code_exists(code):
-            await self._recompute_last_match_for_room(uow, code)
         return {"status": "undone"}
 
     async def delete_match(
@@ -352,9 +309,7 @@ class SwipeMatchService:
         uow: DatabaseUnitOfWork,
     ) -> dict:
         await uow.matches.delete_for_user(movie_id, user_id)
-        if active_room and await uow.rooms.pairing_code_exists(active_room):
-            await self._recompute_last_match_for_room(uow, active_room)
         return {"status": "deleted"}
 
 
-__all__ = ["SwipeMatchService", "match_record_as_last_match_json"]
+__all__ = ["SwipeMatchService"]

--- a/jellyswipe/static/app.js
+++ b/jellyswipe/static/app.js
@@ -905,8 +905,12 @@
                         // Update solo badge UI
                         document.getElementById('matches-pill').innerText = isSoloMode ? 'Shortlist' : 'Matches';
                         document.getElementById('solo-badge').classList.toggle('hidden', !isSoloMode);
-                        // Don't trigger UI changes for bootstrap state —
-                        // the page already loaded via /me response
+                        // If room is already ready (e.g. solo) and game hasn't loaded yet, load now.
+                        // On page refresh the /me handler calls loadMovies() first, so game-area
+                        // is already visible and this guard prevents a double-call.
+                        if (d.ready && document.getElementById('game-area').classList.contains('hidden')) {
+                            loadMovies(isSoloMode);
+                        }
                         break;
 
                     case 'session_ready':

--- a/jellyswipe/static/app.js
+++ b/jellyswipe/static/app.js
@@ -860,61 +860,128 @@
         }
 
         let sseSource = null;
+        let lastSeenEventId = 0;
+        let seenEventIds = new Set();  // Dedup set (bounded by session lifetime)
 
         const startPolling = () => {
             if (sseSource) { sseSource.close(); sseSource = null; }
-            sseSource = new EventSource(`/room/${currentRoomCode}/stream`);
+
+            // Build URL with cursor if we have one
+            let streamUrl = `/room/${currentRoomCode}/stream`;
+            if (lastSeenEventId > 0) {
+                streamUrl += `?after_event_id=${lastSeenEventId}`;
+            }
+
+            sseSource = new EventSource(streamUrl);
+
             sseSource.onmessage = async (event) => {
+                // Track event ID from SSE id field
+                if (event.lastEventId) {
+                    const eid = parseInt(event.lastEventId, 10);
+                    if (eid > lastSeenEventId) lastSeenEventId = eid;
+                }
+
                 const d = JSON.parse(event.data);
-                if (d.closed) {
-                    sseSource.close();
-                    sseSource = null;
-                    currentRoomCode = null;
-                    document.getElementById('game-area').classList.add('hidden');
-                    document.getElementById('branding').classList.remove('hidden');
-                    document.getElementById('controls-area').classList.remove('hidden');
-                    document.getElementById('quit-pill').classList.add('hidden');
-                    document.getElementById('matches-pill').classList.add('hidden');
-                    document.getElementById('undo-btn').classList.add('hidden');
-                    return;
-                }
-                if (d.genre && d.genre !== currentGenre) {
-                    currentGenre = d.genre;
-                    document.getElementById('genre-pill').innerText = currentGenre === 'All' ? 'Genres ▾' : currentGenre + ' ▾';
-                    const movieRes = await apiFetch(`/room/${currentRoomCode}/deck`);
-                    movieStack = await movieRes.json(); swipeHistory = []; renderInitialDeck();
-                }
-                if (d.hide_watched !== undefined && d.hide_watched !== hideWatched) {
-                    hideWatched = d.hide_watched;
-                    const pill = document.getElementById('hide-watched-pill');
-                    pill.innerText = hideWatched ? 'Hide Watched' : 'Show Watched';
-                    pill.classList.toggle('active', hideWatched);
-                    const movieRes = await apiFetch(`/room/${currentRoomCode}/deck`);
-                    movieStack = await movieRes.json(); swipeHistory = []; renderInitialDeck();
-                }
-                if (d.ready && document.getElementById('game-area').classList.contains('hidden')) {
-                    loadMovies(d.solo || false);
-                }
-                if (d.last_match) {
-                    document.getElementById('matched-movie-title').innerText = d.last_match.title;
-                    document.getElementById('match-popup-poster').src = d.last_match.thumb || '';
-                    const heading = document.getElementById('match-heading');
 
-                    // Update heading based on media type
-                    if (d.last_match.media_type === 'tv_show') {
-                        heading.innerText = "IT'S A TV MATCH!";
-                    } else {
-                        heading.innerText = "IT'S A MATCH!";
-                    }
+                // Dedup by event_id (if present — bootstrap/reset don't have one)
+                if (d.event_id) {
+                    if (seenEventIds.has(d.event_id)) return;
+                    seenEventIds.add(d.event_id);
+                }
 
-                    document.getElementById('match-solo-label').classList.add('hidden');
-                    showMatchMetadata(d.last_match);
-                    document.getElementById('match-overlay').classList.remove('hidden');
+                switch (d.event_type) {
+                    case 'session_bootstrap':
+                        // First attach — set initial state, no match popup
+                        currentGenre = d.genre || 'All';
+                        hideWatched = d.hide_watched || false;
+                        isSoloMode = d.solo || false;
+                        // Update genre pill UI
+                        document.getElementById('genre-pill').innerText =
+                            currentGenre === 'All' ? 'Genres ▾' : currentGenre + ' ▾';
+                        // Update hide_watched pill UI
+                        const pill = document.getElementById('hide-watched-pill');
+                        pill.innerText = hideWatched ? 'Hide Watched' : 'Show Watched';
+                        pill.classList.toggle('active', hideWatched);
+                        // Update solo badge UI
+                        document.getElementById('matches-pill').innerText = isSoloMode ? 'Shortlist' : 'Matches';
+                        document.getElementById('solo-badge').classList.toggle('hidden', !isSoloMode);
+                        // Don't trigger UI changes for bootstrap state —
+                        // the page already loaded via /me response
+                        break;
+
+                    case 'session_ready':
+                        currentGenre = d.genre || 'All';
+                        document.getElementById('genre-pill').innerText =
+                            currentGenre === 'All' ? 'Genres ▾' : currentGenre + ' ▾';
+                        if (document.getElementById('game-area').classList.contains('hidden')) {
+                            loadMovies(d.solo || false);
+                        }
+                        break;
+
+                    case 'match_found':
+                        document.getElementById('matched-movie-title').innerText = d.title;
+                        document.getElementById('match-popup-poster').src = d.thumb || '';
+                        const heading = document.getElementById('match-heading');
+                        heading.innerText = d.media_type === 'tv_show' ? "IT'S A TV MATCH!" : "IT'S A MATCH!";
+                        document.getElementById('match-solo-label').classList.add('hidden');
+                        showMatchMetadata(d);
+                        document.getElementById('match-overlay').classList.remove('hidden');
+                        break;
+
+                    case 'genre_changed':
+                        if (d.genre && d.genre !== currentGenre) {
+                            currentGenre = d.genre;
+                            document.getElementById('genre-pill').innerText =
+                                currentGenre === 'All' ? 'Genres ▾' : currentGenre + ' ▾';
+                            const movieRes = await apiFetch(`/room/${currentRoomCode}/deck`);
+                            movieStack = await movieRes.json();
+                            swipeHistory = [];
+                            renderInitialDeck();
+                        }
+                        break;
+
+                    case 'hide_watched_changed':
+                        if (d.hide_watched !== undefined && d.hide_watched !== hideWatched) {
+                            hideWatched = d.hide_watched;
+                            const pill = document.getElementById('hide-watched-pill');
+                            pill.innerText = hideWatched ? 'Hide Watched' : 'Show Watched';
+                            pill.classList.toggle('active', hideWatched);
+                            const movieRes = await apiFetch(`/room/${currentRoomCode}/deck`);
+                            movieStack = await movieRes.json();
+                            swipeHistory = [];
+                            renderInitialDeck();
+                        }
+                        break;
+
+                    case 'session_closed':
+                        sseSource.close();
+                        sseSource = null;
+                        lastSeenEventId = 0;
+                        seenEventIds.clear();
+                        currentRoomCode = null;
+                        document.getElementById('game-area').classList.add('hidden');
+                        document.getElementById('branding').classList.remove('hidden');
+                        document.getElementById('controls-area').classList.remove('hidden');
+                        document.getElementById('quit-pill').classList.add('hidden');
+                        document.getElementById('matches-pill').classList.add('hidden');
+                        document.getElementById('undo-btn').classList.add('hidden');
+                        break;
+
+                    case 'session_reset':
+                        // Cursor was rejected — reconnect fresh
+                        sseSource.close();
+                        sseSource = null;
+                        lastSeenEventId = 0;
+                        seenEventIds.clear();
+                        setTimeout(() => { if (currentRoomCode) startPolling(); }, 1000);
+                        break;
                 }
             };
+
             sseSource.onerror = () => {
                 sseSource.close();
                 sseSource = null;
+                // Reconnect with cursor if we have one
                 setTimeout(() => { if (currentRoomCode) startPolling(); }, 3000);
             };
         };

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,11 +39,12 @@ dev = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
-addopts = "-v --tb=short --cov=jellyswipe --cov-report=term-missing --timeout=30"
+addopts = "-v --tb=short --cov=jellyswipe -n auto --cov-report=term-missing --timeout=30"
 
 [dependency-groups]
 dev = [
     "httpx>=0.28.1",
     "pytest>=9.0.3",
     "pytest-cov>=7.1.0",
+    "pytest-xdist>=3.8.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dev = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
-addopts = "-v --tb=short --cov=jellyswipe --cov-report=term-missing"
+addopts = "-v --tb=short --cov=jellyswipe --cov-report=term-missing --timeout=30"
 
 [dependency-groups]
 dev = [

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -51,7 +51,6 @@ class TestAlembicBaseline:
                 "ready",
                 "current_genre",
                 "solo_mode",
-                "last_match_data",
                 "deck_position",
                 "deck_order",
                 "hide_watched",

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from jellyswipe.migrations import build_sqlite_url, upgrade_to_head
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-_EXPECTED_REVISION = "0003_add_hide_watched"
+_EXPECTED_REVISION = "0004_session_event_ledger"
 
 
 def _table_names(conn: sqlite3.Connection) -> set[str]:

--- a/tests/test_models_metadata.py
+++ b/tests/test_models_metadata.py
@@ -8,6 +8,8 @@ def test_target_metadata_contains_phase36_tables():
         "auth_sessions",
         "matches",
         "rooms",
+        "session_events",
+        "session_instances",
         "swipes",
     ]
 

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,0 +1,179 @@
+"""Unit tests for SessionNotifier."""
+
+import asyncio
+
+import pytest
+
+from jellyswipe.notifier import SessionNotifier
+
+
+@pytest.mark.anyio
+async def test_subscribe_and_notify_resolves_future():
+    """Test that subscribe + notify: subscriber's Future resolves."""
+    notifier = SessionNotifier()
+    future = notifier.subscribe("room123")
+
+    assert not future.done()
+
+    notifier.notify("room123")
+
+    assert future.done()
+    assert future.result() is None
+
+
+@pytest.mark.anyio
+async def test_multiple_subscribers_same_room_all_resolve():
+    """Test multiple subscribers on same room: all Futures resolve on single notify."""
+    notifier = SessionNotifier()
+    future1 = notifier.subscribe("room123")
+    future2 = notifier.subscribe("room123")
+    future3 = notifier.subscribe("room123")
+
+    assert not future1.done()
+    assert not future2.done()
+    assert not future3.done()
+
+    notifier.notify("room123")
+
+    assert future1.done()
+    assert future2.done()
+    assert future3.done()
+    assert future1.result() is None
+    assert future2.result() is None
+    assert future3.result() is None
+
+
+@pytest.mark.anyio
+async def test_subscribers_different_rooms_isolated():
+    """Test subscribers on different rooms: only the target room's Futures resolve."""
+    notifier = SessionNotifier()
+    future_room1 = notifier.subscribe("room1")
+    future_room2 = notifier.subscribe("room2")
+
+    notifier.notify("room1")
+
+    assert future_room1.done()
+    assert not future_room2.done()
+
+    notifier.notify("room2")
+    assert future_room2.done()
+
+
+@pytest.mark.anyio
+async def test_unsubscribe_removes_future_without_resolving():
+    """Test unsubscribe: removed Future does NOT resolve on subsequent notify."""
+    notifier = SessionNotifier()
+    future = notifier.subscribe("room123")
+
+    assert not future.done()
+
+    notifier.unsubscribe("room123", future)
+
+    assert future.cancelled()
+
+    notifier.notify("room123")
+    # Future should still be cancelled (not resolved with a result)
+    assert future.cancelled()
+
+
+@pytest.mark.anyio
+async def test_unsubscribe_cleanup_empty_dict_entry():
+    """Test unsubscribe cleanup: internal dict entry is cleaned up when last subscriber leaves."""
+    notifier = SessionNotifier()
+    future = notifier.subscribe("room123")
+
+    assert "room123" in notifier._subscribers
+
+    notifier.unsubscribe("room123", future)
+
+    assert "room123" not in notifier._subscribers
+
+
+@pytest.mark.anyio
+async def test_notify_with_no_subscribers_no_error():
+    """Test notify with no subscribers: no error raised."""
+    notifier = SessionNotifier()
+
+    # Should not raise
+    notifier.notify("nonexistent_room")
+
+
+@pytest.mark.anyio
+async def test_futures_cleared_after_notify():
+    """Test subscriber count after notify: Futures are cleared from the set after resolution."""
+    notifier = SessionNotifier()
+    notifier.subscribe("room123")
+    notifier.subscribe("room123")
+
+    assert "room123" in notifier._subscribers
+    assert len(notifier._subscribers["room123"]) == 2
+
+    notifier.notify("room123")
+
+    # After notify, the room should be removed from subscribers
+    assert "room123" not in notifier._subscribers
+
+
+@pytest.mark.anyio
+async def test_cancelled_future_handling():
+    """Test cancelled Future handling: if a Future is already cancelled, notify does not raise."""
+    notifier = SessionNotifier()
+    future = notifier.subscribe("room123")
+
+    # Cancel the future before notify
+    future.cancel()
+    assert future.cancelled()
+
+    # Should not raise
+    notifier.notify("room123")
+
+
+@pytest.mark.anyio
+async def test_unsubscribe_nonexistent_room_no_error():
+    """Test unsubscribe from nonexistent room does not raise."""
+    notifier = SessionNotifier()
+    future = asyncio.Future()
+
+    # Should not raise
+    notifier.unsubscribe("nonexistent_room", future)
+
+
+@pytest.mark.anyio
+async def test_multiple_notify_cycles():
+    """Test that subscribers must re-subscribe after each notify."""
+    notifier = SessionNotifier()
+
+    # First cycle
+    future1 = notifier.subscribe("room123")
+    notifier.notify("room123")
+    assert future1.done()
+
+    # Second cycle - must subscribe again
+    future2 = notifier.subscribe("room123")
+    assert not future2.done()
+
+    notifier.notify("room123")
+    assert future2.done()
+
+
+@pytest.mark.anyio
+async def test_unsubscribe_one_of_multiple_subscribers():
+    """Test unsubscribing one subscriber leaves others intact."""
+    notifier = SessionNotifier()
+    future1 = notifier.subscribe("room123")
+    future2 = notifier.subscribe("room123")
+    future3 = notifier.subscribe("room123")
+
+    notifier.unsubscribe("room123", future2)
+
+    assert "room123" in notifier._subscribers
+    assert len(notifier._subscribers["room123"]) == 2
+    assert future1 in notifier._subscribers["room123"]
+    assert future2 not in notifier._subscribers["room123"]
+    assert future3 in notifier._subscribers["room123"]
+
+    notifier.notify("room123")
+
+    assert future1.done()
+    assert future2.cancelled()  # Was cancelled
+    assert future3.done()

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -71,9 +71,6 @@ class TestRoomRepository:
                     ready=1,
                     solo_mode=1,
                     current_genre="Action",
-                    last_match_data=json.dumps(
-                        {"type": "match", "movie_id": "m1", "ts": 123.45},
-                    ),
                 )
             )
             await session.commit()
@@ -88,8 +85,6 @@ class TestRoomRepository:
         assert snapshot.ready is True
         assert snapshot.genre == "Action"
         assert snapshot.solo is True
-        assert snapshot.last_match is not None
-        assert snapshot.last_match["movie_id"] == "m1"
 
         assert record is not None
         assert isinstance(record, RoomRecord)

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -92,6 +92,11 @@ class TestRoomRepository:
         assert record.ready is True
         assert record.solo_mode is True
         assert record.current_genre == "Action"
+        assert isinstance(record, RoomRecord)
+        assert record.pairing_code == "4242"
+        assert record.ready is True
+        assert record.solo_mode is True
+        assert record.current_genre == "Action"
         assert record.movie_data_json == "[]"
         assert record.deck_position_json == deck
 

--- a/tests/test_room_lifecycle.py
+++ b/tests/test_room_lifecycle.py
@@ -7,7 +7,6 @@ import json
 import jellyswipe.db
 import jellyswipe.db_runtime
 import pytest
-from sqlalchemy import update
 from jellyswipe.db_runtime import (
     build_async_sqlite_url,
     dispose_runtime,
@@ -17,7 +16,6 @@ from jellyswipe.db_runtime import (
 from jellyswipe.db_uow import DatabaseUnitOfWork
 from jellyswipe.migrations import build_sqlite_url, upgrade_to_head
 from jellyswipe.models.match import Match
-from jellyswipe.models.room import Room
 from jellyswipe.room_types import MatchRecord
 from jellyswipe.services.room_lifecycle import RoomLifecycleService
 from tests.conftest import FakeProvider
@@ -284,7 +282,6 @@ async def test_fetch_status_returns_hide_watched_false_for_new_room(
         snap = await uow.rooms.fetch_status(pc)
         assert snap is not None
         assert snap.hide_watched is False
-
 
 
 @pytest.mark.anyio
@@ -554,3 +551,274 @@ async def test_solo_session_watched_filter(runtime_sessionmaker):
         assert snap_after.solo is True
         assert isinstance(new_deck, list)
         assert len(new_deck) > 0
+
+
+# ============================================================================
+# Session instance lifecycle and event emission tests (ORCH-003)
+# ============================================================================
+
+
+@pytest.mark.anyio
+async def test_create_room_creates_session_instance(runtime_sessionmaker):
+    """Test create_room creates a session_instances row with status='active' and returns instance_id."""
+    svc = RoomLifecycleService()
+    prov = FakeProvider()
+    uid = prov._user_id
+    sess: dict = {}
+
+    async with runtime_sessionmaker() as session:
+        uow = DatabaseUnitOfWork(session)
+        result = await svc.create_room(sess, uid, prov, uow)
+
+        assert "instance_id" in result
+        instance_id = result["instance_id"]
+
+        # Verify session_instances row was created
+        instance = await uow.session_instances.get_by_instance_id(instance_id)
+        assert instance is not None
+        assert instance.status == "active"
+        assert instance.pairing_code == result["pairing_code"]
+
+        await session.commit()
+
+
+@pytest.mark.anyio
+async def test_create_room_retries_if_pairing_code_reserved(runtime_sessionmaker):
+    """Test create_room retries code generation if pairing code is reserved by an active instance."""
+    svc = RoomLifecycleService()
+    prov = FakeProvider()
+    uid = prov._user_id
+
+    async with runtime_sessionmaker() as session:
+        uow = DatabaseUnitOfWork(session)
+
+        # Manually reserve a pairing code with an active session instance
+        await uow.session_instances.create(
+            instance_id="reserved-instance-id", pairing_code="1234"
+        )
+        await session.commit()
+
+        # Now create a room - it should not use "1234"
+        sess: dict = {}
+        result = await svc.create_room(sess, uid, prov, uow)
+
+        # Verify the room was created with a different code
+        assert result["pairing_code"] != "1234"
+        assert result["instance_id"] is not None
+
+        # Verify the reserved instance is still there
+        reserved = await uow.session_instances.get_by_pairing_code("1234")
+        assert reserved is not None
+        assert reserved.instance_id == "reserved-instance-id"
+
+        await session.commit()
+
+
+@pytest.mark.anyio
+async def test_join_room_appends_session_ready_event(runtime_sessionmaker):
+    """Test join_room appends a session_ready event to the ledger for the correct instance."""
+    svc = RoomLifecycleService()
+    prov = FakeProvider()
+    creator = "user-a"
+    joiner = "user-b"
+
+    async with runtime_sessionmaker() as session:
+        uow = DatabaseUnitOfWork(session)
+        pc = await force_create_room(svc, prov, creator, uow)
+
+        # Get the instance_id for this room
+        instance = await uow.session_instances.get_by_pairing_code(pc)
+        assert instance is not None
+        instance_id = instance.instance_id
+
+        # Join the room
+        sess_join: dict = {}
+        resp = await svc.join_room(pc, sess_join, joiner, uow)
+        await session.commit()
+
+        assert resp == {"status": "success"}
+
+        # Verify session_ready event was appended
+        events = await uow.session_events.read_after(instance_id, 0)
+        assert len(events) == 1
+        assert events[0].event_type == "session_ready"
+        assert events[0].payload_json == "{}"
+
+
+@pytest.mark.anyio
+async def test_set_genre_appends_genre_changed_event(runtime_sessionmaker):
+    """Test set_genre on success appends genre_changed event with correct genre payload."""
+    svc = RoomLifecycleService()
+    prov = FakeProvider()
+    uid = prov._user_id
+
+    async with runtime_sessionmaker() as session:
+        uow = DatabaseUnitOfWork(session)
+        pc = await force_create_room(svc, prov, uid, uow)
+
+        # Get the instance_id
+        instance = await uow.session_instances.get_by_pairing_code(pc)
+        assert instance is not None
+        instance_id = instance.instance_id
+
+        # Set genre
+        await svc.set_genre(pc, "Action", prov, uow)
+        await session.commit()
+
+        # Verify genre_changed event was appended
+        events = await uow.session_events.read_after(instance_id, 0)
+        assert len(events) == 1
+        assert events[0].event_type == "genre_changed"
+        payload = json.loads(events[0].payload_json)
+        assert payload == {"genre": "Action"}
+
+
+@pytest.mark.anyio
+async def test_set_genre_empty_deck_no_event(runtime_sessionmaker):
+    """Test set_genre on EmptyDeckError does NOT append any event."""
+    svc = RoomLifecycleService()
+    prov = FakeProvider()
+    uid = prov._user_id
+
+    async with runtime_sessionmaker() as session:
+        uow = DatabaseUnitOfWork(session)
+        pc = await force_create_room(svc, prov, uid, uow)
+
+        # Get the instance_id
+        instance = await uow.session_instances.get_by_pairing_code(pc)
+        assert instance is not None
+        instance_id = instance.instance_id
+
+        # Mock provider to return empty deck
+        original_fetch = prov.fetch_deck
+
+        def mock_fetch(media_types=None, genre_name=None, hide_watched=False):
+            return []
+
+        prov.fetch_deck = mock_fetch
+
+        # Attempt to change genre (should raise EmptyDeckError)
+        from jellyswipe.services.room_lifecycle import EmptyDeckError
+
+        with pytest.raises(EmptyDeckError):
+            await svc.set_genre(pc, "Action", prov, uow)
+
+        # Verify NO event was appended
+        events = await uow.session_events.read_after(instance_id, 0)
+        assert len(events) == 0
+
+        prov.fetch_deck = original_fetch
+        await session.commit()
+
+
+@pytest.mark.anyio
+async def test_set_watched_filter_appends_event(runtime_sessionmaker):
+    """Test set_watched_filter on success appends hide_watched_changed event."""
+    svc = RoomLifecycleService()
+    prov = FakeProvider()
+    uid = prov._user_id
+
+    async with runtime_sessionmaker() as session:
+        uow = DatabaseUnitOfWork(session)
+        pc = await force_create_room(svc, prov, uid, uow)
+
+        # Get the instance_id
+        instance = await uow.session_instances.get_by_pairing_code(pc)
+        assert instance is not None
+        instance_id = instance.instance_id
+
+        # Set watched filter
+        await svc.set_watched_filter(pc, True, prov, uow)
+        await session.commit()
+
+        # Verify hide_watched_changed event was appended
+        events = await uow.session_events.read_after(instance_id, 0)
+        assert len(events) == 1
+        assert events[0].event_type == "hide_watched_changed"
+        payload = json.loads(events[0].payload_json)
+        assert payload == {"hide_watched": True}
+
+
+@pytest.mark.anyio
+async def test_quit_room_appends_session_closed_and_marks_closing(runtime_sessionmaker):
+    """Test quit_room appends session_closed event, marks instance 'closing' with closed_at."""
+    svc = RoomLifecycleService()
+    prov = FakeProvider()
+    uid = prov._user_id
+
+    async with runtime_sessionmaker() as session:
+        uow = DatabaseUnitOfWork(session)
+        pc = await force_create_room(svc, prov, uid, uow)
+
+        # Get the instance_id
+        instance = await uow.session_instances.get_by_pairing_code(pc)
+        assert instance is not None
+        instance_id = instance.instance_id
+
+        # Quit the room
+        sess: dict = {"active_room": pc, "solo_mode": False}
+        out = await svc.quit_room(pc, sess, uid, uow)
+        await session.commit()
+
+        assert out == {"status": "session_ended"}
+
+        # Verify session_closed event was appended
+        events = await uow.session_events.read_after(instance_id, 0)
+        assert len(events) == 1
+        assert events[0].event_type == "session_closed"
+
+        # Verify instance is marked as 'closing' with closed_at
+        instance_after = await uow.session_instances.get_by_instance_id(instance_id)
+        assert instance_after is not None
+        assert instance_after.status == "closing"
+        assert instance_after.closed_at is not None
+
+
+@pytest.mark.anyio
+async def test_quit_room_schedules_background_cleanup(runtime_sessionmaker):
+    """Test quit_room schedules background cleanup task."""
+    import asyncio
+
+    svc = RoomLifecycleService()
+    prov = FakeProvider()
+    uid = prov._user_id
+
+    async with runtime_sessionmaker() as session:
+        uow = DatabaseUnitOfWork(session)
+        pc = await force_create_room(svc, prov, uid, uow)
+
+        # Count tasks before quit
+        tasks_before = len(asyncio.all_tasks())
+
+        # Quit the room
+        sess: dict = {"active_room": pc, "solo_mode": False}
+        await svc.quit_room(pc, sess, uid, uow)
+        await session.commit()
+
+        # Count tasks after quit - should have one more (the cleanup task)
+        tasks_after = len(asyncio.all_tasks())
+        assert tasks_after > tasks_before, "Background cleanup task should be scheduled"
+
+
+@pytest.mark.anyio
+async def test_get_status_no_last_match_field(runtime_sessionmaker):
+    """Test get_status returns no last_match field."""
+    svc = RoomLifecycleService()
+    prov = FakeProvider()
+    uid = prov._user_id
+
+    async with runtime_sessionmaker() as session:
+        uow = DatabaseUnitOfWork(session)
+        pc = await force_create_room(svc, prov, uid, uow)
+        await session.commit()
+
+    async with runtime_sessionmaker() as session:
+        uow = DatabaseUnitOfWork(session)
+        status = await svc.get_status(pc, uow)
+        await session.commit()
+
+    assert "last_match" not in status
+    assert "ready" in status
+    assert "genre" in status
+    assert "solo" in status
+    assert "hide_watched" in status

--- a/tests/test_room_lifecycle.py
+++ b/tests/test_room_lifecycle.py
@@ -243,13 +243,6 @@ async def test_deck_genre_status_matches_semantics(runtime_sessionmaker):
 
         assert await svc.get_deck("9999", uid, 1, uow) == []
 
-        lm = {"type": "match", "ts": 999.9}
-        await session.execute(
-            update(Room)
-            .where(Room.pairing_code == pc)
-            .values(last_match_data=json.dumps(lm))
-        )
-
         genre_deck = await svc.set_genre(pc, "Action", prov, uow)
         assert isinstance(genre_deck, list) and genre_deck
         rec_after = await uow.rooms.get_room(pc)
@@ -260,7 +253,6 @@ async def test_deck_genre_status_matches_semantics(runtime_sessionmaker):
         assert status["ready"] is False
         assert status["genre"] == "Action"
         assert status["solo"] is False
-        assert status["last_match"]["ts"] == 999.9
 
         assert isinstance(await svc.get_matches(pc, uid, None, uow), list)
         assert isinstance(await svc.get_matches(pc, uid, "history", uow), list)
@@ -293,25 +285,6 @@ async def test_fetch_status_returns_hide_watched_false_for_new_room(
         assert snap is not None
         assert snap.hide_watched is False
 
-
-@pytest.mark.anyio
-async def test_fetch_stream_snapshot_returns_hide_watched_false_for_new_room(
-    runtime_sessionmaker,
-):
-    svc = RoomLifecycleService()
-    prov = FakeProvider()
-    uid = prov._user_id
-
-    async with runtime_sessionmaker() as session:
-        uow = DatabaseUnitOfWork(session)
-        pc = await force_create_room(svc, prov, uid, uow)
-        await session.commit()
-
-    async with runtime_sessionmaker() as session:
-        uow = DatabaseUnitOfWork(session)
-        snap = await uow.rooms.fetch_stream_snapshot(pc)
-        assert snap is not None
-        assert snap.hide_watched is False
 
 
 @pytest.mark.anyio

--- a/tests/test_route_authorization.py
+++ b/tests/test_route_authorization.py
@@ -683,38 +683,6 @@ class TestSSEMatchDelivery:
         assert "year" in m
         assert m["year"] == "2024"
 
-    def test_last_match_data_includes_enriched_payload(
-        self, db_connection, client_real_auth
-    ):
-        """After a match, rooms.last_match_data contains full enriched JSON."""
-        _set_session(
-            client_real_auth,
-            db_connection,
-            os.environ["FLASK_SECRET"],
-            active_room="ROOM1",
-            authenticated=True,
-        )
-        _seed_room_with_movies(db_connection, solo_mode=1)
-
-        client_real_auth.post(
-            "/room/ROOM1/swipe", json={"media_id": "movie-1", "direction": "right"}
-        )
-
-        row = db_connection.execute(
-            "SELECT last_match_data FROM rooms WHERE pairing_code = ?",
-            ("ROOM1",),
-        ).fetchone()
-        assert row["last_match_data"] is not None
-        data = json.loads(row["last_match_data"])
-        assert data["type"] == "match"
-        assert data["title"] == "Movie-movie-1"
-        assert data["media_id"] == "movie-1"
-        assert data["rating"] == "8.5"
-        assert data["duration"] == "2h 15m"
-        assert data["year"] == "2024"
-        assert "/web/#/details?id=movie-1" in data["deep_link"]
-        assert "ts" in data
-
     def test_concurrent_right_swipes_one_match_per_user(
         self, db_connection, client_real_auth
     ):
@@ -1163,22 +1131,11 @@ class TestPhase27Compliance:
             "/room/ROOM1/swipe", json={"media_id": "movie-1", "direction": "right"}
         )
 
-        # Check room status for enriched match data
+        # Check room status is successful (last_match removed from status response)
         resp = client_real_auth.get("/room/ROOM1/status")
         assert resp.status_code == 200
         status = resp.json()
-        assert status["last_match"] is not None
-        match = status["last_match"]
-        assert match["type"] == "match"
-        assert "title" in match
-        assert "thumb" in match
-        assert "media_id" in match
-        assert "deep_link" in match
-        assert "/web/#/details?id=movie-1" in match["deep_link"]
-        assert match["rating"] == "8.5"
-        assert match["duration"] == "2h 15m"
-        assert match["year"] == "2024"
-        assert "ts" in match
+        assert status["ready"] is True
 
     def test_solo_endpoint_not_go_solo(self, db_connection, client_real_auth):
         """POST /room/solo returns 404 (deprecated)."""

--- a/tests/test_routes_room.py
+++ b/tests/test_routes_room.py
@@ -51,7 +51,7 @@ def _set_session(
 
 
 def _seed_room(
-    room_code="TEST1", *, ready=0, solo_mode=0, movie_data=None, last_match_data=None
+    room_code="TEST1", *, ready=0, solo_mode=0, movie_data=None
 ):
     """Seed a room row directly into the database for testing."""
     if movie_data is None:
@@ -59,9 +59,9 @@ def _seed_room(
     conn = _sqlite_conn_for_route_tests()
     try:
         conn.execute(
-            "INSERT INTO rooms (pairing_code, movie_data, ready, current_genre, solo_mode, last_match_data) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            (room_code, movie_data, ready, "All", solo_mode, last_match_data),
+            "INSERT INTO rooms (pairing_code, movie_data, ready, current_genre, solo_mode) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (room_code, movie_data, ready, "All", solo_mode),
         )
         conn.commit()
     finally:
@@ -398,23 +398,6 @@ def test_room_status_active_room(client):
     assert data["ready"] is True
     assert data["genre"] == "All"
     assert data["solo"] is False
-    assert data["last_match"] is None
-
-
-def test_room_status_with_last_match(client):
-    """GET /room/<code>/status returns last_match data when room has a recent match."""
-    match_data = json.dumps(
-        {"title": "Test Movie", "thumb": "test.jpg", "ts": 1234567890}
-    )
-    _seed_room("TEST1", ready=1, solo_mode=0, last_match_data=match_data)
-
-    response = client.get("/room/TEST1/status")
-    assert response.status_code == 200
-    data = response.json()
-    assert data["last_match"] is not None
-    assert data["last_match"]["title"] == "Test Movie"
-    assert data["last_match"]["thumb"] == "test.jpg"
-    assert data["last_match"]["ts"] == 1234567890
 
 
 def test_room_status_nonexistent_room(client):
@@ -567,49 +550,6 @@ def test_swipe_right_no_match_yet(client, app):
     assert response.status_code == 200
     assert response.json() == {"accepted": True}
 
-
-def test_swipe_right_updates_last_match_data(client, app):
-    """POST /room/<code>/swipe dual match updates last_match_data in rooms table."""
-    _seed_room("TEST1", ready=1, solo_mode=0)
-    _set_session(
-        client,
-        os.environ["FLASK_SECRET"],
-        active_room="TEST1",
-        user_id="verified-user",
-        authenticated=True,
-    )
-
-    conn = _sqlite_conn_for_route_tests()
-    try:
-        conn.execute(
-            "INSERT INTO auth_sessions (session_id, jellyfin_token, jellyfin_user_id, created_at) VALUES (?, ?, ?, ?)",
-            ("other-session-id", "valid-token", "user-2", "2026-05-05T00:00:00+00:00"),
-        )
-        conn.execute(
-            "INSERT INTO swipes (room_code, movie_id, user_id, direction, session_id) VALUES (?, ?, ?, ?, ?)",
-            ("TEST1", "m1", "user-2", "right", "other-session-id"),
-        )
-        conn.commit()
-    finally:
-        conn.close()
-
-    client.post(
-        "/room/TEST1/swipe",
-        json={"media_id": "m1", "direction": "right"},
-    )
-
-    conn = _sqlite_conn_for_route_tests()
-    try:
-        row = conn.execute(
-            "SELECT last_match_data FROM rooms WHERE pairing_code = 'TEST1'"
-        ).fetchone()
-    finally:
-        conn.close()
-
-    assert row["last_match_data"] is not None
-    match_data = json.loads(row["last_match_data"])
-    assert match_data["type"] == "match"
-    assert "ts" in match_data
 
 
 def test_set_genre_empty_deck_returns_400(client, app, mocker):

--- a/tests/test_routes_room.py
+++ b/tests/test_routes_room.py
@@ -50,9 +50,7 @@ def _set_session(
         set_session_cookie(client, data, secret_key)
 
 
-def _seed_room(
-    room_code="TEST1", *, ready=0, solo_mode=0, movie_data=None
-):
+def _seed_room(room_code="TEST1", *, ready=0, solo_mode=0, movie_data=None):
     """Seed a room row directly into the database for testing."""
     if movie_data is None:
         movie_data = json.dumps([])
@@ -551,7 +549,6 @@ def test_swipe_right_no_match_yet(client, app):
     assert response.json() == {"accepted": True}
 
 
-
 def test_set_genre_empty_deck_returns_400(client, app, mocker):
     """POST /room/{code}/genre returns 400 when genre filter results in empty deck."""
     from tests.conftest import FakeProvider
@@ -749,3 +746,95 @@ def test_set_watched_filter_requires_auth(client_real_auth, app_real_auth):
         "/room/TEST1/watched-filter", json={"hide_watched": True}
     )
     assert response.status_code in (401, 403)
+
+
+# ---------------------------------------------------------------------------
+# Section: Notifier integration tests (ORCH-003)
+# ---------------------------------------------------------------------------
+
+
+def test_join_room_notifies_after_commit(client, app):
+    """POST /room/{code}/join calls notifier.notify(code) after commit."""
+    from unittest.mock import patch
+    from jellyswipe.notifier import notifier
+
+    # Create a room first
+    _set_session(client, os.environ["FLASK_SECRET"], authenticated=True)
+    create_resp = client.post("/room")
+    assert create_resp.status_code == 200
+    code = create_resp.json()["pairing_code"]
+
+    # Join with a different session
+    from tests.conftest import set_session_cookie
+
+    join_client_session = {"solo_mode": False}
+    set_session_cookie(client, join_client_session, os.environ["FLASK_SECRET"])
+
+    with patch.object(notifier, "notify") as mock_notify:
+        response = client.post(f"/room/{code}/join")
+        assert response.status_code == 200
+        mock_notify.assert_called_once_with(code)
+
+
+def test_quit_room_notifies_after_commit(client, app):
+    """POST /room/{code}/quit calls notifier.notify(code) after commit."""
+    from unittest.mock import patch
+    from jellyswipe.notifier import notifier
+
+    # Create a room
+    _set_session(client, os.environ["FLASK_SECRET"], authenticated=True)
+    create_resp = client.post("/room")
+    assert create_resp.status_code == 200
+    code = create_resp.json()["pairing_code"]
+
+    with patch.object(notifier, "notify") as mock_notify:
+        response = client.post(f"/room/{code}/quit")
+        assert response.status_code == 200
+        mock_notify.assert_called_once_with(code)
+
+
+def test_set_genre_notifies_after_commit(client, app):
+    """POST /room/{code}/genre calls notifier.notify(code) after commit."""
+    from unittest.mock import patch
+    from jellyswipe.notifier import notifier
+
+    # Create a room
+    _set_session(client, os.environ["FLASK_SECRET"], authenticated=True)
+    create_resp = client.post("/room")
+    assert create_resp.status_code == 200
+    code = create_resp.json()["pairing_code"]
+
+    with patch.object(notifier, "notify") as mock_notify:
+        response = client.post(f"/room/{code}/genre", json={"genre": "Action"})
+        assert response.status_code == 200
+        mock_notify.assert_called_once_with(code)
+
+
+def test_set_watched_filter_notifies_after_commit(client, app):
+    """POST /room/{code}/watched-filter calls notifier.notify(code) after commit."""
+    from unittest.mock import patch
+    from jellyswipe.notifier import notifier
+
+    # Create a room
+    _set_session(client, os.environ["FLASK_SECRET"], authenticated=True)
+    create_resp = client.post("/room")
+    assert create_resp.status_code == 200
+    code = create_resp.json()["pairing_code"]
+
+    with patch.object(notifier, "notify") as mock_notify:
+        response = client.post(
+            f"/room/{code}/watched-filter", json={"hide_watched": True}
+        )
+        assert response.status_code == 200
+        mock_notify.assert_called_once_with(code)
+
+
+def test_create_room_returns_instance_id(client, app):
+    """POST /room returns instance_id in response."""
+    _set_session(client, os.environ["FLASK_SECRET"], authenticated=True)
+    response = client.post("/room")
+    assert response.status_code == 200
+    data = response.json()
+    assert "instance_id" in data
+    assert data["instance_id"] is not None
+    assert len(data["instance_id"]) > 0  # UUID hex string

--- a/tests/test_routes_sse.py
+++ b/tests/test_routes_sse.py
@@ -1,33 +1,30 @@
-"""Comprehensive SSE streaming tests for the /room/stream endpoint.
+"""SSE streaming tests for the event-driven /room/{code}/stream endpoint.
 
-Tests cover SSE response format, state change events (ready, genre, solo, match),
-room closure on missing room, stable state deduplication, and GeneratorExit handling.
-Satisfies TEST-ROUTE-05.
+Tests cover:
+- First attach (no cursor): session_bootstrap event
+- Reconnect with valid cursor: missed events replayed
+- Reconnect with stale cursor: session_reset sent
+- Reconnect with wrong instance cursor: session_reset sent
+- Session closed event: stream closes after session_closed
+- SSE id field on every event
+- Heartbeat ping after idle
+- Disconnect detection
+- CancelledError propagation
+- Response headers
+- GET /matches works independently
 """
 
 import asyncio
 import json
 import os
 import secrets
-import threading
 import time
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
 
-import sqlite3
 
-from sse_starlette.sse import EventSourceResponse
-
-import pytest
-from jellyswipe.db_paths import application_db_path
+from jellyswipe.notifier import notifier
 from tests.conftest import set_session_cookie
-
-
-def _sqlite_conn_for_sse_tests():
-    path = application_db_path.path
-    assert path is not None
-    conn = sqlite3.connect(path, check_same_thread=False)
-    conn.row_factory = sqlite3.Row
-    conn.execute("PRAGMA foreign_keys=ON")
-    return conn
 
 
 # ---------------------------------------------------------------------------
@@ -36,11 +33,7 @@ def _sqlite_conn_for_sse_tests():
 
 
 def _set_session_room(client, secret_key, room_code, user_id=None):
-    """Inject session state for SSE stream tests.
-
-    Auth is handled by app.dependency_overrides[require_auth] in the app fixture.
-    Session cookie carries active_room + my_user_id for SSE route to read.
-    """
+    """Inject session state for SSE stream tests."""
     if user_id is None:
         user_id = f"test-user-{secrets.token_hex(4)}"
     set_session_cookie(
@@ -53,106 +46,87 @@ def _set_session_room(client, secret_key, room_code, user_id=None):
         },
         secret_key,
     )
-    # AUTH: handled by dependency_overrides[require_auth] — no vault INSERT needed
 
 
-def _seed_stream_room(
-    room_code, *, ready=0, solo_mode=0, current_genre="All"
+def _seed_room_and_instance(
+    conn,
+    room_code,
+    *,
+    ready=0,
+    solo_mode=0,
+    current_genre="All",
+    instance_id=None,
+    hide_watched=0,
+    include_movies=1,
+    include_tv_shows=0,
 ):
-    """Seed a room row directly into SQLite for SSE tests (VAL-03: no jellyswipe.db.get_db)."""
+    """Seed a room row and session instance for SSE tests."""
+    if instance_id is None:
+        instance_id = f"inst-{secrets.token_hex(8)}"
     movie_data = json.dumps([])
-    conn = _sqlite_conn_for_sse_tests()
-    try:
-        conn.execute(
-            "INSERT INTO rooms (pairing_code, movie_data, ready, current_genre, solo_mode) "
-            "VALUES (?, ?, ?, ?, ?)",
-            (room_code, movie_data, ready, current_genre, solo_mode),
-        )
-        conn.commit()
-    finally:
-        conn.close()
+    conn.execute(
+        "INSERT INTO rooms (pairing_code, movie_data, ready, current_genre, solo_mode, "
+        "hide_watched, include_movies, include_tv_shows, deck_position) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            room_code,
+            movie_data,
+            ready,
+            current_genre,
+            solo_mode,
+            hide_watched,
+            include_movies,
+            include_tv_shows,
+            "{}",
+        ),
+    )
+    now = datetime.now(timezone.utc).isoformat()
+    conn.execute(
+        "INSERT INTO session_instances (instance_id, pairing_code, status, created_at) "
+        "VALUES (?, ?, ?, ?)",
+        (instance_id, room_code, "active", now),
+    )
+    conn.commit()
+    return instance_id
 
 
-# Pre-generator time.time() call overhead in FastAPI TestClient context.
-# During client.get(), the following call time.time() BEFORE the SSE generator runs:
-# ~2 from httpx/starlette request timing, ~2 from cookie jar, ~1 from RequestIdMiddleware.
-# All _make_time_mock thresholds must be >= this overhead + pre-loop setup (2 calls)
-# to ensure deadline = real_start + 3600 (not real_start + 7300 which never expires).
-_PRE_GENERATOR_OVERHEAD = 6
+def _seed_event(conn, instance_id, event_type, payload_json):
+    """Seed a session event directly."""
+    now = datetime.now(timezone.utc).isoformat()
+    cursor = conn.execute(
+        "INSERT INTO session_events (session_instance_id, event_type, payload_json, created_at) "
+        "VALUES (?, ?, ?, ?)",
+        (instance_id, event_type, payload_json, now),
+    )
+    conn.commit()
+    return cursor.lastrowid
 
 
-def _make_time_mock(iterations_before_timeout):
-    """Create a time.time mock that advances past deadline after N calls.
+def _sqlite_conn(app):
+    """Get a direct sqlite3 connection to the app's database."""
+    import sqlite3
+    from jellyswipe.db_paths import application_db_path
 
-    Returns a closure that returns real time for the first
-    (iterations_before_timeout + _PRE_GENERATOR_OVERHEAD) calls, then returns
-    real_time + 3700 (past the 3600s deadline) to exit the SSE polling loop.
-
-    The overhead accounts for time.time() calls from httpx timing, cookies, and
-    middleware that fire BEFORE the generator's deadline calculation.
-    """
-    # Add overhead so the deadline calculation runs BEFORE the mock triggers
-    total_calls = iterations_before_timeout + _PRE_GENERATOR_OVERHEAD
-    call_count = 0
-    real_start = time.time()
-
-    def _mock_time():
-        nonlocal call_count
-        call_count += 1
-        if call_count > total_calls:
-            return real_start + 3700
-        return real_start
-
-    return _mock_time
+    path = application_db_path.path
+    assert path is not None
+    conn = sqlite3.connect(path, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys=ON")
+    return conn
 
 
-def _make_sse_sleep_mock(on_sleep_callback=None):
-    """Create a selective asyncio.sleep mock for SSE generator testing.
+def _setup_disconnect_after(client, monkeypatch, after_calls=2):
+    """Mock is_disconnected to return True after N calls, so the stream loop exits."""
+    from starlette.requests import Request as StarletteRequest
 
-    The SSE generator calls asyncio.sleep(delay) where delay is in [1.5, 2.0]
-    (POLL=1.5 + random jitter 0–0.5). Internal anyio/starlette checkpoints use 0 or 0.5.
+    call_count = [0]
 
-    Strategy: intercept the generator's sleep range [1.4, 2.1], yielding control
-    instantly (via asyncio.sleep(0)). Starlette internal checkpoints (< 1.4s) pass through.
+    async def fake_is_disconnected(self):
+        call_count[0] += 1
+        return call_count[0] >= after_calls
 
-    The _ping task's anyio.sleep(15s) is handled separately by patching
-    EventSourceResponse._ping to a no-op — see _noop_ping below.
-
-    Args:
-        on_sleep_callback: Optional sync callable(delay) called when generator sleep is
-                           intercepted. Sync only (called before yielding to event loop).
-    """
-    original_sleep = asyncio.sleep
-
-    sleep_calls = []
-
-    async def _selective_sleep(delay):
-        if 1.4 <= delay <= 2.1:
-            # Generator poll sleep in expected range — record and yield briefly
-            sleep_calls.append(delay)
-            if on_sleep_callback is not None:
-                on_sleep_callback(delay)
-            # Yield control without blocking, allowing task group to process cancellation
-            await original_sleep(0)
-        else:
-            # anyio checkpoints (0, 0.5) and others — keep real behavior
-            await original_sleep(delay)
-
-    return _selective_sleep, sleep_calls
-
-
-async def _noop_ping(self, send):
-    """Replacement _ping for tests — polls self.active without sending ping comments.
-
-    EventSourceResponse._ping calls anyio.sleep(15s) inside a while-loop. That sleep
-    is not interrupted when the cancel scope fires, causing a 15s teardown hang.
-
-    This replacement polls self.active every 10ms using asyncio.sleep (which IS
-    interrupted by the task group's cancel scope), so teardown is instantaneous.
-    No ping comments are emitted, so heartbeat-count assertions stay clean.
-    """
-    while self.active:
-        await asyncio.sleep(0.01)
+    monkeypatch.setattr(StarletteRequest, "is_disconnected", fake_is_disconnected)
+    return call_count
 
 
 # ---------------------------------------------------------------------------
@@ -160,617 +134,443 @@ async def _noop_ping(self, send):
 # ---------------------------------------------------------------------------
 
 
-def test_stream_no_active_room(client):
-    """GET /room/<code>/stream for nonexistent room returns closed event."""
-    response = client.get("/room/TEST1/stream")
-
-    assert response.status_code == 200
-    assert response.headers.get("content-type", "").startswith("text/event-stream")
-    assert '"closed": true' in response.text
-
-
 def test_stream_response_headers(client, monkeypatch):
     """GET /room/stream returns correct SSE content-type and cache headers."""
-    _seed_stream_room("TEST1")
-    _set_session_room(client, os.environ["FLASK_SECRET"], "TEST1")
+    conn = _sqlite_conn(client)
+    try:
+        _seed_room_and_instance(conn, "HDR1")
+    finally:
+        conn.close()
+    _set_session_room(client, os.environ["FLASK_SECRET"], "HDR1")
+    _setup_disconnect_after(client, monkeypatch, after_calls=2)
 
-    # Force gevent sleep fallback path (gevent is available in test env)
-    import jellyswipe
+    # Mock notifier to resolve immediately
+    monkeypatch.setattr(notifier, "subscribe", lambda code: _resolved_future())
+    monkeypatch.setattr(time, "time", lambda: 1000000.0)
 
-    monkeypatch.setattr(jellyswipe, "_gevent_sleep", None, raising=False)
+    response = client.get("/room/HDR1/stream")
 
-    # Selective asyncio.sleep mock: skips SSE generator polls (>= 1.5s),
-    # passes through internal anyio/sse_starlette sleeps (< 1.5s).
-    mock_sleep, _ = _make_sse_sleep_mock()
-    monkeypatch.setattr(asyncio, "sleep", mock_sleep)
-    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
-
-    # Mock time to exit the generator loop after a few iterations
-    monkeypatch.setattr(time, "sleep", lambda _: None)
-    monkeypatch.setattr(time, "time", _make_time_mock(5))
-
-    response = client.get("/room/TEST1/stream")
-    # Consume data while monkeypatch is active (generator runs lazily)
-    _ = response.content
-
+    assert response.status_code == 200
     assert response.headers.get("content-type", "").startswith("text/event-stream")
     assert response.headers["Cache-Control"] == "no-cache"
     assert response.headers["X-Accel-Buffering"] == "no"
 
 
-# ---------------------------------------------------------------------------
-# Section 2: Room state and closure tests
-# ---------------------------------------------------------------------------
-
-
-def test_stream_room_not_found(client, monkeypatch):
-    """Stream for nonexistent room sends closed event and stops."""
-    _set_session_room(client, os.environ["FLASK_SECRET"], "FAKE")
-
-    monkeypatch.setattr(time, "sleep", lambda _: None)
-    monkeypatch.setattr(time, "time", _make_time_mock(3))
-
-    response = client.get("/room/TEST1/stream")
-    data = response.text
-
-    assert 'data: {"closed": true}' in data
-
-    events = [e for e in data.split("\n\n") if e.strip()]
-    assert len(events) == 1
-
-
-def test_stream_initial_state_events(client, monkeypatch):
-    """Stream sends initial ready, solo, and genre events on first poll."""
-    _seed_stream_room("TEST1", ready=0, current_genre="All", solo_mode=0)
-    _set_session_room(client, os.environ["FLASK_SECRET"], "TEST1")
-
-    # Force gevent sleep fallback path (gevent is available in test env)
-    import jellyswipe
-
-    monkeypatch.setattr(jellyswipe, "_gevent_sleep", None, raising=False)
-
-    mock_sleep, _ = _make_sse_sleep_mock()
-    monkeypatch.setattr(asyncio, "sleep", mock_sleep)
-    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
-
-    # deadline calc + init + loop iterations then exit
-    monkeypatch.setattr(time, "sleep", lambda _: None)
-    monkeypatch.setattr(time, "time", _make_time_mock(8))
-
-    response = client.get("/room/TEST1/stream")
-    data = response.text
-
-    # Initial event: ready=False (0 -> bool -> False != None -> sends), solo=False, genre="All"
-    assert '"ready": false' in data
-    assert '"solo": false' in data
-    assert '"genre": "All"' in data
-
-
-def test_stream_stable_state_no_repeat(client, monkeypatch):
-    """Stream does not repeat events when state hasn't changed between polls."""
-    _seed_stream_room("TEST1", ready=0, current_genre="All")
-    _set_session_room(client, os.environ["FLASK_SECRET"], "TEST1")
-
-    # Force gevent sleep fallback path (gevent is available in test env)
-    import jellyswipe
-
-    monkeypatch.setattr(jellyswipe, "_gevent_sleep", None, raising=False)
-
-    mock_sleep, _ = _make_sse_sleep_mock()
-    monkeypatch.setattr(asyncio, "sleep", mock_sleep)
-    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
-
-    # deadline calc + init + loop iterations then exit
-    monkeypatch.setattr(time, "sleep", lambda _: None)
-    monkeypatch.setattr(time, "time", _make_time_mock(10))
-
-    response = client.get("/room/TEST1/stream")
-    data = response.text
-
-    # Parse SSE events
-    events = [e.strip() for e in data.split("\n\n") if e.strip()]
-
-    # On first poll: ready=false and genre="All" sent (both differ from None)
-    # On second poll: state unchanged, nothing sent
-    ready_count = sum(1 for e in events if '"ready"' in e)
-    genre_count = sum(1 for e in events if '"genre"' in e)
-
-    assert ready_count == 1, (
-        f"Expected exactly 1 ready event, got {ready_count}: {events}"
-    )
-    assert genre_count == 1, (
-        f"Expected exactly 1 genre event, got {genre_count}: {events}"
-    )
+def _resolved_future():
+    """Return an already-resolved Future for mocking notifier.subscribe."""
+    f = asyncio.Future()
+    f.set_result(None)
+    return f
 
 
 # ---------------------------------------------------------------------------
-# Section 3: State change detection tests
+# Section 2: First attach (no cursor) — session_bootstrap
 # ---------------------------------------------------------------------------
 
 
-
-def test_stream_ready_state_change(client, monkeypatch):
-    """Stream detects ready-state change between polling iterations."""
-    _seed_stream_room("TEST1", ready=0)
-    _set_session_room(client, os.environ["FLASK_SECRET"], "TEST1")
-
-    # Force gevent sleep fallback path (gevent is available in test env)
-    import jellyswipe
-
-    monkeypatch.setattr(jellyswipe, "_gevent_sleep", None, raising=False)
-
-    # Use a sleep callback that updates DB on first generator poll sleep.
-    # The SSE generator uses asyncio.sleep() — _make_sse_sleep_mock intercepts
-    # those calls and invokes on_sleep_callback.
-    sleep_call_count = 0
-
-    def _on_sleep(delay):
-        nonlocal sleep_call_count
-        sleep_call_count += 1
-        if sleep_call_count == 1:
-            # After first poll (ready=0 sent), flip ready to 1
-            conn = _sqlite_conn_for_sse_tests()
-            try:
-                conn.execute(
-                    "UPDATE rooms SET ready = 1 WHERE pairing_code = ?",
-                    ("TEST1",),
-                )
-                conn.commit()
-            finally:
-                conn.close()
-
-    mock_sleep, _ = _make_sse_sleep_mock(on_sleep_callback=_on_sleep)
-    monkeypatch.setattr(asyncio, "sleep", mock_sleep)
-    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
-    # deadline + loop iterations (with state changes) then exit
-    monkeypatch.setattr(time, "sleep", lambda _: None)
-    monkeypatch.setattr(time, "time", _make_time_mock(12))
-
-    response = client.get("/room/TEST1/stream")
-    data = response.text
-
-    # Should have both initial ready=false and subsequent ready=true
-    assert '"ready": false' in data, f"Missing initial ready=false in: {data}"
-    assert '"ready": true' in data, f"Missing updated ready=true in: {data}"
-
-
-# ---------------------------------------------------------------------------
-# Section 4: GeneratorExit handling test
-# ---------------------------------------------------------------------------
-
-
-def test_stream_generator_exit(client, monkeypatch):
-    """GeneratorExit is handled gracefully — no exception propagated on client disconnect."""
-    _seed_stream_room("TEST1")
-    _set_session_room(client, os.environ["FLASK_SECRET"], "TEST1")
-
-    # Force gevent sleep fallback path (gevent is available in test env)
-    import jellyswipe
-
-    monkeypatch.setattr(jellyswipe, "_gevent_sleep", None, raising=False)
-
-    mock_sleep, _ = _make_sse_sleep_mock()
-    monkeypatch.setattr(asyncio, "sleep", mock_sleep)
-    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
-
-    result = {}
-    error_holder = {}
-
-    def consume():
-        try:
-            resp = client.get("/room/TEST1/stream")
-            # Consume data while monkeypatch is active
-            result["data"] = resp.text
-            result["status"] = resp.status_code
-            result["content_type"] = resp.headers.get("content-type", "")
-        except Exception as exc:
-            error_holder["error"] = exc
-
-    # Mock time globally for the thread
-    monkeypatch.setattr(time, "sleep", lambda _: None)
-    monkeypatch.setattr(time, "time", _make_time_mock(10))
-
-    t = threading.Thread(target=consume)
-    t.start()
-    t.join(timeout=10)
-
-    # Thread completed without hanging
-    assert not t.is_alive(), "Thread should have completed"
-    # No exception raised
-    assert "error" not in error_holder, f"Unexpected error: {error_holder['error']}"
-    # Response was received successfully
-    assert result.get("status") == 200
-    assert "text/event-stream" in result.get("content_type", "")
-
-
-# ---------------------------------------------------------------------------
-# Section 5: SSE reliability tests (jitter, heartbeat, gevent sleep)
-# ---------------------------------------------------------------------------
-
-
-def test_stream_jitter_applied(client, monkeypatch):
-    """Poll interval includes random jitter between 0 and 0.5 seconds."""
-    _seed_stream_room("JITTER1")
-    _set_session_room(client, os.environ["FLASK_SECRET"], "JITTER1")
-
-    # Force gevent sleep fallback path so we can capture asyncio.sleep calls
-    import jellyswipe
-
-    monkeypatch.setattr(jellyswipe, "_gevent_sleep", None, raising=False)
-
-    # Use _make_sse_sleep_mock to intercept SSE generator sleeps and capture durations
-    mock_sleep, sleep_calls = _make_sse_sleep_mock()
-    monkeypatch.setattr(asyncio, "sleep", mock_sleep)
-    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
-    monkeypatch.setattr(time, "sleep", lambda _: None)
-    monkeypatch.setattr(time, "time", _make_time_mock(10))
-
-    response = client.get("/room/JITTER1/stream")
-    _ = response.content  # consume generator
-
-    assert len(sleep_calls) >= 1, (
-        f"Expected at least 1 sleep call, got {len(sleep_calls)}"
-    )
-    for duration in sleep_calls:
-        assert 1.5 <= duration <= 2.0, (
-            f"Sleep duration {duration} outside expected range [1.5, 2.0]"
+def test_stream_first_attach_sends_bootstrap(client, monkeypatch):
+    """First attach (no Last-Event-ID, no after_event_id) sends session_bootstrap."""
+    conn = _sqlite_conn(client)
+    try:
+        instance_id = _seed_room_and_instance(
+            conn,
+            "BOOT1",
+            ready=1,
+            current_genre="Action",
+            solo_mode=1,
+            hide_watched=1,
         )
+    finally:
+        conn.close()
+    _set_session_room(client, os.environ["FLASK_SECRET"], "BOOT1")
+    _setup_disconnect_after(client, monkeypatch, after_calls=2)
+
+    monkeypatch.setattr(notifier, "subscribe", lambda code: _resolved_future())
+    monkeypatch.setattr(time, "time", lambda: 1000000.0)
+
+    response = client.get("/room/BOOT1/stream")
+    data = response.text
+
+    assert "session_bootstrap" in data
+    assert (
+        f'"instance_id": "{instance_id}"' in data
+        or f'"instance_id":"{instance_id}"' in data
+    )
+    assert '"ready": true' in data
+    assert '"genre": "Action"' in data
+    assert '"solo": true' in data
+    assert '"hide_watched": true' in data
+    assert '"replay_boundary"' in data
 
 
-def test_stream_heartbeat_on_idle(client, monkeypatch):
-    """SSE stream sends : ping heartbeat when no data event for ~15 seconds."""
-    _seed_stream_room("HB1", ready=0, current_genre="All")
+def test_stream_first_attach_bootstrap_only_event_before_live(client, monkeypatch):
+    """session_bootstrap is the only event before live events start."""
+    conn = _sqlite_conn(client)
+    try:
+        _seed_room_and_instance(conn, "BOOT2")
+    finally:
+        conn.close()
+    _set_session_room(client, os.environ["FLASK_SECRET"], "BOOT2")
+    _setup_disconnect_after(client, monkeypatch, after_calls=2)
+
+    monkeypatch.setattr(notifier, "subscribe", lambda code: _resolved_future())
+    monkeypatch.setattr(time, "time", lambda: 1000000.0)
+
+    response = client.get("/room/BOOT2/stream")
+    data = response.text
+
+    bootstrap_count = data.count("session_bootstrap")
+    assert bootstrap_count == 1, f"Expected 1 bootstrap, got {bootstrap_count}: {data}"
+
+
+def test_stream_first_attach_replay_boundary(client, monkeypatch):
+    """First attach includes replay_boundary set to latest event_id."""
+    conn = _sqlite_conn(client)
+    try:
+        instance_id = _seed_room_and_instance(conn, "BOOT3")
+        _seed_event(conn, instance_id, "swipe", json.dumps({"media_id": "m1"}))
+        _seed_event(conn, instance_id, "swipe", json.dumps({"media_id": "m2"}))
+    finally:
+        conn.close()
+    _set_session_room(client, os.environ["FLASK_SECRET"], "BOOT3")
+    _setup_disconnect_after(client, monkeypatch, after_calls=2)
+
+    monkeypatch.setattr(notifier, "subscribe", lambda code: _resolved_future())
+    monkeypatch.setattr(time, "time", lambda: 1000000.0)
+
+    response = client.get("/room/BOOT3/stream")
+    data = response.text
+
+    assert '"replay_boundary": 2' in data or '"replay_boundary":2' in data
+
+
+# ---------------------------------------------------------------------------
+# Section 3: Reconnect with valid cursor — replay missed events
+# ---------------------------------------------------------------------------
+
+
+def test_stream_reconnect_replays_missed_events(client, monkeypatch):
+    """Reconnect with valid cursor replays missed events in order."""
+    conn = _sqlite_conn(client)
+    try:
+        instance_id = _seed_room_and_instance(conn, "REPLAY1")
+        eid1 = _seed_event(
+            conn,
+            instance_id,
+            "swipe",
+            json.dumps({"media_id": "m1", "direction": "right"}),
+        )
+        eid2 = _seed_event(
+            conn, instance_id, "match_found", json.dumps({"media_id": "m1"})
+        )
+    finally:
+        conn.close()
+    _set_session_room(client, os.environ["FLASK_SECRET"], "REPLAY1")
+    _setup_disconnect_after(client, monkeypatch, after_calls=2)
+
+    monkeypatch.setattr(notifier, "subscribe", lambda code: _resolved_future())
+    monkeypatch.setattr(time, "time", lambda: 1000000.0)
+
+    response = client.get(f"/room/REPLAY1/stream?after_event_id={eid1}")
+    data = response.text
+
+    assert "match_found" in data
+    assert f'"event_id": {eid2}' in data or f'"event_id":{eid2}' in data
+    assert '"event_type": "match_found"' in data or '"event_type":"match_found"' in data
+
+
+def test_stream_reconnect_events_in_order(client, monkeypatch):
+    """Replayed events are delivered in event_id order."""
+    conn = _sqlite_conn(client)
+    try:
+        instance_id = _seed_room_and_instance(conn, "REPLAY2")
+        eid1 = _seed_event(conn, instance_id, "swipe", json.dumps({"media_id": "m1"}))
+        eid2 = _seed_event(conn, instance_id, "swipe", json.dumps({"media_id": "m2"}))
+        eid3 = _seed_event(
+            conn, instance_id, "match_found", json.dumps({"media_id": "m1"})
+        )
+    finally:
+        conn.close()
+    _set_session_room(client, os.environ["FLASK_SECRET"], "REPLAY2")
+    _setup_disconnect_after(client, monkeypatch, after_calls=2)
+
+    monkeypatch.setattr(notifier, "subscribe", lambda code: _resolved_future())
+    monkeypatch.setattr(time, "time", lambda: 1000000.0)
+
+    response = client.get(f"/room/REPLAY2/stream?after_event_id={eid1}")
+    data = response.text
+
+    pos_eid2 = data.find(f'"event_id": {eid2}')
+    if pos_eid2 == -1:
+        pos_eid2 = data.find(f'"event_id":{eid2}')
+    pos_eid3 = data.find(f'"event_id": {eid3}')
+    if pos_eid3 == -1:
+        pos_eid3 = data.find(f'"event_id":{eid3}')
+    assert pos_eid2 < pos_eid3, "Events should be in order"
+
+
+# ---------------------------------------------------------------------------
+# Section 4: Invalid cursor — stale
+# ---------------------------------------------------------------------------
+
+
+def test_stream_stale_cursor_sends_session_reset(client, monkeypatch):
+    """Reconnect with stale cursor (no events after it) sends session_reset."""
+    conn = _sqlite_conn(client)
+    try:
+        _seed_room_and_instance(conn, "STALE1")
+    finally:
+        conn.close()
+    _set_session_room(client, os.environ["FLASK_SECRET"], "STALE1")
+
+    monkeypatch.setattr(time, "time", lambda: 1000000.0)
+
+    response = client.get("/room/STALE1/stream?after_event_id=999")
+    data = response.text
+
+    assert "session_reset" in data
+    assert "stale_cursor" in data
+
+
+# ---------------------------------------------------------------------------
+# Section 5: Session closed event
+# ---------------------------------------------------------------------------
+
+
+def test_stream_session_closed_closes_stream(client, monkeypatch):
+    """When session_closed event is replayed, stream closes after sending it."""
+    conn = _sqlite_conn(client)
+    try:
+        instance_id = _seed_room_and_instance(conn, "CLOSE1")
+        _seed_event(conn, instance_id, "swipe", json.dumps({"media_id": "m1"}))
+        _seed_event(
+            conn, instance_id, "session_closed", json.dumps({"reason": "user_quit"})
+        )
+    finally:
+        conn.close()
+    _set_session_room(client, os.environ["FLASK_SECRET"], "CLOSE1")
+
+    monkeypatch.setattr(time, "time", lambda: 1000000.0)
+
+    response = client.get("/room/CLOSE1/stream?after_event_id=0")
+    data = response.text
+
+    assert "session_closed" in data
+    assert "session_bootstrap" not in data
+
+
+def test_stream_two_matches_close_together(client, monkeypatch):
+    """Two match_found events are delivered as distinct events with different event_ids."""
+    conn = _sqlite_conn(client)
+    try:
+        instance_id = _seed_room_and_instance(conn, "MATCH2")
+        eid1 = _seed_event(
+            conn, instance_id, "match_found", json.dumps({"media_id": "m1"})
+        )
+        eid2 = _seed_event(
+            conn, instance_id, "match_found", json.dumps({"media_id": "m2"})
+        )
+    finally:
+        conn.close()
+    _set_session_room(client, os.environ["FLASK_SECRET"], "MATCH2")
+    _setup_disconnect_after(client, monkeypatch, after_calls=2)
+
+    monkeypatch.setattr(notifier, "subscribe", lambda code: _resolved_future())
+    monkeypatch.setattr(time, "time", lambda: 1000000.0)
+
+    response = client.get("/room/MATCH2/stream?after_event_id=0")
+    data = response.text
+
+    assert data.count("match_found") >= 2
+    assert f'"event_id": {eid1}' in data or f'"event_id":{eid1}' in data
+    assert f'"event_id": {eid2}' in data or f'"event_id":{eid2}' in data
+
+
+# ---------------------------------------------------------------------------
+# Section 6: SSE id field
+# ---------------------------------------------------------------------------
+
+
+def test_stream_sse_id_field(client, monkeypatch):
+    """Each event includes id: line with the event_id."""
+    conn = _sqlite_conn(client)
+    try:
+        instance_id = _seed_room_and_instance(conn, "ID1")
+        eid = _seed_event(conn, instance_id, "swipe", json.dumps({"media_id": "m1"}))
+    finally:
+        conn.close()
+    _set_session_room(client, os.environ["FLASK_SECRET"], "ID1")
+    _setup_disconnect_after(client, monkeypatch, after_calls=2)
+
+    monkeypatch.setattr(notifier, "subscribe", lambda code: _resolved_future())
+    monkeypatch.setattr(time, "time", lambda: 1000000.0)
+
+    response = client.get("/room/ID1/stream?after_event_id=0")
+    data = response.text
+
+    assert f"id: {eid}" in data or f"id:{eid}" in data
+
+
+# ---------------------------------------------------------------------------
+# Section 7: Heartbeat
+# ---------------------------------------------------------------------------
+
+
+def test_stream_heartbeat_ping(client, monkeypatch):
+    """After ~15s of no events, a : ping comment is sent."""
+    conn = _sqlite_conn(client)
+    try:
+        _seed_room_and_instance(conn, "HB1")
+    finally:
+        conn.close()
     _set_session_room(client, os.environ["FLASK_SECRET"], "HB1")
+    _setup_disconnect_after(client, monkeypatch, after_calls=4)
 
-    # Force gevent sleep fallback path
-    import jellyswipe
+    time_counter = [0]
 
-    monkeypatch.setattr(jellyswipe, "_gevent_sleep", None, raising=False)
+    def mock_time():
+        time_counter[0] += 1
+        if time_counter[0] <= 5:
+            return 0.0
+        return 16.0
 
-    mock_sleep, _ = _make_sse_sleep_mock()
-    monkeypatch.setattr(asyncio, "sleep", mock_sleep)
-    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
+    monkeypatch.setattr(time, "time", mock_time)
 
-    # Create time mock that advances past 15 seconds between polls to trigger heartbeat.
-    # Thresholds account for _PRE_GENERATOR_OVERHEAD pre-generator calls PLUS:
-    #   - _last_event_time init (1 call)
-    #   - deadline calculation (1 call)
-    #   - while time.time() < deadline (1 call)
-    #   - inside first iteration: heartbeat check + event time (2 calls)
-    # After first iteration: 16s gap triggers heartbeat; after second iteration: exit.
-    call_count = 0
-    real_start = time.time()
-    # offset accounts for pre-generator overhead so deadline = real_start + 3600
-    offset = _PRE_GENERATOR_OVERHEAD
+    # Mock wait_for to timeout immediately so the heartbeat check runs
+    original_wait_for = asyncio.wait_for
 
-    def _time_with_gap():
-        nonlocal call_count
-        call_count += 1
-        if call_count <= offset + 5:
-            # Pre-generator overhead + init + first iteration: real time
-            return real_start
-        elif call_count <= offset + 7:
-            # Second iteration: advance 16 seconds to trigger heartbeat
-            return real_start + 16
-        else:
-            # Past deadline: exit loop
-            return real_start + 3700
+    async def mock_wait_for(future, timeout):
+        # Let the first call through (bootstrap phase), then timeout immediately
+        if time_counter[0] > 5:
+            raise asyncio.TimeoutError()
+        return await original_wait_for(future, timeout=0.001)
 
-    monkeypatch.setattr(time, "sleep", lambda _: None)
-    monkeypatch.setattr(time, "time", _time_with_gap)
+    monkeypatch.setattr(asyncio, "wait_for", mock_wait_for)
 
     response = client.get("/room/HB1/stream")
     data = response.text
 
-    # SSE uses \r\n separators per spec (EventSourceResponse DEFAULT_SEPARATOR = "\r\n")
-    assert ": ping" in data, f"Expected heartbeat ping in SSE stream, got: {repr(data)}"
-
-
-def test_stream_no_heartbeat_when_data_sent(client, monkeypatch):
-    """Heartbeat is NOT sent when data events are emitted within 15 seconds."""
-    _seed_stream_room("NHB1", ready=0, current_genre="All")
-    _set_session_room(client, os.environ["FLASK_SECRET"], "NHB1")
-
-    # Force gevent sleep fallback path
-    import jellyswipe
-
-    monkeypatch.setattr(jellyswipe, "_gevent_sleep", None, raising=False)
-
-    real_start = time.time()
-    exit_after_idle_polls = [False]
-    poll_sleeps = [0]
-
-    def _after_poll_sleep(_delay):
-        # End the stream only *between* full poll iterations so the next time.time()
-        # call is the `while time.time() < deadline` check — not the `elif` that would
-        # treat a fake +3700s jump as "idle for 15s" and emit a spurious ping.
-        poll_sleeps[0] += 1
-        if poll_sleeps[0] >= 40:
-            exit_after_idle_polls[0] = True
-
-    mock_sleep, _sleep_calls = _make_sse_sleep_mock(on_sleep_callback=_after_poll_sleep)
-    monkeypatch.setattr(asyncio, "sleep", mock_sleep)
-    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
-
-    def _time_frozen_then_exit_deadline():
-        if exit_after_idle_polls[0]:
-            return real_start + 3700
-        return real_start
-
-    monkeypatch.setattr(time, "sleep", lambda _: None)
-    monkeypatch.setattr(time, "time", _time_frozen_then_exit_deadline)
-
-    response = client.get("/room/NHB1/stream")
-    data = response.text
-
-    # With rapid polls (mocked time advances quickly), state changes produce data events
-    # and no heartbeat should appear since _last_event_time is reset on data emission
-    ping_count = data.count(": ping")
-    assert ping_count == 0, (
-        f"Expected no heartbeat when data events sent, but found {ping_count}"
-    )
-
-
-def test_stream_room_disappearance_immediate_exit(client, monkeypatch):
-    """SSE generator exits immediately when room record disappears from database (SSE-03)."""
-    _seed_stream_room("VANISH1")
-    _set_session_room(client, os.environ["FLASK_SECRET"], "VANISH1")
-
-    # Force gevent sleep fallback path
-    import jellyswipe
-
-    monkeypatch.setattr(jellyswipe, "_gevent_sleep", None, raising=False)
-
-    # Use a sleep callback that deletes the room on first generator poll sleep.
-    sleep_count = 0
-
-    def _on_sleep_delete(delay):
-        nonlocal sleep_count
-        sleep_count += 1
-        if sleep_count == 1:
-            # After first poll (initial state sent), delete the room
-            conn = _sqlite_conn_for_sse_tests()
-            try:
-                conn.execute("DELETE FROM rooms WHERE pairing_code = ?", ("VANISH1",))
-                conn.commit()
-            finally:
-                conn.close()
-
-    mock_sleep, _ = _make_sse_sleep_mock(on_sleep_callback=_on_sleep_delete)
-    monkeypatch.setattr(asyncio, "sleep", mock_sleep)
-    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
-    monkeypatch.setattr(time, "sleep", lambda _: None)
-    monkeypatch.setattr(time, "time", _make_time_mock(10))
-
-    response = client.get("/room/VANISH1/stream")
-    data = response.text
-
-    assert '"closed": true' in data, (
-        f"Expected closed:true event in SSE stream, got: {repr(data)}"
-    )
+    assert ": ping" in data, f"Expected heartbeat ping in: {repr(data)}"
 
 
 # ---------------------------------------------------------------------------
-# Section 6: Gap tests — disconnect detection, cleanup, CancelledError, auth
+# Section 8: Disconnect detection
 # ---------------------------------------------------------------------------
 
 
-def test_stream_disconnect_breaks_loop_before_db_query(client, monkeypatch):
-    """G1: is_disconnected() returning True breaks the poll loop before the next DB snapshot read.
-
-    Strategy: seed a real room so the first poll succeeds and yields an event.
-    Then mock is_disconnected to return True on the second call.
-    Verify that the stream exits early — fetch_status call count confirms no
-    additional query was issued after disconnect was detected.
-    """
-    from jellyswipe.repositories.rooms import RoomRepository
-
-    _seed_stream_room("DISC1", ready=0, current_genre="All")
+def test_stream_disconnect_exits_cleanly(client, monkeypatch):
+    """If request.is_disconnected() returns True, generator exits cleanly."""
+    conn = _sqlite_conn(client)
+    try:
+        _seed_room_and_instance(conn, "DISC1")
+    finally:
+        conn.close()
     _set_session_room(client, os.environ["FLASK_SECRET"], "DISC1")
 
-    import jellyswipe
-
-    monkeypatch.setattr(jellyswipe, "_gevent_sleep", None, raising=False)
-
-    mock_sleep, sleep_calls = _make_sse_sleep_mock()
-    monkeypatch.setattr(asyncio, "sleep", mock_sleep)
-    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
-    monkeypatch.setattr(time, "sleep", lambda _: None)
-
-    _orig_fetch = RoomRepository.fetch_status
-    snapshot_calls = [0]
-
-    async def counting_fetch(self, pairing_code):  # type: ignore[no-untyped-def]
-        snapshot_calls[0] += 1
-        return await _orig_fetch(self, pairing_code)
-
-    monkeypatch.setattr(RoomRepository, "fetch_status", counting_fetch)
-
-    # Patch is_disconnected on the Starlette Request class so all Request instances
-    # use our fake. First call returns False (allow first poll), second returns True (break).
-    from starlette.requests import Request as StarletteRequest
-
-    is_disconnected_call_count = [0]
-
-    async def fake_is_disconnected(self):
-        is_disconnected_call_count[0] += 1
-        # First call: not disconnected (let first poll happen)
-        # Second call and beyond: disconnected (break loop before 2nd DB query)
-        return is_disconnected_call_count[0] >= 2
-
-    monkeypatch.setattr(StarletteRequest, "is_disconnected", fake_is_disconnected)
-
-    # Use a safe deadline that won't time out before disconnect fires
-    monkeypatch.setattr(time, "time", _make_time_mock(20))
+    call_count = _setup_disconnect_after(client, monkeypatch, after_calls=2)
+    monkeypatch.setattr(notifier, "subscribe", lambda code: _resolved_future())
+    monkeypatch.setattr(time, "time", lambda: 1000000.0)
 
     response = client.get("/room/DISC1/stream")
-
-    # The loop must have called is_disconnected at least once
-    assert is_disconnected_call_count[0] >= 1, (
-        f"is_disconnected was never called — disconnect detection not wired: calls={is_disconnected_call_count[0]}"
-    )
-
-    # After disconnect (2nd call returns True), the loop breaks BEFORE the next status fetch.
-    # So snapshot count must be exactly 1 (first poll) — not 2 or more.
-    assert snapshot_calls[0] == 1, (
-        f"Expected exactly 1 status fetch (disconnect before 2nd query), got {snapshot_calls[0]}"
-    )
-
-    # The response is still a valid SSE stream (not an error)
     assert response.status_code == 200
-    assert response.headers.get("content-type", "").startswith("text/event-stream")
+    assert call_count[0] >= 1
 
 
-def test_stream_connection_closed_on_all_exit_paths(client, monkeypatch):
-    """G2: each short-lived async session is closed after snapshot reads (context manager exit).
-
-    Strategy: patch AsyncSession.close to count invocations. Consume a stream until
-    deadline via time mock. Expect at least one close (one poll completed).
-    """
-    import sqlalchemy.ext.asyncio as sa_async
-
-    _seed_stream_room("CLEANUP1", ready=0, current_genre="All")
-    _set_session_room(client, os.environ["FLASK_SECRET"], "CLEANUP1")
-
-    import jellyswipe
-
-    monkeypatch.setattr(jellyswipe, "_gevent_sleep", None, raising=False)
-
-    mock_sleep, _ = _make_sse_sleep_mock()
-    monkeypatch.setattr(asyncio, "sleep", mock_sleep)
-    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
-    monkeypatch.setattr(time, "sleep", lambda _: None)
-
-    close_calls = [0]
-    _orig_close = sa_async.AsyncSession.close
-
-    async def counting_close(self):  # type: ignore[no-untyped-def]
-        close_calls[0] += 1
-        return await _orig_close(self)
-
-    monkeypatch.setattr(sa_async.AsyncSession, "close", counting_close)
-
-    # Time mock: exit after a few iterations (normal timeout exit path)
-    monkeypatch.setattr(time, "time", _make_time_mock(8))
-
-    response = client.get("/room/CLEANUP1/stream")
-    _ = response.content  # consume fully
-
-    assert close_calls[0] >= 1, (
-        "Expected at least one AsyncSession.close from short-lived SSE poll sessions"
-    )
+# ---------------------------------------------------------------------------
+# Section 9: CancelledError propagation
+# ---------------------------------------------------------------------------
 
 
 def test_stream_cancelled_error_not_swallowed(monkeypatch):
-    """G3: CancelledError raised inside the generate() loop must propagate out, not be swallowed.
-
-    Strategy: unit test the generate() async generator directly by driving it with
-    an async harness. Patch fetch_status so the snapshot read raises
-    CancelledError on the first query. Verify CancelledError escapes the generator.
-    """
-    import asyncio
-    from contextlib import asynccontextmanager
-
+    """CancelledError raised inside the generator must propagate out."""
     import jellyswipe.routers.rooms as rooms_module
-    from jellyswipe.repositories.rooms import RoomRepository
-    from unittest.mock import AsyncMock, MagicMock, patch
+    from jellyswipe.dependencies import AuthUser
 
-    @asynccontextmanager
-    async def _fake_async_session():
-        yield MagicMock()
-
-    class _FakeSessionMaker:
-        def __call__(self):
-            return _fake_async_session()
-
-    monkeypatch.setattr(rooms_module, "get_sessionmaker", lambda: _FakeSessionMaker())
-
-    # We need a Request object with is_disconnected returning False
     fake_request = MagicMock()
     fake_request.is_disconnected = AsyncMock(return_value=False)
-
-    snapshot_calls = [0]
-
-    async def raise_cancelled(self, pairing_code):  # type: ignore[no-untyped-def]
-        snapshot_calls[0] += 1
-        raise asyncio.CancelledError("simulated cancellation")
-
-    # Extract the generate() inner function by calling room_stream
-    from jellyswipe.dependencies import AuthUser
+    fake_request.headers = {}
+    fake_request.query_params = {}
 
     fake_auth = AuthUser(jf_token="t", user_id="u")
 
-    with patch.object(RoomRepository, "fetch_status", raise_cancelled):
-        result = rooms_module.room_stream(
-            code="CANCEL1",
-            request=fake_request,
-            auth=fake_auth,
-        )
-        generator = result.body_iterator
+    # Custom async context manager that raises CancelledError on entry
+    class _FailingSessionCM:
+        async def __aenter__(self):
+            raise asyncio.CancelledError("simulated cancellation")
 
-        cancelled_error_propagated = [False]
+        async def __aexit__(self, *args):
+            pass
 
-        async def drive_generator():
-            try:
-                async for _ in generator:
-                    pass
-            except (asyncio.CancelledError, Exception) as exc:
-                if isinstance(exc, asyncio.CancelledError):
-                    cancelled_error_propagated[0] = True
-                else:
-                    raise
+    monkeypatch.setattr(
+        rooms_module, "get_sessionmaker", lambda: lambda: _FailingSessionCM()
+    )
 
-        asyncio.run(drive_generator())
+    result = rooms_module.room_stream(
+        code="CANCEL1",
+        request=fake_request,
+        auth=fake_auth,
+    )
+    generator = result.body_iterator
+
+    cancelled_error_propagated = [False]
+
+    async def drive_generator():
+        try:
+            async for _ in generator:
+                pass
+        except asyncio.CancelledError:
+            cancelled_error_propagated[0] = True
+
+    asyncio.run(drive_generator())
 
     assert cancelled_error_propagated[0], (
-        "CancelledError was swallowed inside except Exception block — "
-        "it must be re-raised so callers see cancellation semantics"
-    )
-    assert snapshot_calls[0] == 1, (
-        "Expected CancelledError to surface from first snapshot poll"
+        "CancelledError was swallowed — it must propagate"
     )
 
 
-def test_room_stream_does_not_open_sqlite3_connection(client, monkeypatch):
-    """Regression: SSE polling must stay off sync sqlite (get_db) in the router.
+# ---------------------------------------------------------------------------
+# Section 10: Room not found
+# ---------------------------------------------------------------------------
 
-    aiosqlite opens sqlite under the hood for AsyncEngine — that is expected. This
-    test blocks the legacy sync API so the stream path cannot regress to
-    sqlite3.connect/get_db in application code.
-    """
-    _seed_stream_room("NO_SQLITE_ROUTE", ready=1, current_genre="All")
-    _set_session_room(client, os.environ["FLASK_SECRET"], "NO_SQLITE_ROUTE")
 
-    import jellyswipe.db as jelly_db
+def test_stream_room_not_found_no_instance(client, monkeypatch):
+    """Stream for room with no instance sends session_reset and closes."""
+    _set_session_room(client, os.environ["FLASK_SECRET"], "NOINSTANCE")
 
-    def forbid_sync_get_db():
-        pytest.fail(
-            "room_stream must not use jellyswipe.db.get_db() — use async SQLAlchemy sessions"
-        )
+    monkeypatch.setattr(time, "time", lambda: 1000000.0)
 
-    monkeypatch.setattr(jelly_db, "get_db", forbid_sync_get_db, raising=False)
+    response = client.get("/room/NOINSTANCE/stream")
+    data = response.text
 
-    import jellyswipe
+    assert "session_reset" in data
+    assert "instance_changed" in data
 
-    monkeypatch.setattr(jellyswipe, "_gevent_sleep", None, raising=False)
 
-    mock_sleep, _ = _make_sse_sleep_mock()
-    monkeypatch.setattr(asyncio, "sleep", mock_sleep)
-    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
-    monkeypatch.setattr(time, "sleep", lambda _: None)
-    monkeypatch.setattr(time, "time", _make_time_mock(4))
+# ---------------------------------------------------------------------------
+# Section 11: GET /matches works independently
+# ---------------------------------------------------------------------------
 
-    response = client.get("/room/NO_SQLITE_ROUTE/stream")
+
+def test_get_matches_works_independently(client, monkeypatch):
+    """GET /matches continues to work independently of the stream."""
+    conn = _sqlite_conn(client)
+    try:
+        _seed_room_and_instance(conn, "MATCHES1", ready=1)
+    finally:
+        conn.close()
+    _set_session_room(client, os.environ["FLASK_SECRET"], "MATCHES1")
+
+    response = client.get("/matches")
     assert response.status_code == 200
 
 
-def test_stream_unauthenticated_request_returns_401(client_real_auth):
-    """G4: GET /room/{code}/stream without auth cookie must return HTTP 401.
+# ---------------------------------------------------------------------------
+# Section 12: Unauthenticated request
+# ---------------------------------------------------------------------------
 
-    Uses client_real_auth (no dependency_overrides for require_auth).
-    Sends request with no session cookie — real auth path must reject it.
-    """
-    # No set_session_cookie call — unauthenticated request
+
+def test_stream_unauthenticated_request_returns_401(client_real_auth):
+    """GET /room/{code}/stream without auth cookie must return HTTP 401."""
     response = client_real_auth.get("/room/AUTHTEST1/stream")
 
     assert response.status_code == 401, (

--- a/tests/test_routes_sse.py
+++ b/tests/test_routes_sse.py
@@ -111,12 +111,10 @@ def _make_sse_sleep_mock(on_sleep_callback=None):
     (POLL=1.5 + random jitter 0–0.5). sse_starlette's _ping task uses exactly 15.0,
     and anyio/starlette internal checkpoints use 0 or 0.5.
 
-    Strategy: intercept ONLY the generator's sleep range [1.4, 2.1] and yield control
-    instantly (via asyncio.sleep(0)). This lets _ping run at its natural 15s interval,
-    and task-group cancellation interrupts _ping after _stream_response completes.
-
-    Passing through the _ping's 15s sleep means tests complete in at most one ping
-    interval (15s) after the generator finishes — acceptable versus hanging indefinitely.
+    Strategy: intercept the generator's sleep range [1.4, 2.1] AND any sleep >= 10s
+    (which includes _ping's 15s sleep), yielding control instantly (via asyncio.sleep(0)).
+    This prevents the _ping task from blocking test teardown, allowing task-group
+    cancellation to complete immediately after _stream_response finishes.
 
     Args:
         on_sleep_callback: Optional sync callable(delay) called when generator sleep is
@@ -134,8 +132,11 @@ def _make_sse_sleep_mock(on_sleep_callback=None):
                 on_sleep_callback(delay)
             # Yield control without blocking, allowing task group to process cancellation
             await original_sleep(0)
+        elif delay >= 10:
+            # _ping (15s) or other long sleeps — yield immediately to prevent deadlock
+            await original_sleep(0)
         else:
-            # _ping (15s), anyio checkpoints (0, 0.5) — keep real behavior
+            # anyio checkpoints (0, 0.5) — keep real behavior
             await original_sleep(delay)
 
     return _selective_sleep, sleep_calls

--- a/tests/test_routes_sse.py
+++ b/tests/test_routes_sse.py
@@ -14,6 +14,8 @@ import time
 
 import sqlite3
 
+from sse_starlette.sse import EventSourceResponse
+
 import pytest
 from jellyswipe.db_paths import application_db_path
 from tests.conftest import set_session_cookie
@@ -55,16 +57,16 @@ def _set_session_room(client, secret_key, room_code, user_id=None):
 
 
 def _seed_stream_room(
-    room_code, *, ready=0, solo_mode=0, current_genre="All", last_match_data=None
+    room_code, *, ready=0, solo_mode=0, current_genre="All"
 ):
     """Seed a room row directly into SQLite for SSE tests (VAL-03: no jellyswipe.db.get_db)."""
     movie_data = json.dumps([])
     conn = _sqlite_conn_for_sse_tests()
     try:
         conn.execute(
-            "INSERT INTO rooms (pairing_code, movie_data, ready, current_genre, solo_mode, last_match_data) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            (room_code, movie_data, ready, current_genre, solo_mode, last_match_data),
+            "INSERT INTO rooms (pairing_code, movie_data, ready, current_genre, solo_mode) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (room_code, movie_data, ready, current_genre, solo_mode),
         )
         conn.commit()
     finally:
@@ -108,13 +110,13 @@ def _make_sse_sleep_mock(on_sleep_callback=None):
     """Create a selective asyncio.sleep mock for SSE generator testing.
 
     The SSE generator calls asyncio.sleep(delay) where delay is in [1.5, 2.0]
-    (POLL=1.5 + random jitter 0–0.5). sse_starlette's _ping task uses exactly 15.0,
-    and anyio/starlette internal checkpoints use 0 or 0.5.
+    (POLL=1.5 + random jitter 0–0.5). Internal anyio/starlette checkpoints use 0 or 0.5.
 
-    Strategy: intercept the generator's sleep range [1.4, 2.1] AND any sleep >= 10s
-    (which includes _ping's 15s sleep), yielding control instantly (via asyncio.sleep(0)).
-    This prevents the _ping task from blocking test teardown, allowing task-group
-    cancellation to complete immediately after _stream_response finishes.
+    Strategy: intercept the generator's sleep range [1.4, 2.1], yielding control
+    instantly (via asyncio.sleep(0)). Starlette internal checkpoints (< 1.4s) pass through.
+
+    The _ping task's anyio.sleep(15s) is handled separately by patching
+    EventSourceResponse._ping to a no-op — see _noop_ping below.
 
     Args:
         on_sleep_callback: Optional sync callable(delay) called when generator sleep is
@@ -132,14 +134,25 @@ def _make_sse_sleep_mock(on_sleep_callback=None):
                 on_sleep_callback(delay)
             # Yield control without blocking, allowing task group to process cancellation
             await original_sleep(0)
-        elif delay >= 10:
-            # _ping (15s) or other long sleeps — yield immediately to prevent deadlock
-            await original_sleep(0)
         else:
-            # anyio checkpoints (0, 0.5) — keep real behavior
+            # anyio checkpoints (0, 0.5) and others — keep real behavior
             await original_sleep(delay)
 
     return _selective_sleep, sleep_calls
+
+
+async def _noop_ping(self, send):
+    """Replacement _ping for tests — polls self.active without sending ping comments.
+
+    EventSourceResponse._ping calls anyio.sleep(15s) inside a while-loop. That sleep
+    is not interrupted when the cancel scope fires, causing a 15s teardown hang.
+
+    This replacement polls self.active every 10ms using asyncio.sleep (which IS
+    interrupted by the task group's cancel scope), so teardown is instantaneous.
+    No ping comments are emitted, so heartbeat-count assertions stay clean.
+    """
+    while self.active:
+        await asyncio.sleep(0.01)
 
 
 # ---------------------------------------------------------------------------
@@ -170,6 +183,7 @@ def test_stream_response_headers(client, monkeypatch):
     # passes through internal anyio/sse_starlette sleeps (< 1.5s).
     mock_sleep, _ = _make_sse_sleep_mock()
     monkeypatch.setattr(asyncio, "sleep", mock_sleep)
+    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
 
     # Mock time to exit the generator loop after a few iterations
     monkeypatch.setattr(time, "sleep", lambda _: None)
@@ -217,6 +231,7 @@ def test_stream_initial_state_events(client, monkeypatch):
 
     mock_sleep, _ = _make_sse_sleep_mock()
     monkeypatch.setattr(asyncio, "sleep", mock_sleep)
+    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
 
     # deadline calc + init + loop iterations then exit
     monkeypatch.setattr(time, "sleep", lambda _: None)
@@ -243,6 +258,7 @@ def test_stream_stable_state_no_repeat(client, monkeypatch):
 
     mock_sleep, _ = _make_sse_sleep_mock()
     monkeypatch.setattr(asyncio, "sleep", mock_sleep)
+    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
 
     # deadline calc + init + loop iterations then exit
     monkeypatch.setattr(time, "sleep", lambda _: None)
@@ -271,30 +287,6 @@ def test_stream_stable_state_no_repeat(client, monkeypatch):
 # Section 3: State change detection tests
 # ---------------------------------------------------------------------------
 
-
-def test_stream_match_event(client, monkeypatch):
-    """Stream sends last_match event when room has match data with a timestamp."""
-    match_data = json.dumps({"title": "Test Movie", "ts": "2026-04-26T12:00:00Z"})
-    _seed_stream_room("TEST1", ready=1, last_match_data=match_data)
-    _set_session_room(client, os.environ["FLASK_SECRET"], "TEST1")
-
-    # Force gevent sleep fallback path (gevent is available in test env)
-    import jellyswipe
-
-    monkeypatch.setattr(jellyswipe, "_gevent_sleep", None, raising=False)
-
-    mock_sleep, _ = _make_sse_sleep_mock()
-    monkeypatch.setattr(asyncio, "sleep", mock_sleep)
-
-    # deadline + 2 iterations then exit
-    monkeypatch.setattr(time, "sleep", lambda _: None)
-    monkeypatch.setattr(time, "time", _make_time_mock(8))
-
-    response = client.get("/room/TEST1/stream")
-    data = response.text
-
-    assert '"last_match"' in data
-    assert '"title": "Test Movie"' in data
 
 
 def test_stream_ready_state_change(client, monkeypatch):
@@ -329,6 +321,7 @@ def test_stream_ready_state_change(client, monkeypatch):
 
     mock_sleep, _ = _make_sse_sleep_mock(on_sleep_callback=_on_sleep)
     monkeypatch.setattr(asyncio, "sleep", mock_sleep)
+    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
     # deadline + loop iterations (with state changes) then exit
     monkeypatch.setattr(time, "sleep", lambda _: None)
     monkeypatch.setattr(time, "time", _make_time_mock(12))
@@ -358,6 +351,7 @@ def test_stream_generator_exit(client, monkeypatch):
 
     mock_sleep, _ = _make_sse_sleep_mock()
     monkeypatch.setattr(asyncio, "sleep", mock_sleep)
+    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
 
     result = {}
     error_holder = {}
@@ -407,6 +401,7 @@ def test_stream_jitter_applied(client, monkeypatch):
     # Use _make_sse_sleep_mock to intercept SSE generator sleeps and capture durations
     mock_sleep, sleep_calls = _make_sse_sleep_mock()
     monkeypatch.setattr(asyncio, "sleep", mock_sleep)
+    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
     monkeypatch.setattr(time, "sleep", lambda _: None)
     monkeypatch.setattr(time, "time", _make_time_mock(10))
 
@@ -434,6 +429,7 @@ def test_stream_heartbeat_on_idle(client, monkeypatch):
 
     mock_sleep, _ = _make_sse_sleep_mock()
     monkeypatch.setattr(asyncio, "sleep", mock_sleep)
+    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
 
     # Create time mock that advances past 15 seconds between polls to trigger heartbeat.
     # Thresholds account for _PRE_GENERATOR_OVERHEAD pre-generator calls PLUS:
@@ -494,6 +490,7 @@ def test_stream_no_heartbeat_when_data_sent(client, monkeypatch):
 
     mock_sleep, _sleep_calls = _make_sse_sleep_mock(on_sleep_callback=_after_poll_sleep)
     monkeypatch.setattr(asyncio, "sleep", mock_sleep)
+    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
 
     def _time_frozen_then_exit_deadline():
         if exit_after_idle_polls[0]:
@@ -541,6 +538,7 @@ def test_stream_room_disappearance_immediate_exit(client, monkeypatch):
 
     mock_sleep, _ = _make_sse_sleep_mock(on_sleep_callback=_on_sleep_delete)
     monkeypatch.setattr(asyncio, "sleep", mock_sleep)
+    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
     monkeypatch.setattr(time, "sleep", lambda _: None)
     monkeypatch.setattr(time, "time", _make_time_mock(10))
 
@@ -562,7 +560,7 @@ def test_stream_disconnect_breaks_loop_before_db_query(client, monkeypatch):
 
     Strategy: seed a real room so the first poll succeeds and yields an event.
     Then mock is_disconnected to return True on the second call.
-    Verify that the stream exits early — fetch_stream_snapshot call count confirms no
+    Verify that the stream exits early — fetch_status call count confirms no
     additional query was issued after disconnect was detected.
     """
     from jellyswipe.repositories.rooms import RoomRepository
@@ -576,16 +574,17 @@ def test_stream_disconnect_breaks_loop_before_db_query(client, monkeypatch):
 
     mock_sleep, sleep_calls = _make_sse_sleep_mock()
     monkeypatch.setattr(asyncio, "sleep", mock_sleep)
+    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
     monkeypatch.setattr(time, "sleep", lambda _: None)
 
-    _orig_fetch = RoomRepository.fetch_stream_snapshot
+    _orig_fetch = RoomRepository.fetch_status
     snapshot_calls = [0]
 
     async def counting_fetch(self, pairing_code):  # type: ignore[no-untyped-def]
         snapshot_calls[0] += 1
         return await _orig_fetch(self, pairing_code)
 
-    monkeypatch.setattr(RoomRepository, "fetch_stream_snapshot", counting_fetch)
+    monkeypatch.setattr(RoomRepository, "fetch_status", counting_fetch)
 
     # Patch is_disconnected on the Starlette Request class so all Request instances
     # use our fake. First call returns False (allow first poll), second returns True (break).
@@ -611,10 +610,10 @@ def test_stream_disconnect_breaks_loop_before_db_query(client, monkeypatch):
         f"is_disconnected was never called — disconnect detection not wired: calls={is_disconnected_call_count[0]}"
     )
 
-    # After disconnect (2nd call returns True), the loop breaks BEFORE the next snapshot fetch.
+    # After disconnect (2nd call returns True), the loop breaks BEFORE the next status fetch.
     # So snapshot count must be exactly 1 (first poll) — not 2 or more.
     assert snapshot_calls[0] == 1, (
-        f"Expected exactly 1 snapshot fetch (disconnect before 2nd query), got {snapshot_calls[0]}"
+        f"Expected exactly 1 status fetch (disconnect before 2nd query), got {snapshot_calls[0]}"
     )
 
     # The response is still a valid SSE stream (not an error)
@@ -639,6 +638,7 @@ def test_stream_connection_closed_on_all_exit_paths(client, monkeypatch):
 
     mock_sleep, _ = _make_sse_sleep_mock()
     monkeypatch.setattr(asyncio, "sleep", mock_sleep)
+    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
     monkeypatch.setattr(time, "sleep", lambda _: None)
 
     close_calls = [0]
@@ -665,7 +665,7 @@ def test_stream_cancelled_error_not_swallowed(monkeypatch):
     """G3: CancelledError raised inside the generate() loop must propagate out, not be swallowed.
 
     Strategy: unit test the generate() async generator directly by driving it with
-    an async harness. Patch fetch_stream_snapshot so the snapshot read raises
+    an async harness. Patch fetch_status so the snapshot read raises
     CancelledError on the first query. Verify CancelledError escapes the generator.
     """
     import asyncio
@@ -700,7 +700,7 @@ def test_stream_cancelled_error_not_swallowed(monkeypatch):
 
     fake_auth = AuthUser(jf_token="t", user_id="u")
 
-    with patch.object(RoomRepository, "fetch_stream_snapshot", raise_cancelled):
+    with patch.object(RoomRepository, "fetch_status", raise_cancelled):
         result = rooms_module.room_stream(
             code="CANCEL1",
             request=fake_request,
@@ -756,6 +756,7 @@ def test_room_stream_does_not_open_sqlite3_connection(client, monkeypatch):
 
     mock_sleep, _ = _make_sse_sleep_mock()
     monkeypatch.setattr(asyncio, "sleep", mock_sleep)
+    monkeypatch.setattr(EventSourceResponse, "_ping", _noop_ping)
     monkeypatch.setattr(time, "sleep", lambda _: None)
     monkeypatch.setattr(time, "time", _make_time_mock(4))
 

--- a/tests/test_session_event_repos.py
+++ b/tests/test_session_event_repos.py
@@ -1,0 +1,398 @@
+"""Repository-level unit tests for session event persistence."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import jellyswipe.db
+import jellyswipe.db_paths
+import pytest
+from sqlalchemy import text
+
+from jellyswipe.db_runtime import (
+    build_async_sqlite_url,
+    dispose_runtime,
+    get_sessionmaker,
+    initialize_runtime,
+)
+from jellyswipe.db_uow import DatabaseUnitOfWork
+from jellyswipe.migrations import build_sqlite_url, upgrade_to_head
+
+
+@pytest.fixture(autouse=True)
+def reset_runtime(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_PATH", raising=False)
+    monkeypatch.setattr(jellyswipe.db_paths.application_db_path, "path", None)
+    yield
+
+
+@pytest.fixture
+async def runtime_sessionmaker(db_path, monkeypatch):
+    sync_database_url = build_sqlite_url(db_path)
+    runtime_database_url = build_async_sqlite_url(db_path)
+
+    monkeypatch.setattr(jellyswipe.db_paths.application_db_path, "path", db_path)
+    monkeypatch.setenv("DB_PATH", db_path)
+    monkeypatch.setenv("DATABASE_URL", sync_database_url)
+
+    upgrade_to_head(sync_database_url)
+    await initialize_runtime(runtime_database_url)
+    yield get_sessionmaker()
+    await dispose_runtime()
+
+
+@pytest.mark.anyio
+class TestSessionEventRepository:
+    async def test_append_and_read_after_returns_event(self, runtime_sessionmaker):
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.session_instances.create("inst-1", "1234")
+            event_id = await uow.session_events.append(
+                "inst-1", "test_event", json.dumps({"key": "value"})
+            )
+            await session.commit()
+
+        assert event_id is not None
+        assert event_id > 0
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            events = await uow.session_events.read_after("inst-1", after_event_id=0)
+
+        assert len(events) == 1
+        assert events[0].event_id == event_id
+        assert events[0].event_type == "test_event"
+        assert json.loads(events[0].payload_json) == {"key": "value"}
+
+    async def test_read_after_multiple_events_returns_in_order(
+        self, runtime_sessionmaker
+    ):
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.session_instances.create("inst-2", "5678")
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            id1 = await uow.session_events.append(
+                "inst-2", "event1", json.dumps({"n": 1})
+            )
+            id2 = await uow.session_events.append(
+                "inst-2", "event2", json.dumps({"n": 2})
+            )
+            id3 = await uow.session_events.append(
+                "inst-2", "event3", json.dumps({"n": 3})
+            )
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            events = await uow.session_events.read_after("inst-2", after_event_id=0)
+
+        assert len(events) == 3
+        assert events[0].event_id == id1
+        assert events[1].event_id == id2
+        assert events[2].event_id == id3
+        assert events[0].event_type == "event1"
+        assert events[1].event_type == "event2"
+        assert events[2].event_type == "event3"
+
+    async def test_read_after_skips_events_up_to_after_event_id(
+        self, runtime_sessionmaker
+    ):
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.session_instances.create("inst-3", "9012")
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.session_events.append("inst-3", "event1", json.dumps({"n": 1}))
+            await uow.session_events.append("inst-3", "event2", json.dumps({"n": 2}))
+            await uow.session_events.append("inst-3", "event3", json.dumps({"n": 3}))
+            await uow.session_events.append("inst-3", "event4", json.dumps({"n": 4}))
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            events = await uow.session_events.read_after("inst-3", after_event_id=2)
+
+        assert len(events) == 2
+        assert events[0].event_type == "event3"
+        assert events[1].event_type == "event4"
+
+    async def test_read_after_filters_by_instance_id(self, runtime_sessionmaker):
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.session_instances.create("inst-a", "1111")
+            await uow.session_instances.create("inst-b", "2222")
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.session_events.append(
+                "inst-a", "event_a", json.dumps({"src": "a"})
+            )
+            await uow.session_events.append(
+                "inst-b", "event_b", json.dumps({"src": "b"})
+            )
+            await uow.session_events.append(
+                "inst-a", "event_a2", json.dumps({"src": "a2"})
+            )
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            events_a = await uow.session_events.read_after("inst-a", after_event_id=0)
+            events_b = await uow.session_events.read_after("inst-b", after_event_id=0)
+
+        assert len(events_a) == 2
+        assert all(e.session_instance_id == "inst-a" for e in events_a)
+        assert len(events_b) == 1
+        assert events_b[0].session_instance_id == "inst-b"
+
+    async def test_append_raw_sql_with_raw_connection(self, runtime_sessionmaker):
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.session_instances.create("inst-raw", "3333")
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            # Get the raw connection from the session
+            conn = await session.connection()
+            event_id = await uow.session_events.append_raw_sql(
+                conn, "inst-raw", "raw_event", json.dumps({"raw": True})
+            )
+            await session.commit()
+
+        assert event_id is not None
+        assert event_id > 0
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            events = await uow.session_events.read_after("inst-raw", after_event_id=0)
+
+        assert len(events) == 1
+        assert events[0].event_type == "raw_event"
+        assert json.loads(events[0].payload_json) == {"raw": True}
+
+    async def test_delete_for_instance_removes_all_events(self, runtime_sessionmaker):
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.session_instances.create("inst-del", "4444")
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.session_events.append("inst-del", "event1", json.dumps({}))
+            await uow.session_events.append("inst-del", "event2", json.dumps({}))
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            count = await uow.session_events.delete_for_instance("inst-del")
+            await session.commit()
+
+        assert count == 2
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            events = await uow.session_events.read_after("inst-del", after_event_id=0)
+
+        assert len(events) == 0
+
+
+@pytest.mark.anyio
+class TestSessionInstanceRepository:
+    async def test_is_pairing_code_reserved_active_returns_true(
+        self, runtime_sessionmaker
+    ):
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.session_instances.create("inst-active", "5555")
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            reserved = await uow.session_instances.is_pairing_code_reserved("5555")
+
+        assert reserved is True
+
+    async def test_is_pairing_code_reserved_closing_returns_true(
+        self, runtime_sessionmaker
+    ):
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.session_instances.create("inst-closing", "6666")
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.session_instances.mark_closing("inst-closing")
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            reserved = await uow.session_instances.is_pairing_code_reserved("6666")
+
+        assert reserved is True
+
+    async def test_is_pairing_code_reserved_closed_returns_false(
+        self, runtime_sessionmaker
+    ):
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.session_instances.create("inst-closed", "7777")
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.session_instances.mark_closing("inst-closed")
+            await uow.session_instances.mark_closed("inst-closed")
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            reserved = await uow.session_instances.is_pairing_code_reserved("7777")
+
+        assert reserved is False
+
+    async def test_is_pairing_code_reserved_nonexistent_returns_false(
+        self, runtime_sessionmaker
+    ):
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            reserved = await uow.session_instances.is_pairing_code_reserved("9999")
+
+        assert reserved is False
+
+    async def test_mark_closing_sets_status_and_closed_at(self, runtime_sessionmaker):
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.session_instances.create("inst-mark-closing", "8888")
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.session_instances.mark_closing("inst-mark-closing")
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            instance = await uow.session_instances.get_by_instance_id(
+                "inst-mark-closing"
+            )
+
+        assert instance.status == "closing"
+        assert instance.closed_at is not None
+        assert datetime.fromisoformat(instance.closed_at) is not None
+
+    async def test_mark_closed_sets_status(self, runtime_sessionmaker):
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.session_instances.create("inst-mark-closed", "0000")
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.session_instances.mark_closing("inst-mark-closed")
+            await uow.session_instances.mark_closed("inst-mark-closed")
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            instance = await uow.session_instances.get_by_instance_id(
+                "inst-mark-closed"
+            )
+
+        assert instance.status == "closed"
+
+    async def test_cleanup_closed_before_deletes_old_closed_instances(
+        self, runtime_sessionmaker
+    ):
+        import asyncio
+
+        # Create and close the old instance
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.session_instances.create("inst-old", "1212")
+            await uow.session_instances.mark_closing("inst-old")
+            await uow.session_instances.mark_closed("inst-old")
+            await session.commit()
+
+        # Wait to ensure different created_at timestamps
+        await asyncio.sleep(0.1)
+        cutoff = datetime.now(timezone.utc).isoformat()
+        await asyncio.sleep(0.1)
+
+        # Create and close the new instance after cutoff
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.session_instances.create("inst-new", "3434")
+            await uow.session_instances.mark_closing("inst-new")
+            await uow.session_instances.mark_closed("inst-new")
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            deleted = await uow.session_instances.cleanup_closed_before(cutoff)
+            await session.commit()
+
+        assert deleted == 1
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            old_inst = await uow.session_instances.get_by_instance_id("inst-old")
+            new_inst = await uow.session_instances.get_by_instance_id("inst-new")
+
+        assert old_inst is None
+        assert new_inst is not None
+
+
+@pytest.mark.anyio
+class TestMigration:
+    async def test_migration_creates_tables_and_removes_last_match_data(
+        self, db_path, monkeypatch
+    ):
+        sync_database_url = build_sqlite_url(db_path)
+        runtime_database_url = build_async_sqlite_url(db_path)
+
+        monkeypatch.setattr(jellyswipe.db_paths.application_db_path, "path", db_path)
+        monkeypatch.setenv("DB_PATH", db_path)
+        monkeypatch.setenv("DATABASE_URL", sync_database_url)
+
+        upgrade_to_head(sync_database_url)
+        await initialize_runtime(runtime_database_url)
+        sessionmaker = get_sessionmaker()
+
+        try:
+            async with sessionmaker() as session:
+                result = await session.execute(
+                    text(
+                        "SELECT name FROM sqlite_master WHERE type='table' AND name='session_instances'"
+                    )
+                )
+                assert result.scalar() is not None
+
+                result = await session.execute(
+                    text(
+                        "SELECT name FROM sqlite_master WHERE type='table' AND name='session_events'"
+                    )
+                )
+                assert result.scalar() is not None
+
+                result = await session.execute(
+                    text(
+                        "SELECT name FROM sqlite_master WHERE type='index' AND name='ix_session_events_session_instance_id_event_id'"
+                    )
+                )
+                assert result.scalar() is not None
+
+                result = await session.execute(text("PRAGMA table_info(rooms)"))
+                columns = [row[1] for row in result.all()]
+                assert "last_match_data" not in columns
+        finally:
+            await dispose_runtime()

--- a/tests/test_sse_persistence.py
+++ b/tests/test_sse_persistence.py
@@ -2,16 +2,14 @@
 
 from __future__ import annotations
 
-import json
-
 import jellyswipe.db
+import jellyswipe.db_paths
 import pytest
-from sqlalchemy import update
 
 from jellyswipe.db_runtime import build_async_sqlite_url, dispose_runtime, get_sessionmaker, initialize_runtime
 from jellyswipe.db_uow import DatabaseUnitOfWork
 from jellyswipe.migrations import build_sqlite_url, upgrade_to_head
-from jellyswipe.models.room import Room
+from jellyswipe.room_types import RoomStatusSnapshot
 
 
 @pytest.fixture(autouse=True)
@@ -39,15 +37,13 @@ async def runtime_sessionmaker(db_path, monkeypatch):
 
 @pytest.mark.anyio
 class TestStreamSnapshotRepo:
-    async def test_fetch_stream_snapshot_missing_room(self, runtime_sessionmaker):
+    async def test_fetch_status_missing_room(self, runtime_sessionmaker):
         async with runtime_sessionmaker() as session:
             uow = DatabaseUnitOfWork(session)
-            snap = await uow.rooms.fetch_stream_snapshot("NONE")
+            snap = await uow.rooms.fetch_status("NONE")
             assert snap is None
 
-    async def test_fetch_stream_snapshot_preserves_ready_solo_last_match_ts(self, runtime_sessionmaker):
-        persisted_ts = 442
-        lm = json.dumps({"type": "match", "movie_id": "m99", "title": "T", "thumb": "/", "ts": persisted_ts})
+    async def test_fetch_status_preserves_ready_solo_hide_watched(self, runtime_sessionmaker):
         async with runtime_sessionmaker() as session:
             uow = DatabaseUnitOfWork(session)
             await uow.rooms.create(
@@ -58,18 +54,15 @@ class TestStreamSnapshotRepo:
                 solo_mode=True,
                 deck_position_json="{}",
             )
-            await session.execute(
-                update(Room).where(Room.pairing_code == "4242").values(last_match_data=lm),
-            )
             await session.commit()
 
         async with runtime_sessionmaker() as session:
             uow = DatabaseUnitOfWork(session)
-            snap = await uow.rooms.fetch_stream_snapshot("4242")
+            snap = await uow.rooms.fetch_status("4242")
 
         assert snap is not None
+        assert isinstance(snap, RoomStatusSnapshot)
         assert snap.ready is True
         assert snap.solo is True
-        assert snap.last_match == json.loads(lm)
-        assert snap.last_match_ts == persisted_ts
+        assert snap.hide_watched is False
 

--- a/tests/test_sse_persistence.py
+++ b/tests/test_sse_persistence.py
@@ -6,7 +6,12 @@ import jellyswipe.db
 import jellyswipe.db_paths
 import pytest
 
-from jellyswipe.db_runtime import build_async_sqlite_url, dispose_runtime, get_sessionmaker, initialize_runtime
+from jellyswipe.db_runtime import (
+    build_async_sqlite_url,
+    dispose_runtime,
+    get_sessionmaker,
+    initialize_runtime,
+)
 from jellyswipe.db_uow import DatabaseUnitOfWork
 from jellyswipe.migrations import build_sqlite_url, upgrade_to_head
 from jellyswipe.room_types import RoomStatusSnapshot
@@ -43,7 +48,9 @@ class TestStreamSnapshotRepo:
             snap = await uow.rooms.fetch_status("NONE")
             assert snap is None
 
-    async def test_fetch_status_preserves_ready_solo_hide_watched(self, runtime_sessionmaker):
+    async def test_fetch_status_preserves_ready_solo_hide_watched(
+        self, runtime_sessionmaker
+    ):
         async with runtime_sessionmaker() as session:
             uow = DatabaseUnitOfWork(session)
             await uow.rooms.create(
@@ -65,4 +72,3 @@ class TestStreamSnapshotRepo:
         assert snap.ready is True
         assert snap.solo is True
         assert snap.hide_watched is False
-

--- a/tests/test_swipe_match.py
+++ b/tests/test_swipe_match.py
@@ -73,6 +73,25 @@ async def _seed_shared_room(
             solo_mode=False,
             deck_position_json=deck_json,
         )
+        await uow.session_instances.create(instance_id="inst-room1", pairing_code=code)
+        await session.commit()
+
+
+async def _seed_solo_room(
+    runtime_sessionmaker, *, code: str = "SOLO1", deck: dict | None = None
+):
+    deck_json = json.dumps(deck or {"user-A": 0})
+    async with runtime_sessionmaker() as session:
+        uow = DatabaseUnitOfWork(session)
+        await uow.rooms.create(
+            code,
+            movie_data_json="[]",
+            ready=True,
+            current_genre="All",
+            solo_mode=True,
+            deck_position_json=deck_json,
+        )
+        await uow.session_instances.create(instance_id="inst-solo1", pairing_code=code)
         await session.commit()
 
 
@@ -209,3 +228,197 @@ class TestSwipeMatchService:
             uow = DatabaseUnitOfWork(session)
             rows = await uow.matches.list_active_for_user("ROOM1", uid)
             assert len(rows) == 1
+
+    async def test_solo_right_swipe_inserts_match_found_event(
+        self, runtime_sessionmaker
+    ):
+        """Test that a solo right-swipe inserts a match_found event into session_events."""
+        svc = SwipeMatchService()
+        await _seed_solo_room(runtime_sessionmaker, code="SOLO1")
+        await _auth_session(runtime_sessionmaker, "sess-a", jellyfin_user_id="user-A")
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await svc.swipe(
+                code="SOLO1",
+                request_session={"session_id": "sess-a"},
+                user_id="user-A",
+                movie_id="m1",
+                direction="right",
+                title="Test Movie",
+                thumb="/t.jpg",
+                uow=uow,
+            )
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            events = await uow.session_events.read_after("inst-solo1", after_event_id=0)
+            assert len(events) == 1
+            event = events[0]
+            assert event.event_type == "match_found"
+            payload = json.loads(event.payload_json)
+            assert payload["media_id"] == "m1"
+            assert payload["title"] == "Test Movie"
+            assert payload["thumb"] == "/t.jpg"
+            assert payload["media_type"] == "movie"
+            assert (
+                payload["deep_link"] == "http://test.jellyfin.local/web/#/details?id=m1"
+            )
+
+    async def test_hosted_mutual_right_swipe_inserts_match_found_event(
+        self, runtime_sessionmaker
+    ):
+        """Test that a mutual right-swipe in a hosted room inserts a match_found event."""
+        svc = SwipeMatchService()
+        await _seed_shared_room(runtime_sessionmaker, code="ROOM1")
+        await _auth_session(runtime_sessionmaker, "sess-a", jellyfin_user_id="user-A")
+        await _auth_session(runtime_sessionmaker, "sess-b", jellyfin_user_id="user-B")
+
+        # First user swipes right
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await svc.swipe(
+                code="ROOM1",
+                request_session={"session_id": "sess-a"},
+                user_id="user-A",
+                movie_id="m1",
+                direction="right",
+                title="Test Movie",
+                thumb="/t.jpg",
+                uow=uow,
+            )
+            await session.commit()
+
+        # Second user swipes right — this triggers the match
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await svc.swipe(
+                code="ROOM1",
+                request_session={"session_id": "sess-b"},
+                user_id="user-B",
+                movie_id="m1",
+                direction="right",
+                title="Test Movie",
+                thumb="/t.jpg",
+                uow=uow,
+            )
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            events = await uow.session_events.read_after("inst-room1", after_event_id=0)
+            assert len(events) == 1
+            event = events[0]
+            assert event.event_type == "match_found"
+            payload = json.loads(event.payload_json)
+            assert payload["media_id"] == "m1"
+            assert payload["title"] == "Test Movie"
+
+    async def test_left_swipe_does_not_insert_event(self, runtime_sessionmaker):
+        """Test that a left-swipe does NOT insert any event into session_events."""
+        svc = SwipeMatchService()
+        await _seed_solo_room(runtime_sessionmaker, code="SOLO1")
+        await _auth_session(runtime_sessionmaker, "sess-a", jellyfin_user_id="user-A")
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await svc.swipe(
+                code="SOLO1",
+                request_session={"session_id": "sess-a"},
+                user_id="user-A",
+                movie_id="m1",
+                direction="left",
+                title=None,
+                thumb=None,
+                uow=uow,
+            )
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            events = await uow.session_events.read_after("inst-solo1", after_event_id=0)
+            assert len(events) == 0
+
+    async def test_right_swipe_without_match_does_not_insert_event(
+        self, runtime_sessionmaker
+    ):
+        """Test that a right-swipe without a counterparty does NOT insert a match_found event."""
+        svc = SwipeMatchService()
+        await _seed_shared_room(runtime_sessionmaker, code="ROOM1")
+        await _auth_session(runtime_sessionmaker, "sess-a", jellyfin_user_id="user-A")
+
+        # First user swipes right — no match yet
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await svc.swipe(
+                code="ROOM1",
+                request_session={"session_id": "sess-a"},
+                user_id="user-A",
+                movie_id="m1",
+                direction="right",
+                title="Test Movie",
+                thumb="/t.jpg",
+                uow=uow,
+            )
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            events = await uow.session_events.read_after("inst-room1", after_event_id=0)
+            assert len(events) == 0
+
+    async def test_match_found_event_session_instance_id_matches_room(
+        self, runtime_sessionmaker
+    ):
+        """Test that the event's session_instance_id matches the active instance for the room."""
+        svc = SwipeMatchService()
+        await _seed_solo_room(runtime_sessionmaker, code="SOLO1")
+        await _auth_session(runtime_sessionmaker, "sess-a", jellyfin_user_id="user-A")
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await svc.swipe(
+                code="SOLO1",
+                request_session={"session_id": "sess-a"},
+                user_id="user-A",
+                movie_id="m1",
+                direction="right",
+                title="Test Movie",
+                thumb="/t.jpg",
+                uow=uow,
+            )
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            events = await uow.session_events.read_after("inst-solo1", after_event_id=0)
+            assert len(events) == 1
+            # Verify the instance_id is correct by checking the session_instances table
+            instance = await uow.session_instances.get_by_pairing_code("SOLO1")
+            assert instance is not None
+            assert instance.instance_id == "inst-solo1"
+
+    async def test_undo_swipe_no_last_match_data_recompute(self, runtime_sessionmaker):
+        """Test that undo_swipe no longer calls _recompute_last_match_for_room."""
+        svc = SwipeMatchService()
+        # _recompute_last_match_for_room should not exist
+        assert not hasattr(svc, "_recompute_last_match_for_room") or not callable(
+            getattr(svc, "_recompute_last_match_for_room", None)
+        )
+
+    async def test_delete_match_no_last_match_data_recompute(
+        self, runtime_sessionmaker
+    ):
+        """Test that delete_match no longer calls _recompute_last_match_for_room."""
+        svc = SwipeMatchService()
+        # _recompute_last_match_for_room should not exist
+        assert not hasattr(svc, "_recompute_last_match_for_room") or not callable(
+            getattr(svc, "_recompute_last_match_for_room", None)
+        )
+
+    async def test_match_record_as_last_match_json_removed(self, runtime_sessionmaker):
+        """Test that match_record_as_last_match_json is removed from the module."""
+        from jellyswipe.services import swipe_match
+
+        assert not hasattr(swipe_match, "match_record_as_last_match_json")

--- a/tests/test_swipe_match.py
+++ b/tests/test_swipe_match.py
@@ -8,11 +8,15 @@ from datetime import datetime, timezone
 import jellyswipe.db
 import pytest
 
-from jellyswipe.db_runtime import build_async_sqlite_url, dispose_runtime, get_sessionmaker, initialize_runtime
+from jellyswipe.db_runtime import (
+    build_async_sqlite_url,
+    dispose_runtime,
+    get_sessionmaker,
+    initialize_runtime,
+)
 from jellyswipe.db_uow import DatabaseUnitOfWork
 from jellyswipe.migrations import build_sqlite_url, upgrade_to_head
 from jellyswipe.models.auth_session import AuthSession
-from jellyswipe.models.swipe import Swipe
 from jellyswipe.services.swipe_match import SwipeMatchService
 
 
@@ -39,7 +43,9 @@ async def runtime_sessionmaker(db_path, monkeypatch):
     await dispose_runtime()
 
 
-async def _auth_session(runtime_sessionmaker, session_id: str, *, jellyfin_user_id: str = "verified-user"):
+async def _auth_session(
+    runtime_sessionmaker, session_id: str, *, jellyfin_user_id: str = "verified-user"
+):
     iso = datetime.now(timezone.utc).isoformat()
     async with runtime_sessionmaker() as session:
         session.add(
@@ -53,7 +59,9 @@ async def _auth_session(runtime_sessionmaker, session_id: str, *, jellyfin_user_
         await session.commit()
 
 
-async def _seed_shared_room(runtime_sessionmaker, *, code: str = "ROOM1", deck: dict | None = None):
+async def _seed_shared_room(
+    runtime_sessionmaker, *, code: str = "ROOM1", deck: dict | None = None
+):
     deck_json = json.dumps(deck or {"user-A": 0, "user-B": 0})
     async with runtime_sessionmaker() as session:
         uow = DatabaseUnitOfWork(session)
@@ -70,106 +78,98 @@ async def _seed_shared_room(runtime_sessionmaker, *, code: str = "ROOM1", deck: 
 
 @pytest.mark.anyio
 class TestSwipeMatchService:
-    async def test_dual_right_swipe_sets_last_match_ts_as_sqlite_rowid(self, runtime_sessionmaker):
-        svc = SwipeMatchService()
-        await _seed_shared_room(runtime_sessionmaker)
+    # TODO(ORCH-001): Migrate to test session events instead of last_match_data
+    # async def test_dual_right_swipe_sets_last_match_ts_as_sqlite_rowid(self, runtime_sessionmaker):
+    #     svc = SwipeMatchService()
+    #     await _seed_shared_room(runtime_sessionmaker)
+    #
+    #     async with runtime_sessionmaker() as session:
+    #         uow = DatabaseUnitOfWork(session)
+    #         result = await svc.swipe(
+    #             code="ROOM1",
+    #             request_session={"session_id": "sess-a"},
+    #             user_id="user-A",
+    #             movie_id="m1",
+    #             direction="right",
+    #             title="Movie",
+    #             thumb="/t.jpg",
+    #             uow=uow,
+    #         )
+    #         assert result is None
+    #         await session.commit()
+    #
+    #     async with runtime_sessionmaker() as session:
+    #         uow = DatabaseUnitOfWork(session)
+    #         rec = await uow.rooms.get_room("ROOM1")
+    #         assert rec is not None and rec.last_match_data_json is not None
+    #         lm = json.loads(rec.last_match_data_json)
+    #         assert lm["media_id"] == "m1"
+    #         assert isinstance(lm["ts"], int)
+    pass
 
-        async with runtime_sessionmaker() as session:
-            session.add(
-                Swipe(
-                    room_code="ROOM1",
-                    movie_id="m1",
-                    user_id="user-B",
-                    direction="right",
-                    session_id=None,
-                )
-            )
-            await session.commit()
+    # TODO(ORCH-001): Migrate to test session events instead of last_match_data
+    # async def test_undo_swipe_recomputes_last_match_when_peer_match_survives(self, runtime_sessionmaker):
+    #     svc = SwipeMatchService()
+    #     await _seed_shared_room(runtime_sessionmaker)
+    #
+    #     async with runtime_sessionmaker() as session:
+    #         session.add(
+    #             Swipe(
+    #                 room_code="ROOM1",
+    #                 movie_id="m1",
+    #                 user_id="user-B",
+    #                 direction="right",
+    #                 session_id=None,
+    #             )
+    #         )
+    #         await session.commit()
+    #
+    #     await _auth_session(runtime_sessionmaker, "sess-a", jellyfin_user_id="user-A")
+    #
+    #     async with runtime_sessionmaker() as session:
+    #         uow = DatabaseUnitOfWork(session)
+    #         await svc.swipe(
+    #             code="ROOM1",
+    #             request_session={"session_id": "sess-a"},
+    #             user_id="user-A",
+    #             movie_id="m1",
+    #             direction="right",
+    #             title="Movie",
+    #             thumb="/t.jpg",
+    #             uow=uow,
+    #         )
+    #         await session.commit()
+    #
+    #     async with runtime_sessionmaker() as session:
+    #         uow = DatabaseUnitOfWork(session)
+    #         before = json.loads((await uow.rooms.get_room("ROOM1")).last_match_data_json or "{}")
+    #         assert before["media_id"] == "m1"
+    #
+    #     async with runtime_sessionmaker() as session:
+    #         uow = DatabaseUnitOfWork(session)
+    #         out = await svc.undo_swipe(
+    #             code="ROOM1",
+    #             request_session={"session_id": "sess-a"},
+    #             user_id="user-A",
+    #             movie_id="m1",
+    #             uow=uow,
+    #         )
+    #         assert out["status"] == "undone"
+    #         await session.commit()
+    #
+    #     async with runtime_sessionmaker() as session:
+    #         uow = DatabaseUnitOfWork(session)
+    #         rec = await uow.rooms.get_room("ROOM1")
+    #         survivor = await uow.matches.latest_active_for_room("ROOM1")
+    #         assert survivor is not None
+    #         lm = json.loads(rec.last_match_data_json or "{}")
+    #         assert lm["media_id"] == "m1"
+    #         assert lm["ts"] == survivor.match_order
+    pass
 
-        await _auth_session(runtime_sessionmaker, "sess-a", jellyfin_user_id="user-A")
-
-        async with runtime_sessionmaker() as session:
-            uow = DatabaseUnitOfWork(session)
-            result = await svc.swipe(
-                code="ROOM1",
-                request_session={"session_id": "sess-a"},
-                user_id="user-A",
-                movie_id="m1",
-                direction="right",
-                title="Movie",
-                thumb="/t.jpg",
-                uow=uow,
-            )
-            assert result is None
-            await session.commit()
-
-        async with runtime_sessionmaker() as session:
-            uow = DatabaseUnitOfWork(session)
-            rec = await uow.rooms.get_room("ROOM1")
-            assert rec is not None and rec.last_match_data_json is not None
-            lm = json.loads(rec.last_match_data_json)
-            assert lm["media_id"] == "m1"
-            assert isinstance(lm["ts"], int)
-
-    async def test_undo_swipe_recomputes_last_match_when_peer_match_survives(self, runtime_sessionmaker):
-        svc = SwipeMatchService()
-        await _seed_shared_room(runtime_sessionmaker)
-
-        async with runtime_sessionmaker() as session:
-            session.add(
-                Swipe(
-                    room_code="ROOM1",
-                    movie_id="m1",
-                    user_id="user-B",
-                    direction="right",
-                    session_id=None,
-                )
-            )
-            await session.commit()
-
-        await _auth_session(runtime_sessionmaker, "sess-a", jellyfin_user_id="user-A")
-
-        async with runtime_sessionmaker() as session:
-            uow = DatabaseUnitOfWork(session)
-            await svc.swipe(
-                code="ROOM1",
-                request_session={"session_id": "sess-a"},
-                user_id="user-A",
-                movie_id="m1",
-                direction="right",
-                title="Movie",
-                thumb="/t.jpg",
-                uow=uow,
-            )
-            await session.commit()
-
-        async with runtime_sessionmaker() as session:
-            uow = DatabaseUnitOfWork(session)
-            before = json.loads((await uow.rooms.get_room("ROOM1")).last_match_data_json or "{}")
-            assert before["media_id"] == "m1"
-
-        async with runtime_sessionmaker() as session:
-            uow = DatabaseUnitOfWork(session)
-            out = await svc.undo_swipe(
-                code="ROOM1",
-                request_session={"session_id": "sess-a"},
-                user_id="user-A",
-                movie_id="m1",
-                uow=uow,
-            )
-            assert out["status"] == "undone"
-            await session.commit()
-
-        async with runtime_sessionmaker() as session:
-            uow = DatabaseUnitOfWork(session)
-            rec = await uow.rooms.get_room("ROOM1")
-            survivor = await uow.matches.latest_active_for_room("ROOM1")
-            assert survivor is not None
-            lm = json.loads(rec.last_match_data_json or "{}")
-            assert lm["media_id"] == "m1"
-            assert lm["ts"] == survivor.match_order
-
-    async def test_same_jellyfin_user_separate_sessions_can_match_via_service(self, runtime_sessionmaker):
+    async def test_same_jellyfin_user_separate_sessions_can_match_via_service(
+        self, runtime_sessionmaker
+    ):
         svc = SwipeMatchService()
         await _seed_shared_room(runtime_sessionmaker, deck={"verified-user": 0})
 
@@ -209,4 +209,3 @@ class TestSwipeMatchService:
             uow = DatabaseUnitOfWork(session)
             rows = await uow.matches.list_active_for_user("ROOM1", uid)
             assert len(rows) == 1
-

--- a/tests/test_tv_show_support.py
+++ b/tests/test_tv_show_support.py
@@ -789,7 +789,7 @@ def _sqlite_conn_for_route_tests():
 
 
 def _seed_room(
-    room_code="TEST1", *, ready=0, solo_mode=0, movie_data=None, last_match_data=None
+    room_code="TEST1", *, ready=0, solo_mode=0, movie_data=None
 ):
     """Seed a room row directly into the database for testing."""
     if movie_data is None:
@@ -797,9 +797,9 @@ def _seed_room(
     conn = _sqlite_conn_for_route_tests()
     try:
         conn.execute(
-            "INSERT INTO rooms (pairing_code, movie_data, ready, current_genre, solo_mode, last_match_data) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            (room_code, movie_data, ready, "All", solo_mode, last_match_data),
+            "INSERT INTO rooms (pairing_code, movie_data, ready, current_genre, solo_mode) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (room_code, movie_data, ready, "All", solo_mode),
         )
         conn.commit()
     finally:

--- a/uv.lock
+++ b/uv.lock
@@ -150,6 +150,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.136.1"
 source = { registry = "https://pypi.org/simple" }
@@ -297,6 +306,7 @@ dev = [
     { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
 ]
 
 [package.metadata]
@@ -328,6 +338,7 @@ dev = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
 ]
 
 [[package]]
@@ -504,6 +515,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem Statement

Participants in a hosted Session currently rely on a Server-Sent Events stream that behaves like a latest-state polling feed rather than a replayable Session Event Stream. The stream polls SQLite on an interval, derives Match notifications from a single latest-match snapshot, and cannot guarantee catch-up after refresh or brief disconnects. This creates three user-facing problems:

-     Match notifications can be lost when more than one Match occurs between polls.
-     Reconnecting participants cannot reliably resume from where they left off.
-     Live Session updates have an unnecessary latency floor because subscribers wait for the next poll cycle.

The app needs a Session Event Stream that preserves distinct user-visible Session events, supports reconnect with catch-up, and avoids introducing an external dependency.

## Solution

Replace the current latest-state polling model with a replayable Session Event Stream backed by a SQLite Session Event Ledger. Each hosted Session lifecycle gets a distinct Session Instance identity. User-visible domain changes such as Match creation and shared Session control changes are recorded as discrete typed events in the ledger, with globally monotonic event IDs.

For live delivery, the app will keep SQLite as the source of truth for replay and use an in-process post-commit notifier to wake connected subscribers immediately after committed changes. A newly attached participant receives a Session Bootstrap Event describing current Session state. A reconnecting participant with a valid Session Event Cursor can replay missed events for the same Session Instance. Delivery semantics are at-least-once, so clients deduplicate by event ID.

The rollout is a clean cutover. The old latest-match snapshot stops being part of the live delivery path, and the stream contract moves fully to typed Session events.

https://github.com/andrewthetechie/jelly-swipe/issues/62