### PR TITLE
ticket/ORCH-008: Simplify frontend auth flow in app.js — remove provider probe and login fallback

### DIFF
--- a/jellyswipe/static/app.js
+++ b/jellyswipe/static/app.js
@@ -20,11 +20,6 @@
         }
 
         async function bootstrapJellyfinDelegate() {
-            const provRes = await fetch("/auth/provider", { credentials: "same-origin" });
-            const provData = await provRes.json();
-            if (provData.jellyfin_browser_auth !== "delegate") {
-                return false;
-            }
             const resp = await fetch("/auth/jellyfin-use-server-identity", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
@@ -47,31 +42,7 @@
         }
 
         async function login() {
-            const provRes = await fetch("/auth/provider", { credentials: "same-origin" });
-            const provData = await provRes.json();
-            if (provData.jellyfin_browser_auth === "delegate") {
-                await bootstrapJellyfinDelegate();
-                return;
-            }
-            const username = prompt("Jellyfin account name", "");
-            if (!username) return;
-            const password = prompt("Jellyfin account password", "");
-            if (!password) return;
-            const resp = await fetch("/auth/jellyfin-login", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ username, password }),
-                credentials: "same-origin",
-            });
-            const data = await resp.json();
-            if (!resp.ok || !data.userId) {
-                alert(data.error || "Jellyfin login failed");
-                return;
-            }
-            document.getElementById("login-section").classList.add("hidden");
-            document.getElementById("main-menu").classList.remove("hidden");
-            loadGenres();
-            checkActiveRoom();
+            await bootstrapJellyfinDelegate();
         }
 
         async function checkActiveRoom() {
@@ -1004,33 +975,22 @@
                         loadMovies();
                     }
                 } else {
-                    // Not authenticated — set up login flow
-                    try {
-                        const provRes = await fetch('/auth/provider', { credentials: 'same-origin' });
-                        const provData = await provRes.json();
-                        if (provData.jellyfin_browser_auth === 'delegate') {
-                            document.getElementById('login-btn').innerText = 'Continue';
-                            document.getElementById('login-btn').onclick = () => bootstrapJellyfinDelegate();
-                            const booted = await bootstrapJellyfinDelegate();
-                            if (booted) {
-                                // After delegate bootstrap, check for active room
-                                try {
-                                    const meRes = await fetch('/me', { credentials: 'same-origin' });
-                                    if (meRes.ok) {
-                                        const meData = await meRes.json();
-                                        if (meData.activeRoom) {
-                                            currentRoomCode = meData.activeRoom;
-                                            loadMovies();
-                                        }
-                                    }
-                                } catch(e) {}
+                    // Not authenticated — bootstrap via server delegate
+                    document.getElementById('login-btn').innerText = 'Continue';
+                    document.getElementById('login-btn').onclick = () => bootstrapJellyfinDelegate();
+                    const booted = await bootstrapJellyfinDelegate();
+                    if (booted) {
+                        try {
+                            const meRes = await fetch('/me', { credentials: 'same-origin' });
+                            if (meRes.ok) {
+                                const meData = await meRes.json();
+                                if (meData.activeRoom) {
+                                    currentRoomCode = meData.activeRoom;
+                                    loadMovies();
+                                }
                             }
-                            return;
-                        }
-                    } catch(e) { console.error('Provider probe failed', e); }
-                    // Show login form
-                    document.getElementById('login-btn').innerText = 'Login with Jellyfin';
-                    document.getElementById('login-btn').onclick = login;
+                        } catch(e) {}
+                    }
                 }
             } catch(e) { console.error('Auth check failed', e); }
         };


### PR DESCRIPTION
## Simplify frontend auth flow in app.js — remove provider probe and login fallback

Simplify the frontend authentication flow in `jellyswipe/static/app.js` to remove all references to `/auth/provider` and `/auth/jellyfin-login`, remove the `prompt()` username/password fallback, and collapse the login flow to delegate-only.

