### PR TITLE
ticket/ORCH-010: Update README.md to remove username/password auth references

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@
 **Fork:** This project was forked from [Bergasha/kino-swipe](https://github.com/Bergasha/kino-swipe). It is maintained by [@AndrewTheTechie](https://github.com/AndrewTheTechie).
 
 Always trying to decide on a movie to watch together?, This may be the fun solution you've been looking for.
-Dating app style swipe right for like swipe left for nope, If you both swipe right on the 
+Dating app style swipe right for like swipe left for nope, If you both swipe right on the
 same movie, IT'S A MATCH!!
 
 ## Screenshots
+
 <details>
 <summary>Click to expand screenshots</summary>
 
@@ -23,6 +24,7 @@ same movie, IT'S A MATCH!!
 </details>
 
 ## Features
+
 - **Jellyfin Integration:** Connects directly to your server to pull random movies.
 - **Real-Time Sync:** Host a room, share a 4-digit code, and swipe with a partner instantly.
 - **Visual Feedback:** Faint Red/Green "glow" overlays that react as you drag the posters left or right.
@@ -32,7 +34,7 @@ same movie, IT'S A MATCH!!
 - **PWA Support:** Add it to your Home Screen for a native app feel.
 - **Match Notifications:** Instant alerts when you both swipe right on the same movie.
 - **Match History** All matches now live in Match History until you're ready to delete them.
-- **Solo Mode** Flying solo? no worries, just host session and flick the solo toggle. (Every right swipe saves to Match History) 
+- **Solo Mode** Flying solo? no worries, just host session and flick the solo toggle. (Every right swipe saves to Match History)
 
 ## Media backend: Jellyfin
 
@@ -40,15 +42,13 @@ This application connects directly to a **Jellyfin** server to pull random movie
 
 ### Environment variables
 
-| Variable | Required when | Description |
-|----------|-----------------|-------------|
-| `FLASK_SECRET` | Always | Flask session secret. |
-| `TMDB_API_KEY` | Always | TMDB API key (trailers / cast). |
-| `JELLYFIN_URL` | Always | Base URL of your Jellyfin server (no trailing slash). |
-| `JELLYFIN_API_KEY` | With API key | API key for unattended server access. |
-| `JELLYFIN_USERNAME` | With password (if no API key) | Account username for Jellyfin. |
-| `JELLYFIN_PASSWORD` | With username (if no API key) | Account password for Jellyfin. |
-| `JELLYFIN_DEVICE_ID` | Optional | Stable device id string sent with Jellyfin auth headers (default is built-in). |
+| Variable             | Required when | Description                                                                    |
+| -------------------- | ------------- | ------------------------------------------------------------------------------ |
+| `FLASK_SECRET`       | Always        | Flask session secret.                                                          |
+| `TMDB_ACCESS_TOKEN`  | Always        | TMDB API key (trailers / cast).                                                |
+| `JELLYFIN_URL`       | Always        | Base URL of your Jellyfin server (no trailing slash).                          |
+| `JELLYFIN_API_KEY`   | Always        | API key for unattended server access.                                          |
+| `JELLYFIN_DEVICE_ID` | Optional      | Stable device id string sent with Jellyfin auth headers (default is built-in). |
 
 ### Jellyfin user identity contract
 
@@ -64,8 +64,8 @@ and for user-scoped list actions must include a Jellyfin user token via:
 
 ### Jellyfin operator checks (manual)
 
-1. **Happy path:** With valid `JELLYFIN_URL` and credentials, start the app and hit provider endpoints (`/genres`, `/movies`, `/jellyfin/server-info`). Confirm logs show **no** API keys or access tokens.
-2. **Re-login / reset:** Revoke the API key or set a wrong password, restart or trigger a code path that calls `reset()` on the provider, restore valid credentials, and confirm authenticated **`/Items`** succeeds again.
+1. **Happy path:** With valid `JELLYFIN_URL` and `JELLYFIN_API_KEY`, start the app and hit provider endpoints (`/genres`, `/movies`, `/jellyfin/server-info`). Confirm logs show **no** API keys or access tokens.
+2. **API key rotation:** Revoke the API key, restart, confirm failure, create a new API key, restart, and confirm authenticated **`/Items`** succeeds again.
 3. **After recovery:** Restart the process (or rely on the next provider use after `reset()`) and hit `/genres` or create/join a room so `get_provider()` re-authenticates — you should be back to a working deck without pasting any tokens into logs or tickets.
 
 ### Minimal `.env` example
@@ -77,22 +77,14 @@ TMDB_ACCESS_TOKEN=your-tmdb-read-access-token
 FLASK_SECRET=long-random-string
 ```
 
-Alternatively, use username/password authentication instead of API key:
-
-```env
-JELLYFIN_URL=http://your-jellyfin-host:8096
-JELLYFIN_USERNAME=your-username
-JELLYFIN_PASSWORD=your-password
-TMDB_ACCESS_TOKEN=your-tmdb-read-access-token
-FLASK_SECRET=long-random-string
-```
-
 ## Requirements
+
 - **Media backend:** Jellyfin — see [Media backend: Jellyfin](#media-backend-jellyfin) and the env table above.
 - **TMDB Read Access Token** — required at startup (trailers/cast); keep the token private.
 - **HTTPS/Reverse Proxy:** To "Install" the app as a PWA on your phone so it looks like an app, you must access it over an HTTPS connection. If you access it over local ip, it will work in the browser but when added to homescreen it will just act as a shortcut not like an app.
 
 ## TMDB API instructions
+
 Only required if you want trailers to work on the rear of the movie posters.
 
 1. Go to https://www.themoviedb.org/settings/api
@@ -104,6 +96,7 @@ Only required if you want trailers to work on the rear of the movie posters.
 ## Deployment
 
 ### Option 1: Docker (Recommended)
+
 Copy and paste this into your terminal. Replace the variables with your specific setup.
 
 ```bash
@@ -125,6 +118,7 @@ services:
 ```
 
 **Option 2 — Docker Run**
+
 ```bash
 docker run -d \
   --name jelly-swipe \
@@ -170,11 +164,13 @@ This creates a virtual environment in `.venv/` and installs all dependencies fro
 ### Running the app locally
 
 **Development server (auto-reload):**
+
 ```bash
 uv run python -m jellyswipe.bootstrap
 ```
 
 **Production-style server (for testing):**
+
 ```bash
 uv run python -m jellyswipe.bootstrap
 ```
@@ -182,11 +178,13 @@ uv run python -m jellyswipe.bootstrap
 ### Managing dependencies
 
 **Add a new dependency:**
+
 ```bash
 uv add <package-name>
 ```
 
 **Update the lockfile after dependency changes:**
+
 ```bash
 uv lock --upgrade
 ```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -304,9 +304,6 @@ class FakeProvider:
     def fetch_library_image(self, path):
         return (b"", "image/jpeg")
 
-    def authenticate_user_session(self, username, password):
-        return {"token": self._token, "user_id": self._user_id}
-
 
 @pytest.fixture
 def app(db_path, monkeypatch):

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -70,19 +70,19 @@ class TestRequestIdPropagation:
     """Integration tests for RequestId in HTTP responses."""
 
     def test_response_has_x_request_id_header(self, client):
-        resp = client.get("/auth/provider")
+        resp = client.get("/")
         assert "X-Request-Id" in resp.headers, "Missing X-Request-Id header"
 
     def test_x_request_id_matches_format(self, client):
-        resp = client.get("/auth/provider")
+        resp = client.get("/")
         rid = resp.headers.get("X-Request-Id", "")
         assert re.match(r"^req_\d+_[0-9a-f]{8}$", rid), (
             f"X-Request-Id '{rid}' doesn't match expected format"
         )
 
     def test_different_requests_get_different_ids(self, client):
-        resp1 = client.get("/auth/provider")
-        resp2 = client.get("/auth/provider")
+        resp1 = client.get("/")
+        resp2 = client.get("/")
         rid1 = resp1.headers.get("X-Request-Id", "")
         rid2 = resp2.headers.get("X-Request-Id", "")
         assert rid1 != rid2, "Consecutive requests should get different RequestIds"
@@ -328,15 +328,6 @@ class TestErrorLogging:
 
 class TestAdditionalRoutes:
     """Additional coverage for routes not covered by main test classes."""
-
-    @pytest.mark.skip(
-        reason="ORCH-007: /auth/jellyfin-login route deleted, test cleanup in separate ticket"
-    )
-    def test_400_includes_request_id(self, client):
-        resp = client.post("/auth/jellyfin-login", json={})
-        resp.json()
-        assert resp.status_code == 400
-        assert "X-Request-Id" in resp.headers
 
     def test_404_join_room_includes_request_id(self, client):
         from datetime import datetime, timezone

--- a/tests/test_jellyfin_library.py
+++ b/tests/test_jellyfin_library.py
@@ -3,7 +3,6 @@
 from types import SimpleNamespace
 
 import pytest
-import requests
 
 from jellyswipe.jellyfin_library import JellyfinLibraryProvider
 
@@ -34,141 +33,6 @@ def test_auth_with_api_key(mocker, monkeypatch):
 
     # Verify Session.request was NOT called (bypasses _login_from_env)
     mock_request.assert_not_called()
-
-
-@pytest.mark.skip(
-    reason="ORCH-007: username/password auth removed, test cleanup in separate ticket"
-)
-def test_auth_with_username_password_success(mocker, monkeypatch):
-    """Test authentication with username/password makes API call and extracts token."""
-    # Mock environment variables
-    monkeypatch.setenv("JELLYFIN_URL", "http://test.local")
-    monkeypatch.setenv("JELLYFIN_USERNAME", "testuser")
-    monkeypatch.setenv("JELLYFIN_PASSWORD", "testpass")
-    monkeypatch.setenv(
-        "JELLYFIN_API_KEY", ""
-    )  # Clear API key to force username/password
-
-    # Mock Session.request to return successful auth response
-    mock_response = mocker.MagicMock()
-    mock_response.ok = True
-    mock_response.status_code = 200
-    mock_response.json.return_value = {"AccessToken": "user-token-123"}
-    mock_session = mocker.MagicMock()
-    mock_session.post.return_value = mock_response
-    mocker.patch(
-        "jellyswipe.jellyfin_library.requests.Session", return_value=mock_session
-    )
-
-    # Create provider and authenticate
-    provider = JellyfinLibraryProvider("http://test.local")
-    provider.ensure_authenticated()
-
-    # Verify POST to auth endpoint was called
-    mock_session.post.assert_called_once()
-    call_args = mock_session.post.call_args
-    url = call_args[0][0] if call_args[0] else call_args[1].get("url", "")
-    assert "AuthenticateByName" in url
-    assert call_args[1]["json"]["Username"] == "testuser"
-    assert call_args[1]["json"]["Pw"] == "testpass"
-
-    # Verify token is extracted
-    assert provider._access_token == "user-token-123"
-
-
-@pytest.mark.skip(
-    reason="ORCH-007: username/password auth removed, test cleanup in separate ticket"
-)
-def test_auth_with_username_password_network_error(mocker, monkeypatch):
-    """Test authentication with network error raises RuntimeError."""
-    # Mock environment variables
-    monkeypatch.setenv("JELLYFIN_URL", "http://test.local")
-    monkeypatch.setenv("JELLYFIN_USERNAME", "testuser")
-    monkeypatch.setenv("JELLYFIN_PASSWORD", "testpass")
-    monkeypatch.setenv("JELLYFIN_API_KEY", "")
-
-    # Mock Session.request to raise network exception
-    mock_session = mocker.MagicMock()
-    mock_session.post.side_effect = requests.RequestException("Network error")
-    mocker.patch(
-        "jellyswipe.jellyfin_library.requests.Session", return_value=mock_session
-    )
-
-    # Create provider and attempt authentication
-    provider = JellyfinLibraryProvider("http://test.local")
-
-    # Verify RuntimeError is raised
-    with pytest.raises(
-        RuntimeError, match="Jellyfin authentication failed \\(network error\\)"
-    ):
-        provider.ensure_authenticated()
-
-
-@pytest.mark.skip(
-    reason="ORCH-007: username/password auth removed, test cleanup in separate ticket"
-)
-def test_auth_with_invalid_credentials(mocker, monkeypatch):
-    """Test authentication with invalid credentials raises RuntimeError."""
-    # Mock environment variables
-    monkeypatch.setenv("JELLYFIN_URL", "http://test.local")
-    monkeypatch.setenv("JELLYFIN_USERNAME", "testuser")
-    monkeypatch.setenv("JELLYFIN_PASSWORD", "wrongpass")
-    monkeypatch.setenv("JELLYFIN_API_KEY", "")
-
-    # Mock Session.request to return 401
-    mock_response = mocker.MagicMock()
-    mock_response.ok = False
-    mock_response.status_code = 401
-    mock_session = mocker.MagicMock()
-    mock_session.post.return_value = mock_response
-    mocker.patch(
-        "jellyswipe.jellyfin_library.requests.Session", return_value=mock_session
-    )
-
-    # Create provider and attempt authentication
-    provider = JellyfinLibraryProvider("http://test.local")
-
-    # Verify RuntimeError is raised
-    with pytest.raises(
-        RuntimeError,
-        match="Jellyfin authentication failed \\(check username, password, or server URL\\)",
-    ):
-        provider.ensure_authenticated()
-
-
-@pytest.mark.skip(
-    reason="ORCH-007: username/password auth removed, test cleanup in separate ticket"
-)
-def test_auth_with_missing_token_in_response(mocker, monkeypatch):
-    """Test authentication when response lacks AccessToken raises RuntimeError."""
-    # Mock environment variables
-    monkeypatch.setenv("JELLYFIN_URL", "http://test.local")
-    monkeypatch.setenv("JELLYFIN_USERNAME", "testuser")
-    monkeypatch.setenv("JELLYFIN_PASSWORD", "testpass")
-    monkeypatch.setenv("JELLYFIN_API_KEY", "")
-
-    # Mock Session.request to return 200 OK but without AccessToken
-    mock_response = mocker.MagicMock()
-    mock_response.ok = True
-    mock_response.status_code = 200
-    mock_response.json.return_value = {
-        "User": {"Id": "user-123"}
-    }  # Missing AccessToken
-    mock_session = mocker.MagicMock()
-    mock_session.post.return_value = mock_response
-    mocker.patch(
-        "jellyswipe.jellyfin_library.requests.Session", return_value=mock_session
-    )
-
-    # Create provider and attempt authentication
-    provider = JellyfinLibraryProvider("http://test.local")
-
-    # Verify RuntimeError is raised
-    with pytest.raises(
-        RuntimeError,
-        match="Jellyfin authentication failed \\(no access token in response\\)",
-    ):
-        provider.ensure_authenticated()
 
 
 # ---- User ID Resolution Tests ----
@@ -287,56 +151,6 @@ def test_user_id_from_users_me_endpoint(mocker, monkeypatch):
     user_id2 = provider._user_id()
     assert user_id2 == "user-123"
     assert mock_session.request.call_count == 1  # Only one HTTP call
-
-
-def test_user_id_fallback_to_users_list(mocker, monkeypatch):
-    """Test user ID resolution falls back to /Users when /Users/Me fails."""
-    # Mock environment variables
-    monkeypatch.setenv("JELLYFIN_URL", "http://test.local")
-    monkeypatch.setenv("JELLYFIN_API_KEY", "test-api-key")
-    monkeypatch.setenv("JELLYFIN_USERNAME", "testuser")
-
-    # Create mock session
-    mock_session = mocker.MagicMock()
-
-    # Mock _api() to fail (simulating /Users/Me failure)
-    def mock_api_fail(method, path, **kwargs):
-        raise RuntimeError("API call failed")
-
-    # Mock direct .get() call for /Users endpoint
-    mock_response = mocker.MagicMock()
-    mock_response.ok = True
-    mock_response.status_code = 200
-    mock_response.json.return_value = [
-        {"Id": "user-456", "Name": "testuser"},
-        {"Id": "user-789", "Name": "otheruser"},
-    ]
-    mock_session.get.return_value = mock_response
-
-    mocker.patch(
-        "jellyswipe.jellyfin_library.requests.Session", return_value=mock_session
-    )
-
-    # Create provider and set access token
-    provider = JellyfinLibraryProvider("http://test.local")
-    provider._access_token = "test-token"
-
-    # Patch _api to fail for /Users/Me
-    original_api = provider._api
-
-    def patched_api(method, path, **kwargs):
-        if path == "/Users/Me":
-            raise RuntimeError("API call failed")
-        return original_api(method, path, **kwargs)
-
-    provider._api = patched_api
-
-    # Call _user_id
-    user_id = provider._user_id()
-
-    # Verify user matching JELLYFIN_USERNAME is selected
-    assert user_id == "user-456"
-    assert provider._cached_user_id == "user-456"
 
 
 def test_user_id_fallback_to_first_user(mocker, monkeypatch):
@@ -1054,55 +868,6 @@ def test_fetch_library_image_invalid_path(mocker, monkeypatch):
     # Verify PermissionError is raised for invalid path
     with pytest.raises(PermissionError, match="Invalid Jellyfin image path"):
         provider.fetch_library_image("invalid/path")
-
-
-@pytest.mark.skip(
-    reason="ORCH-007: authenticate_user_session method removed, test cleanup in separate ticket"
-)
-def test_authenticate_user_session_missing_credentials(mocker, monkeypatch):
-    """Test that authenticate_user_session raises RuntimeError for empty credentials."""
-    # Mock environment variables
-    monkeypatch.setenv("JELLYFIN_URL", "http://test.local")
-    monkeypatch.setenv("JELLYFIN_API_KEY", "test-api-key")
-
-    # Create provider
-    provider = JellyfinLibraryProvider("http://test.local")
-
-    # Verify RuntimeError is raised for empty username/password
-    with pytest.raises(
-        RuntimeError, match="Jellyfin login failed \\(missing username/password\\)"
-    ):
-        provider.authenticate_user_session("", "")
-
-
-@pytest.mark.skip(
-    reason="ORCH-007: authenticate_user_session method removed, test cleanup in separate ticket"
-)
-def test_authenticate_user_session_missing_token_or_user_id(mocker, monkeypatch):
-    """Test that authenticate_user_session raises RuntimeError when response lacks token or user_id."""
-    # Mock environment variables
-    monkeypatch.setenv("JELLYFIN_URL", "http://test.local")
-    monkeypatch.setenv("JELLYFIN_API_KEY", "test-api-key")
-
-    # Mock Session.request to return response with AccessToken but missing User.Id
-    mock_response = mocker.MagicMock()
-    mock_response.ok = True
-    mock_response.status_code = 200
-    mock_response.json.return_value = {"AccessToken": "token-123"}  # Missing User.Id
-    mock_session = mocker.MagicMock()
-    mock_session.post.return_value = mock_response
-    mocker.patch(
-        "jellyswipe.jellyfin_library.requests.Session", return_value=mock_session
-    )
-
-    # Create provider
-    provider = JellyfinLibraryProvider("http://test.local")
-
-    # Verify RuntimeError is raised
-    with pytest.raises(
-        RuntimeError, match="Jellyfin login failed \\(missing token or user id\\)"
-    ):
-        provider.authenticate_user_session("user", "pass")
 
 
 def test_api_non_json_response(mocker, monkeypatch):

--- a/tests/test_route_authorization.py
+++ b/tests/test_route_authorization.py
@@ -107,74 +107,7 @@ ROUTE_CASES: Tuple[Tuple[str, str, Optional[Dict[str, Any]]], ...] = (
 )
 
 
-# --- Login/Delegate Route Tests ---
-
-
-@pytest.mark.skip(
-    reason="ORCH-007: /auth/jellyfin-login route deleted, test cleanup in separate ticket"
-)
-def test_login_returns_userId_no_authToken(db_connection, client_real_auth):
-    """Login endpoint stores token in vault and returns only userId."""
-    response = client_real_auth.post(
-        "/auth/jellyfin-login",
-        json={
-            "username": "testuser",
-            "password": "testpass",
-        },
-    )
-    assert response.status_code == 200
-    data = response.json()
-    assert "userId" in data
-    assert "authToken" not in data
-
-
-@pytest.mark.skip(
-    reason="ORCH-007: /auth/jellyfin-login route deleted, test cleanup in separate ticket"
-)
-def test_login_creates_vault_entry(db_connection, client_real_auth):
-    """Login creates a auth_sessions row and sets session_id cookie."""
-    response = client_real_auth.post(
-        "/auth/jellyfin-login",
-        json={
-            "username": "testuser",
-            "password": "testpass",
-        },
-    )
-    assert response.status_code == 200
-    # Verify vault entry was created
-    count = db_connection.execute("SELECT COUNT(*) FROM auth_sessions").fetchone()[0]
-    assert count == 1
-    row = db_connection.execute(
-        "SELECT jellyfin_token, jellyfin_user_id FROM auth_sessions"
-    ).fetchone()
-    assert row["jellyfin_token"] == "valid-token"
-    assert row["jellyfin_user_id"] == "verified-user"
-
-
-@pytest.mark.skip(
-    reason="ORCH-007: /auth/jellyfin-login route deleted, test cleanup in separate ticket"
-)
-def test_login_sets_session_cookie(db_connection, client_real_auth):
-    """Login sets session_id in the session cookie."""
-    response = client_real_auth.post(
-        "/auth/jellyfin-login",
-        json={
-            "username": "testuser",
-            "password": "testpass",
-        },
-    )
-    assert response.status_code == 200
-    # Verify auth works on protected endpoint (session was set)
-    resp2 = client_real_auth.get("/auth/provider")
-    assert resp2.status_code == 200
-
-
-@pytest.mark.skip(
-    reason="ORCH-007: /auth/jellyfin-login route deleted, test cleanup in separate ticket"
-)
-def test_login_missing_credentials_returns_400(db_connection, client_real_auth):
-    response = client_real_auth.post("/auth/jellyfin-login", json={})
-    assert response.status_code == 400
+# --- Delegate Route Tests ---
 
 
 def test_delegate_returns_userId(db_connection, client_real_auth):
@@ -197,30 +130,6 @@ def test_delegate_creates_vault_entry(db_connection, client_real_auth):
     ).fetchone()
     assert row["jellyfin_token"] == "valid-token"
     assert row["jellyfin_user_id"] == "verified-user"
