### PR TITLE
ticket/ORCH-012: Harden Dockerfile with non-root user, PUID/PGID entrypoint, and HEALTHCHECK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,29 @@ COPY --from=builder /app/jellyswipe /app/jellyswipe
 COPY --from=builder /app/alembic.ini /app/alembic.ini
 COPY --from=builder /app/alembic /app/alembic
 
-# Create data directory for persistent storage
-RUN mkdir -p /app/data
+# Install gosu for privilege drop in entrypoint
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gosu \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create jellyswipe user/group. Default IDs are Unraid's `nobody:users`
+# (PUID=99, PGID=100); the entrypoint can rewrite them at runtime.
+# Note: GID 100 is already taken by the `users` group in Debian slim, so we
+# let groupadd auto-assign a system GID. The entrypoint uses groupmod -o at
+# runtime to set the desired PGID (allowing non-unique GIDs).
+RUN groupadd --system jellyswipe \
+    && useradd --system --uid 99 --gid jellyswipe \
+        --no-create-home --shell /usr/sbin/nologin jellyswipe \
+    && mkdir -p /app/data \
+    && chown -R jellyswipe:jellyswipe /app
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+    CMD python -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:5005/healthz', timeout=3).status==200 else 1)"
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
 EXPOSE 5005
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+PUID="${PUID:-99}"
+PGID="${PGID:-100}"
+
+# If running as root and PUID/PGID don't match the baked-in user, rewrite it.
+if [ "$(id -u)" = "0" ]; then
+    current_uid="$(id -u jellyswipe)"
+    current_gid="$(id -g jellyswipe)"
+    if [ "$current_uid" != "$PUID" ] || [ "$current_gid" != "$PGID" ]; then
+        groupmod -o -g "$PGID" jellyswipe
+        usermod  -o -u "$PUID" -g "$PGID" jellyswipe
+    fi
+    # Ensure /app/data is writable by the runtime user. Fast no-op when correct.
+    chown -R jellyswipe:jellyswipe /app/data
+    exec gosu jellyswipe "$@"
+fi
+
+# Already non-root (e.g. user passed `--user` on `docker run`). Exec directly;
+# operator is responsible for ensuring /app/data is writable.
+exec "$@"

--- a/jellyswipe/__init__.py
+++ b/jellyswipe/__init__.py
@@ -221,12 +221,14 @@ def create_app(test_config=None):
     from jellyswipe.routers.media import media_router
     from jellyswipe.routers.proxy import proxy_router
     from jellyswipe.routers.static import static_router
+    from jellyswipe.routers.health import health_router
 
     app.include_router(auth_router)
     app.include_router(rooms_router)
     app.include_router(media_router)
     app.include_router(proxy_router)
     app.include_router(static_router)
+    app.include_router(health_router)
 
     return app
 