**File to modify: `jellyswipe/static/app.js`**

**Change 1 — Simplify `bootstrapJellyfinDelegate()` (lines 22–47):**
- Remove lines 23–27: the `fetch("/auth/provider", ...)` call and the `if (provData.jellyfin_browser_auth !== "delegate") { return false; }` early return.
- The function body starts directly with the `POST /auth/jellyfin-use-server-identity` fetch.
- The rest of the function (success handling, UI updates, `loadGenres()`, `checkActiveRoom()`) stays the same.

**Change 2 — Collapse `login()` (lines 49–75):**
- Replace the entire function body with: `await bootstrapJellyfinDelegate();`
- Delete both `prompt("Jellyfin account name", "")` calls
- Delete the `fetch("/auth/jellyfin-login", ...)` block
- Delete the `/auth/provider` fetch and the delegate/non-delegate branching
- Or: inline the call and delete `login()` entirely if no other code references it after the DOMContentLoaded simplification.

**Change 3 — Simplify DOMContentLoaded not-authenticated branch (lines 1006–1034):**
The current code when `/me` returns non-OK:
```javascript
// Not authenticated — set up login flow
try {
    const provRes = await fetch("/auth/provider", { credentials: 'same-origin' });
    const provData = await provRes.json();
    if (provData.jellyfin_browser_auth === 'delegate') {
        document.getElementById('login-btn').innerText = 'Continue';
        document.getElementById('login-btn').onclick = () => bootstrapJellyfinDelegate();
        const booted = await bootstrapJellyfinDelegate();
        if (booted) { /* check active room */ }
        return;
    }
} catch(e) { console.error('Provider probe failed', e); }
// Show login form
document.getElementById('login-btn').innerText = 'Login with Jellyfin';
document.getElementById('login-btn').onclick = login;
```

Replace with:
```javascript
// Not authenticated — bootstrap via server delegate
document.getElementById('login-btn').innerText = 'Continue';
document.getElementById('login-btn').onclick = () => bootstrapJellyfinDelegate();
const booted = await bootstrapJellyfinDelegate();
if (booted) {
    try {
        const meRes = await fetch('/me', { credentials: 'same-origin' });
        if (meRes.ok) {
            const meData = await meRes.json();
            if (meData.activeRoom) {
                currentRoomCode = meData.activeRoom;
                loadMovies();
            }
        }
    } catch(e) {}
}
```

This removes the `/auth/provider` probe, the `provData.jellyfin_browser_auth` check, and the "Login with Jellyfin" username/password fallback entirely.

**No changes to:**
- `relogin-btn` handler (line 584–588) — just reloads the page, unchanged
- HTML template (`templates/index.html`) — no inline handlers, all wiring is in app.js


### Acceptance Criteria

1. `bootstrapJellyfinDelegate()` no longer fetches `/auth/provider` — it directly calls `POST /auth/jellyfin-use-server-identity` and handles the result
2. `login()` is a one-liner: `async function login() { await bootstrapJellyfinDelegate(); }` (or inlined entirely if no caller remains after DOMContentLoaded simplification)
3. `login()` contains no `prompt(...)` calls
4. `login()` contains no reference to `/auth/jellyfin-login`
5. `app.js` contains no `fetch("/auth/provider", ...)` calls
6. `app.js` contains no `fetch("/auth/jellyfin-login", ...)` calls
7. `app.js` contains no `provData.jellyfin_browser_auth` or provider-shape gate checks
8. The DOMContentLoaded not-authenticated branch (around line 1006) directly calls `bootstrapJellyfinDelegate()` without probing `/auth/provider` first
9. The "Login with Jellyfin" fallback branch (setting `onclick = login` and button text "Login with Jellyfin") is deleted
10. The `relogin-btn` handler (page reload) is unchanged
11. All existing UI functionality works: login button authenticates via server delegate, session expiry reload works, room creation/joining works


---
Ticket: `ORCH-008`