-
-
-@pytest.mark.skip(
-    reason="ORCH-007: /auth/provider route deleted, test cleanup in separate ticket"
-)
-def test_delegate_no_session_flag(db_connection, client_real_auth):
-    """Delegate no longer sets jf_delegate_server_identity session flag."""
-    response = client_real_auth.post("/auth/jellyfin-use-server-identity")
-    assert response.status_code == 200
-    # Verify session is live by calling auth endpoint
-    resp2 = client_real_auth.get("/auth/provider")
-    assert resp2.status_code == 200
-
-
-@pytest.mark.skip(
-    reason="ORCH-007: /auth/provider route deleted, test cleanup in separate ticket"
-)
-def test_delegate_sets_session_cookie(db_connection, client_real_auth):
-    """Delegate sets session_id in the session cookie."""
-    response = client_real_auth.post("/auth/jellyfin-use-server-identity")
-    assert response.status_code == 200
-    # Verify session is live by calling auth endpoint
-    resp2 = client_real_auth.get("/auth/provider")
-    assert resp2.status_code == 200
 
 
 # --- Mutation Route Authorization Tests ---

--- a/tests/test_routes_auth.py
+++ b/tests/test_routes_auth.py
@@ -1,7 +1,7 @@
-"""Comprehensive auth route tests for all 3 authentication endpoints.
+"""Comprehensive auth route tests for delegate identity and 404 regression guards.
 