--- a/jellyswipe/routers/health.py
+++ b/jellyswipe/routers/health.py
@@ -1,0 +1,69 @@
+"""Health probe router for liveness and readiness checks.
+
+Provides two unauthenticated endpoints:
+- GET /healthz — Liveness probe (never touches Jellyfin or SQLite)
+- GET /readyz — Readiness probe (checks SQLite and Jellyfin in parallel)
+"""
+
+import asyncio
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+import requests
+from fastapi import APIRouter, Response
+from sqlalchemy import text
+
+from jellyswipe.config import JELLYFIN_URL
+from jellyswipe.db_runtime import RUNTIME_ENGINE
+
+try:
+    __version__ = _pkg_version("jellyswipe")
+except PackageNotFoundError:
+    __version__ = "unknown"
+
+health_router = APIRouter()
+
+
+async def _check_sqlite() -> str:
+    """Run SELECT 1 against the configured SQLite engine with 1s timeout."""
+    if RUNTIME_ENGINE is None:
+        return "fail: database runtime not initialized"
+    try:
+        async with asyncio.timeout(1):
+            async with RUNTIME_ENGINE.connect() as conn:
+                await conn.execute(text("SELECT 1"))
+        return "ok"
+    except Exception as exc:
+        return f"fail: {exc}"
+
+
+async def _check_jellyfin() -> str:
+    """Hit Jellyfin's public info endpoint with 2s timeout."""
+    try:
+        url = f"{JELLYFIN_URL}/System/Info/Public"
+        resp = await asyncio.to_thread(requests.get, url, timeout=2)
+        if resp.status_code == 200:
+            return "ok"
+        return f"fail: HTTP {resp.status_code}"
+    except Exception as exc:
+        return f"fail: {exc}"
+
+
+@health_router.get("/healthz")
+async def healthz() -> dict:
+    """Liveness probe — returns 200 with version. Never touches Jellyfin or SQLite."""
+    return {"status": "ok", "version": __version__}
+
+
+@health_router.get("/readyz")
+async def readyz(response: Response) -> dict:
+    """Readiness probe — checks SQLite and Jellyfin in parallel."""
+    sqlite_status, jellyfin_status = await asyncio.gather(
+        _check_sqlite(),
+        _check_jellyfin(),
+    )
+    ok = sqlite_status == "ok" and jellyfin_status == "ok"
+    response.status_code = 200 if ok else 503
+    return {
+        "status": "ok" if ok else "degraded",
+        "checks": {"sqlite": sqlite_status, "jellyfin": jellyfin_status},
+    }

--- a/tests/test_infrastructure.py
+++ b/tests/test_infrastructure.py
@@ -109,9 +109,8 @@ def test_dockerfile_cmd_uses_python_bootstrap_entrypoint():
     content = dockerfile_path.read_text()
 
     # Extract the CMD line(s) for targeted assertions.
-    cmd_lines = [
-        line for line in content.splitlines() if line.strip().startswith("CMD")
-    ]
+    # Only match top-level CMD instructions (not indented HEALTHCHECK sub-commands).
+    cmd_lines = [line for line in content.splitlines() if line.startswith("CMD")]
     assert len(cmd_lines) == 1, (
         f"DEP-01 FAIL: expected exactly 1 CMD line in Dockerfile, found {len(cmd_lines)}: {cmd_lines}"
     )