-Covers /auth/provider, /auth/jellyfin-use-server-identity, and /auth/jellyfin-login
-with header-spoof protection tests (EPIC-01).
+Covers /auth/jellyfin-use-server-identity with header-spoof protection tests (EPIC-01),
+404 regression tests for removed routes, and E2E delegate login/logout flow.
 """
 
 from unittest.mock import MagicMock
@@ -10,30 +10,6 @@ import jellyswipe
 import pytest
 
 SPOOF_HEADERS = ("X-Provider-User-Id", "X-Jellyfin-User-Id", "X-Emby-UserId")
-
-
-# ---------------------------------------------------------------------------
-# /auth/provider tests
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.skip(
-    reason="ORCH-007: /auth/provider route deleted, test cleanup in separate ticket"
-)
-def test_auth_provider_returns_jellyfin(client_real_auth):
-    """GET /auth/provider returns 200 with correct provider JSON."""
-    response = client_real_auth.get("/auth/provider")
-    assert response.status_code == 200
-    assert response.json() == {
-        "provider": "jellyfin",
-        "jellyfin_browser_auth": "delegate",
-    }
-
-
-def test_auth_provider_content_type_is_json(client_real_auth):
-    """GET /auth/provider returns application/json content type."""
-    response = client_real_auth.get("/auth/provider")
-    assert "application/json" in response.headers["content-type"]
 
 
 # ---------------------------------------------------------------------------
@@ -48,17 +24,6 @@ def test_jellyfin_use_server_identity_success(client_real_auth):
     assert response.json() == {"userId": "verified-user"}
 
 
-@pytest.mark.skip(
-    reason="ORCH-007: /auth/provider route deleted, test cleanup in separate ticket"
-)
-def test_jellyfin_use_server_identity_sets_session_flag(client_real_auth):
-    """Successful delegate identity sets session_id in session (vault-based auth)."""
-    client_real_auth.post("/auth/jellyfin-use-server-identity")
-    # Verify session is live by calling an auth endpoint
-    resp2 = client_real_auth.get("/auth/provider")
-    assert resp2.status_code == 200
-
-
 def test_jellyfin_use_server_identity_runtime_error_returns_401(
     client_real_auth, monkeypatch
 ):
@@ -70,98 +35,6 @@ def test_jellyfin_use_server_identity_runtime_error_returns_401(
         MagicMock(side_effect=RuntimeError("unavailable")),
     )
     response = client_real_auth.post("/auth/jellyfin-use-server-identity")
-    assert response.status_code == 401
-    assert "error" in response.json()
-
-
-@pytest.mark.skip(
-    reason="ORCH-007: /auth/provider route deleted, test cleanup in separate ticket"
-)
-def test_jellyfin_use_server_identity_failure_no_session_flag(
-    client_real_auth, monkeypatch
-):
-    """Failed delegate identity does NOT set session flag."""
-    fake = jellyswipe._provider_singleton
-    monkeypatch.setattr(
-        fake,
-        "server_access_token_for_delegate",
-        MagicMock(side_effect=RuntimeError("unavailable")),
-    )
-    client_real_auth.post("/auth/jellyfin-use-server-identity")
-    # Verify no session was created by calling an auth endpoint
-    resp2 = client_real_auth.get("/auth/provider")
-    assert resp2.status_code == 200
-
-
-# ---------------------------------------------------------------------------
-# /auth/jellyfin-login tests
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.skip(
-    reason="ORCH-007: /auth/jellyfin-login route deleted, test cleanup in separate ticket"
-)
-def test_jellyfin_login_success(client_real_auth):
-    """POST /auth/jellyfin-login with valid credentials returns userId only (token stored in vault)."""
-    response = client_real_auth.post(
-        "/auth/jellyfin-login",
-        json={"username": "testuser", "password": "testpass"},
-    )
-    assert response.status_code == 200
-    data = response.json()
-    assert "userId" in data
-    assert data["userId"] == "verified-user"
-    assert "authToken" not in data
-
-
-@pytest.mark.skip(
-    reason="ORCH-007: /auth/jellyfin-login route deleted, test cleanup in separate ticket"
-)
-def test_jellyfin_login_missing_username_returns_400(client_real_auth):
-    """POST /auth/jellyfin-login without username returns 400."""
-    response = client_real_auth.post(
-        "/auth/jellyfin-login",
-        json={"password": "testpass"},
-    )
-    assert response.status_code == 400
-
-
-@pytest.mark.skip(
-    reason="ORCH-007: /auth/jellyfin-login route deleted, test cleanup in separate ticket"
-)
-def test_jellyfin_login_missing_password_returns_400(client_real_auth):
-    """POST /auth/jellyfin-login without password returns 400."""
-    response = client_real_auth.post(
-        "/auth/jellyfin-login",
-        json={"username": "testuser"},
-    )
-    assert response.status_code == 400
-
-
-@pytest.mark.skip(
-    reason="ORCH-007: /auth/jellyfin-login route deleted, test cleanup in separate ticket"
-)
-def test_jellyfin_login_empty_body_returns_400(client_real_auth):
-    """POST /auth/jellyfin-login with empty body returns 400."""
-    response = client_real_auth.post("/auth/jellyfin-login", json={})
-    assert response.status_code == 400
-
-
-@pytest.mark.skip(
-    reason="ORCH-007: /auth/jellyfin-login route deleted, test cleanup in separate ticket"
-)
-def test_jellyfin_login_auth_failure_returns_401(client_real_auth, monkeypatch):
-    """POST /auth/jellyfin-login when provider raises exception returns 401."""
-    fake = jellyswipe._provider_singleton
-    monkeypatch.setattr(
-        fake,
-        "authenticate_user_session",
-        MagicMock(side_effect=Exception("auth failed")),
-    )
-    response = client_real_auth.post(
-        "/auth/jellyfin-login",
-        json={"username": "testuser", "password": "testpass"},
-    )
     assert response.status_code == 401
     assert "error" in response.json()
 
@@ -184,34 +57,47 @@ def test_jellyfin_use_server_identity_ignores_spoofed_headers(
     assert response.json()["userId"] == "verified-user"
 
 
-@pytest.mark.skip(
-    reason="ORCH-007: /auth/jellyfin-login route deleted, test cleanup in separate ticket"
-)
-@pytest.mark.parametrize("spoof_header", SPOOF_HEADERS)
-def test_jellyfin_login_ignores_spoofed_headers(client_real_auth, spoof_header):
-    """Login endpoint ignores spoofed identity headers."""
+# ---------------------------------------------------------------------------
+# 404 Regression tests for removed routes
+# ---------------------------------------------------------------------------
+
+
+def test_jellyfin_login_returns_404(client_real_auth):
+    """POST /auth/jellyfin-login returns 404 (route removed)."""
     response = client_real_auth.post(
         "/auth/jellyfin-login",
         json={"username": "testuser", "password": "testpass"},
-        headers={spoof_header: "attacker-id"},
     )
-    assert response.status_code == 200
-    data = response.json()
-    assert data["userId"] == "verified-user"
+    assert response.status_code == 404
 
 
-@pytest.mark.skip(
-    reason="ORCH-007: /auth/provider route deleted, test cleanup in separate ticket"
-)
-@pytest.mark.parametrize("spoof_header", SPOOF_HEADERS)
-def test_auth_provider_ignores_spoofed_headers(client_real_auth, spoof_header):
-    """Provider endpoint ignores spoofed headers (static endpoint)."""
-    response = client_real_auth.get(
-        "/auth/provider",
-        headers={spoof_header: "attacker-id"},
-    )
-    assert response.status_code == 200
-    assert response.json() == {
-        "provider": "jellyfin",
-        "jellyfin_browser_auth": "delegate",
-    }
+def test_auth_provider_returns_404(client_real_auth):
+    """GET /auth/provider returns 404 (route removed)."""
+    response = client_real_auth.get("/auth/provider")
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# E2E delegate login/logout flow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_delegate_login_me_logout_flow(client_real_auth):
+    """Full E2E: delegate login -> GET /me -> logout -> GET /me returns 401."""
+    # Step 1: Delegate login
+    resp = client_real_auth.post("/auth/jellyfin-use-server-identity")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "userId" in body
+    # Step 2: Authenticated request
+    me = client_real_auth.get("/me")
+    assert me.status_code == 200
+    assert "userId" in me.json()
+    # Step 3: Logout
+    logout = client_real_auth.post("/auth/logout")
+    assert logout.status_code == 200
+    assert logout.json()["status"] == "logged_out"
+    # Step 4: Unauthenticated
+    me2 = client_real_auth.get("/me")
+    assert me2.status_code == 401

--- a/tests/test_routes_xss.py
+++ b/tests/test_routes_xss.py
@@ -10,7 +10,6 @@ import json
 import os
 from unittest.mock import MagicMock
 
-import pytest
 import sqlite3
 
 from jellyswipe.db_paths import application_db_path
@@ -154,7 +153,7 @@ class TestLayer3CSPHeader:
         assert "Content-Security-Policy" in response.headers
         assert response.headers["Content-Security-Policy"] != ""
 
-        response = client.get("/auth/provider")
+        response = client.get("/me")
         assert "Content-Security-Policy" in response.headers
         assert response.headers["Content-Security-Policy"] != ""
 
@@ -526,20 +525,6 @@ def test_proxy_valid_uuid_with_dashes_accepted(client):
 # ---------------------------------------------------------------------------
 # Section 3: Input validation tests (D-16, D-17)
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.skip(
-    reason="ORCH-007: /auth/jellyfin-login route deleted, test cleanup in separate ticket"
-)
-def test_login_xss_username_not_echoed(client):
-    response = client.post(
-        "/auth/jellyfin-login",
-        json={"username": XSS_SCRIPT_TAG, "password": "testpass"},
-    )
-
-    body_text = response.text
-    assert "<script>" not in body_text
-    assert response.status_code in (200, 401)
 
 
 def test_join_room_xss_code_not_echoed(client):


### PR DESCRIPTION
## Update README.md to remove username/password auth references

Update `README.md` to reflect the removal of username/password authentication. Remove `JELLYFIN_USERNAME` and `JELLYFIN_PASSWORD` from the env-var table and the alternative `.env` example. Mark `JELLYFIN_API_KEY` as always required.

**File to modify: `README.md`**

**Changes:**

1. **Env-var table** (around lines 43–51):
   - Remove the `JELLYFIN_USERNAME` row (line 49)
   - Remove the `JELLYFIN_PASSWORD` row (line 50)
   - Change `JELLYFIN_API_KEY` "Required when" from "With API key" to "Always"
   - Verify `TMDB_API_KEY` row actually says `TMDB_ACCESS_TOKEN` (the correct env var name) — fix if wrong

2. **Minimal .env example** (around lines 71–88):
   - Keep the API-key `.env` example (lines 73–78)
   - Delete the entire "Alternatively, use username/password authentication instead of API key:" block (lines 80–88)

3. **Jellyfin operator checks** (around lines 66–69):
   - Update step 2 to remove "set a wrong password" — since password auth is gone, the recovery scenario is now just "revoke the API key, restart, confirm failure, create new API key, restart, confirm success"
   - Or simplify to just note that API key rotation is the recovery mechanism

**No changes to:**
- Docker deployment examples (already only show `JELLYFIN_API_KEY`)
- Unraid template section (already only mentions API key)
- Any other section


### Acceptance Criteria

1. `JELLYFIN_USERNAME` row removed from the env-var table in README.md
2. `JELLYFIN_PASSWORD` row removed from the env-var table in README.md
3. `JELLYFIN_API_KEY` row updated to show "Required" (not "With API key") in the "Required when" column
4. The alternative `.env` example with `JELLYFIN_USERNAME`/`JELLYFIN_PASSWORD` is removed entirely (the "Alternatively, use username/password authentication instead of API key:" block)
5. Only the API-key `.env` example remains
6. `TMDB_API_KEY` row in env-var table is corrected to `TMDB_ACCESS_TOKEN` (the actual env var name) if it currently says `TMDB_API_KEY` — verify and fix if needed
7. The "Jellyfin operator checks" section no longer references "wrong password" or "set a wrong password" recovery scenarios — update or remove those steps since password auth is gone


---
Ticket: `ORCH-010`