--- a/tests/test_route_authorization.py
+++ b/tests/test_route_authorization.py
@@ -98,6 +98,10 @@ def _send_request(
 
 
 SPOOF_HEADERS = ("X-Provider-User-Id", "X-Jellyfin-User-Id", "X-Emby-UserId")
+
+# Routes that are intentionally unauthenticated (health probes, etc.)
+UNAUTHENTICATED_ROUTES = {"/healthz", "/readyz"}
+
 ROUTE_CASES: Tuple[Tuple[str, str, Optional[Dict[str, Any]]], ...] = (
     ("POST", "/room/ROOM1/swipe", {"media_id": "movie-1", "direction": "right"}),
     ("GET", "/matches", None),

--- a/tests/test_routes_health.py
+++ b/tests/test_routes_health.py
@@ -1,0 +1,107 @@
+"""Tests for health probe endpoints (/healthz and /readyz)."""
+
+from __future__ import annotations
+
+from sqlalchemy import event
+
+
+class TestHealthz:
+    """Tests for GET /healthz liveness probe."""
+
+    def test_healthz_returns_200_with_status_and_version(self, client):
+        """GET /healthz returns 200 with status='ok' and a non-empty version string."""
+        resp = client.get("/healthz")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert isinstance(data["version"], str)
+        assert len(data["version"]) > 0
+
+    def test_healthz_no_jellyfin_call(self, client, mocker):
+        """GET /healthz does not make any HTTP calls to Jellyfin."""
+        spy = mocker.patch("requests.get")
+        resp = client.get("/healthz")
+        assert resp.status_code == 200
+        assert spy.call_count == 0
+
+    def test_healthz_no_db_queries(self, client, app):
+        """GET /healthz does not issue any SQL queries."""
+        from jellyswipe.db_runtime import RUNTIME_ENGINE
+
+        select_count = [0]
+
+        def _on_execute(conn, cursor, statement, parameters, context, executemany):
+            if "select" in statement.lower():
+                select_count[0] += 1
+
+        event.listen(RUNTIME_ENGINE.sync_engine, "before_cursor_execute", _on_execute)
+        try:
+            resp = client.get("/healthz")
+            assert resp.status_code == 200
+            assert select_count[0] == 0
+        finally:
+            event.remove(
+                RUNTIME_ENGINE.sync_engine, "before_cursor_execute", _on_execute
+            )
+
+    def test_healthz_no_auth_required(self, db_connection, client_real_auth):
+        """GET /healthz without session cookie returns 200 (not 401)."""
+        # Ensure no session cookie is set
+        client_real_auth.cookies.clear()
+        resp = client_real_auth.get("/healthz")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+
+
+class TestReadyz:
+    """Tests for GET /readyz readiness probe."""
+
+    def test_readyz_both_ok(self, client, mocker):
+        """When both SQLite and Jellyfin are healthy, returns 200 with ok status."""
+        mocker.patch("jellyswipe.routers.health._check_sqlite", return_value="ok")
+        mocker.patch("jellyswipe.routers.health._check_jellyfin", return_value="ok")
+        resp = client.get("/readyz")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert data["checks"]["sqlite"] == "ok"
+        assert data["checks"]["jellyfin"] == "ok"
+
+    def test_readyz_jellyfin_timeout(self, client, mocker):
+        """When Jellyfin times out, returns 503 with degraded status."""
+        mocker.patch("jellyswipe.routers.health._check_sqlite", return_value="ok")
+        mocker.patch(
+            "jellyswipe.routers.health._check_jellyfin",
+            return_value="fail: timeout",
+        )
+        resp = client.get("/readyz")
+        assert resp.status_code == 503
+        data = resp.json()
+        assert data["status"] == "degraded"
+        assert data["checks"]["sqlite"] == "ok"
+        assert data["checks"]["jellyfin"].startswith("fail:")
+
+    def test_readyz_sqlite_failure(self, client, mocker):
+        """When SQLite fails, returns 503 with degraded status."""
+        mocker.patch(
+            "jellyswipe.routers.health._check_sqlite",
+            return_value="fail: database error",
+        )
+        mocker.patch("jellyswipe.routers.health._check_jellyfin", return_value="ok")
+        resp = client.get("/readyz")
+        assert resp.status_code == 503
+        data = resp.json()
+        assert data["status"] == "degraded"
+        assert data["checks"]["sqlite"].startswith("fail:")
+
+    def test_readyz_no_auth_required(self, db_connection, client_real_auth):
+        """GET /readyz without session cookie returns 200/503 (not 401)."""
+        # Ensure no session cookie is set
+        client_real_auth.cookies.clear()
+        resp = client_real_auth.get("/readyz")
+        # Could be 200 (both healthy) or 503 (one degraded) but never 401
+        assert resp.status_code in (200, 503)
+        data = resp.json()
+        assert "status" in data
+        assert "checks" in data


### PR DESCRIPTION
## Harden Dockerfile with non-root user, PUID/PGID entrypoint, and HEALTHCHECK

Modify the Dockerfile to drop root privileges via a PUID/PGID-parameterised entrypoint, and add a Docker HEALTHCHECK instruction that probes `/healthz`.

**Context:** This ticket depends on ORCH-011 (health router) because the HEALTHCHECK probes `/healthz`. The health router must exist for the HEALTHCHECK to report healthy.

**Files to create/modify:**

1. **`docker-entrypoint.sh`** (new, repo root) — Entrypoint script handling PUID/PGID, `/app/data` ownership fixup, and privilege drop via `gosu`:

   ```sh
   #!/bin/sh
   set -eu

   PUID="${PUID:-99}"
   PGID="${PGID:-100}"

   # If running as root and PUID/PGID don't match the baked-in user, rewrite it.
   if [ "$(id -u)" = "0" ]; then
       current_uid="$(id -u jellyswipe)"
       current_gid="$(id -g jellyswipe)"
       if [ "$current_uid" != "$PUID" ] || [ "$current_gid" != "$PGID" ]; then
           groupmod -o -g "$PGID" jellyswipe
           usermod  -o -u "$PUID" -g "$PGID" jellyswipe
       fi
       # Ensure /app/data is writable by the runtime user. Fast no-op when correct.
       chown -R jellyswipe:jellyswipe /app/data
       exec gosu jellyswipe "$@"
   fi

   # Already non-root (e.g. user passed `--user` on `docker run`). Exec directly;
   # operator is responsible for ensuring /app/data is writable.
   exec "$@"
   ```

2. **`Dockerfile`** (modify) — Add the following to the final stage (after the existing `COPY --from=builder` lines, before `EXPOSE`):

   ```dockerfile
   # Install gosu for privilege drop in entrypoint
   RUN apt-get update \
       && apt-get install -y --no-install-recommends gosu \
       && rm -rf /var/lib/apt/lists/*

   # Create jellyswipe user/group. Default IDs are Unraid's `nobody:users`
   # (PUID=99, PGID=100); the entrypoint can rewrite them at runtime.
   RUN groupadd --system --gid 100 jellyswipe \
       && useradd --system --uid 99 --gid 100 \
           --no-create-home --shell /usr/sbin/nologin jellyswipe \
       && mkdir -p /app/data \
       && chown -R jellyswipe:jellyswipe /app

   COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
   RUN chmod +x /usr/local/bin/docker-entrypoint.sh

   HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
       CMD python -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:5005/healthz', timeout=3).status==200 else 1)"

   ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
   ```

   - The existing `CMD` line stays as-is: `CMD ["/app/.venv/bin/python", "-m", "jellyswipe.bootstrap"]`
   - No `USER` directive is added — the entrypoint handles privilege drop
   - `--start-period=60s` accommodates first-boot alembic migrations on slow hardware

**Important placement note:** The gosu install and user creation must go in the **final stage** (after `FROM python:3.13-slim`), not in the builder stage. The `COPY docker-entrypoint.sh` goes after the existing `COPY --from=builder` lines. The `EXPOSE 5005` and `CMD` lines remain at the end.

**Boot-time behavior:**

| Scenario | Outcome |
|---|---|
| Fresh install, no PUID/PGID set | Container starts as uid 99/gid 100. Creates `/app/data` owned by 99:100 on host. |
| Existing `./data` owned by root | Operator sets PUID/PGID to match, or `chown -R 99:100 ./data` once. Otherwise container crashes with clear chown error. |
| `docker run --user 1234:5678` | Entrypoint detects non-root, skips rewrite and chown, execs CMD directly. |


### Acceptance Criteria

1. Dockerfile contains no `USER` directive
2. Dockerfile installs `gosu` via apt in the final stage
3. Dockerfile creates `jellyswipe` user (uid=99, gid=100) with `--system` flags
4. Dockerfile copies `docker-entrypoint.sh` and marks it executable
5. Dockerfile has `HEALTHCHECK` instruction probing `http://127.0.0.1:5005/healthz` with `--start-period=60s`
6. Dockerfile has `ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]` and existing `CMD` is preserved
7. `docker build .` succeeds without errors
8. `docker run -e PUID=1234 -e PGID=5678 <image> id` prints `uid=1234 gid=5678`
9. `docker run <image> id` (no PUID/PGID) prints `uid=99 gid=100`
10. `docker run --user 1234:5678 <image> id` prints `uid=1234 gid=5678` (entrypoint skips rewrite)
11. `docker inspect <container> | jq '.[0].State.Health'` reports `healthy` within 90s of boot on a typical dev machine (requires health router from ORCH-011)
12. `docker-entrypoint.sh` uses `set -eu` and exits on any error


---
Ticket: `ORCH-012`