### PR TITLE
feat(ORCH-020): extract TMDB pure lookup module

### DIFF
--- a/jellyswipe/routers/media.py
+++ b/jellyswipe/routers/media.py
@@ -8,7 +8,6 @@ import traceback
 
 from fastapi import APIRouter, Request, Depends
 from jellyswipe import XSSSafeJSONResponse
-from urllib.parse import urlencode
 
 from jellyswipe.dependencies import (
     require_auth,
@@ -16,8 +15,7 @@ from jellyswipe.dependencies import (
     check_rate_limit,
     get_provider,
 )
-from jellyswipe.http_client import make_http_request
-from jellyswipe.config import TMDB_AUTH_HEADERS
+from jellyswipe.tmdb import lookup_trailer, lookup_cast
 
 _logger = logging.getLogger(__name__)
 
@@ -58,26 +56,9 @@ def get_trailer(movie_id: str, request: Request, _: None = Depends(check_rate_li
     """Get YouTube trailer key for a movie."""
     try:
         item = get_provider().resolve_item_for_tmdb(movie_id)
-        params = urlencode({"query": item.title, "year": item.year})
-        search_url = f"https://api.themoviedb.org/3/search/movie?{params}"
-        search_response = make_http_request(
-            method="GET", url=search_url, headers=TMDB_AUTH_HEADERS, timeout=(5, 15)
-        )
-        r = search_response.json()
-        if r.get("results"):
-            tmdb_id = r["results"][0]["id"]
-            v_url = f"https://api.themoviedb.org/3/movie/{tmdb_id}/videos"
-            videos_response = make_http_request(
-                method="GET", url=v_url, headers=TMDB_AUTH_HEADERS, timeout=(5, 15)
-            )
-            v_res = videos_response.json()
-            trailers = [
-                v
-                for v in v_res.get("results", [])
-                if v["site"] == "YouTube" and v["type"] == "Trailer"
-            ]
-            if trailers:
-                return {"youtube_key": trailers[0]["key"]}
+        youtube_key = lookup_trailer(item.title, item.year)
+        if youtube_key:
+            return {"youtube_key": youtube_key}
         return make_error_response("Not found", 404, request)
     except RuntimeError as e:
         if "item lookup failed" in str(e).lower():
@@ -94,33 +75,8 @@ def get_cast(movie_id: str, request: Request, _: None = Depends(check_rate_limit
     """Get cast information for a movie."""
     try:
         item = get_provider().resolve_item_for_tmdb(movie_id)
-        params = urlencode({"query": item.title, "year": item.year})
-        search_url = f"https://api.themoviedb.org/3/search/movie?{params}"
-        search_response = make_http_request(
-            method="GET", url=search_url, headers=TMDB_AUTH_HEADERS, timeout=(5, 15)
-        )
-        r = search_response.json()
-        if r.get("results"):
-            tmdb_id = r["results"][0]["id"]
-            credits_url = f"https://api.themoviedb.org/3/movie/{tmdb_id}/credits"
-            credits_response = make_http_request(
-                method="GET",
-                url=credits_url,
-                headers=TMDB_AUTH_HEADERS,
-                timeout=(5, 15),
-            )
-            c_res = credits_response.json()
-            cast = []
-            for actor in c_res.get("cast", [])[:8]:
-                cast.append(
-                    {
-                        "name": actor["name"],
-                        "character": actor.get("character", ""),
-                        "profile_path": f"https://image.tmdb.org/t/p/w185{actor['profile_path']}"
-                        if actor.get("profile_path")
-                        else None,
-                    }
-                )
+        cast = lookup_cast(item.title, item.year)
+        if cast:
             return {"cast": cast}
         return {"cast": []}
     except RuntimeError as e:

--- a/jellyswipe/tmdb.py
+++ b/jellyswipe/tmdb.py
@@ -1,0 +1,87 @@
+"""Pure TMDB lookup module — zero external dependencies.
+
+All functions are best-effort enrichment. Network failures, missing results,
+and malformed responses return safe defaults (None or []).
+"""
+
+from urllib.parse import urlencode
+
+from jellyswipe.config import TMDB_AUTH_HEADERS
+from jellyswipe.http_client import make_http_request
+
+TMDB_BASE_URL = "https://api.themoviedb.org/3"
+
+
+def lookup_trailer(title: str, year) -> str | None:
+    """Search TMDB for a movie, return YouTube trailer key.
+
+    Steps:
+    1. GET /search/movie?query={title}&year={year}
+    2. Take first result's tmdb_id
+    3. GET /movie/{tmdb_id}/videos
+    4. Find first YouTube Trailer
+
+    All failures return None. Best-effort enrichment.
+    """
+    try:
+        params = urlencode({"query": title, "year": year})
+        search_url = f"{TMDB_BASE_URL}/search/movie?{params}"
+        search_response = make_http_request(
+            method="GET", url=search_url, headers=TMDB_AUTH_HEADERS, timeout=(5, 15)
+        )
+        r = search_response.json()
+        if not r.get("results"):
+            return None
+        tmdb_id = r["results"][0]["id"]
+
+        v_url = f"{TMDB_BASE_URL}/movie/{tmdb_id}/videos"
+        videos_response = make_http_request(
+            method="GET", url=v_url, headers=TMDB_AUTH_HEADERS, timeout=(5, 15)
+        )
+        v_res = videos_response.json()
+        trailers = [
+            v
+            for v in v_res.get("results", [])
+            if v["site"] == "YouTube" and v["type"] == "Trailer"
+        ]
+        return trailers[0]["key"] if trailers else None
+    except Exception:
+        return None
+
+
+def lookup_cast(title: str, year) -> list[dict]:
+    """Search TMDB for a movie, return up to 8 cast members.
+
+    Returns list of {"name": str, "character": str, "profile_path": str | None}.
+    All failures return [].
+    """
+    try:
+        params = urlencode({"query": title, "year": year})
+        search_url = f"{TMDB_BASE_URL}/search/movie?{params}"
+        search_response = make_http_request(
+            method="GET", url=search_url, headers=TMDB_AUTH_HEADERS, timeout=(5, 15)
+        )
+        r = search_response.json()
+        if not r.get("results"):
+            return []
+        tmdb_id = r["results"][0]["id"]
+
+        credits_url = f"{TMDB_BASE_URL}/movie/{tmdb_id}/credits"
+        credits_response = make_http_request(
+            method="GET", url=credits_url, headers=TMDB_AUTH_HEADERS, timeout=(5, 15)
+        )
+        c_res = credits_response.json()
+        cast = []
+        for actor in c_res.get("cast", [])[:8]:
+            cast.append(
+                {
+                    "name": actor["name"],
+                    "character": actor.get("character", ""),
+                    "profile_path": f"https://image.tmdb.org/t/p/w185{actor['profile_path']}"
+                    if actor.get("profile_path")
+                    else None,
+                }
+            )
+        return cast
+    except Exception:
+        return []

--- a/tests/test_tmdb.py
+++ b/tests/test_tmdb.py
@@ -1,0 +1,265 @@
+"""Unit tests for the pure TMDB lookup module.
+
+Tests cover lookup_trailer and lookup_cast with mocked HTTP calls.
+"""
+
+from unittest.mock import Mock
+
+from jellyswipe.tmdb import lookup_trailer, lookup_cast
+
+
+class TestLookupTrailer:
+    """Test suite for lookup_trailer function."""
+
+    def _make_mock_response(self, json_data):
+        """Helper to create a mock response object."""
+        mock = Mock()
+        mock.json.return_value = json_data
+        return mock
+
+    def test_successful_lookup_returns_youtube_key(self, mocker):
+        """Search returns results, videos returns YouTube trailer → returns key."""
+        mock_search = self._make_mock_response(
+            {
+                "results": [
+                    {"id": 12345, "title": "Test Movie", "release_date": "2024-01-01"}
+                ]
+            }
+        )
+        mock_videos = self._make_mock_response(
+            {
+                "results": [
+                    {"site": "YouTube", "type": "Trailer", "key": "abc123"},
+                    {"site": "YouTube", "type": "Teaser", "key": "xyz789"},
+                ]
+            }
+        )
+
+        mocker.patch(
+            "jellyswipe.tmdb.make_http_request",
+            side_effect=[mock_search, mock_videos],
+        )
+
+        result = lookup_trailer("Test Movie", 2024)
+        assert result == "abc123"
+
+    def test_no_tmdb_match_returns_none(self, mocker):
+        """Search returns empty results → returns None."""
+        mock_search = self._make_mock_response({"results": []})
+        mocker.patch("jellyswipe.tmdb.make_http_request", return_value=mock_search)
+
+        result = lookup_trailer("Nonexistent Movie", 2024)
+        assert result is None
+
+    def test_no_trailer_found_returns_none(self, mocker):
+        """Search returns results, videos returns non-YouTube entries → returns None."""
+        mock_search = self._make_mock_response({"results": [{"id": 12345}]})
+        mock_videos = self._make_mock_response(
+            {
+                "results": [
+                    {"site": "Vimeo", "type": "Trailer", "key": "vimeo123"},
+                    {"site": "YouTube", "type": "Behind the Scenes", "key": "bts456"},
+                ]
+            }
+        )
+
+        mocker.patch(
+            "jellyswipe.tmdb.make_http_request",
+            side_effect=[mock_search, mock_videos],
+        )
+
+        result = lookup_trailer("Test Movie", 2024)
+        assert result is None
+
+    def test_network_failure_on_search_returns_none(self, mocker):
+        """Search raises exception → returns None."""
+        mocker.patch(
+            "jellyswipe.tmdb.make_http_request",
+            side_effect=Exception("Connection refused"),
+        )
+
+        result = lookup_trailer("Test Movie", 2024)
+        assert result is None
+
+    def test_network_failure_on_videos_returns_none(self, mocker):
+        """Search succeeds, videos raises → returns None."""
+        mock_search = self._make_mock_response({"results": [{"id": 12345}]})
+
+        mocker.patch(
+            "jellyswipe.tmdb.make_http_request",
+            side_effect=[mock_search, Exception("Timeout")],
+        )
+
+        result = lookup_trailer("Test Movie", 2024)
+        assert result is None
+
+    def test_malformed_response_returns_none(self, mocker):
+        """Search returns results without id key → returns None."""
+        mock_search = self._make_mock_response(
+            {
+                "results": [{"title": "Test Movie"}]  # missing "id"
+            }
+        )
+        mocker.patch("jellyswipe.tmdb.make_http_request", return_value=mock_search)
+
+        result = lookup_trailer("Test Movie", 2024)
+        assert result is None
+
+    def test_malformed_videos_response_returns_none(self, mocker):
+        """Videos response missing results key → returns None."""
+        mock_search = self._make_mock_response({"results": [{"id": 12345}]})
+        mock_videos = self._make_mock_response({})  # no "results" key
+
+        mocker.patch(
+            "jellyswipe.tmdb.make_http_request",
+            side_effect=[mock_search, mock_videos],
+        )
+
+        result = lookup_trailer("Test Movie", 2024)
+        assert result is None
+
+
+class TestLookupCast:
+    """Test suite for lookup_cast function."""
+
+    def _make_mock_response(self, json_data):
+        """Helper to create a mock response object."""
+        mock = Mock()
+        mock.json.return_value = json_data
+        return mock
+
+    def test_successful_lookup_returns_cast_list(self, mocker):
+        """Search + credits return data → returns list of cast dicts."""
+        cast_members = [
+            {
+                "name": f"Actor {i}",
+                "character": f"Character {i}",
+                "profile_path": f"/img{i}.jpg",
+            }
+            for i in range(10)
+        ]
+        mock_search = self._make_mock_response({"results": [{"id": 12345}]})
+        mock_credits = self._make_mock_response({"cast": cast_members})
+
+        mocker.patch(
+            "jellyswipe.tmdb.make_http_request",
+            side_effect=[mock_search, mock_credits],
+        )
+
+        result = lookup_cast("Test Movie", 2024)
+        assert len(result) == 8  # capped at 8
+        assert result[0] == {
+            "name": "Actor 0",
+            "character": "Character 0",
+            "profile_path": "https://image.tmdb.org/t/p/w185/img0.jpg",
+        }
+
+    def test_fewer_than_8_cast_members_returns_all(self, mocker):
+        """Returns all available when fewer than 8."""
+        cast_members = [
+            {"name": "Actor 1", "character": "Lead", "profile_path": "/lead.jpg"},
+            {
+                "name": "Actor 2",
+                "character": "Supporting",
+                "profile_path": "/support.jpg",
+            },
+        ]
+        mock_search = self._make_mock_response({"results": [{"id": 12345}]})
+        mock_credits = self._make_mock_response({"cast": cast_members})
+
+        mocker.patch(
+            "jellyswipe.tmdb.make_http_request",
+            side_effect=[mock_search, mock_credits],
+        )
+
+        result = lookup_cast("Test Movie", 2024)
+        assert len(result) == 2
+
+    def test_no_tmdb_match_returns_empty_list(self, mocker):
+        """Search returns empty results → returns []."""
+        mock_search = self._make_mock_response({"results": []})
+        mocker.patch("jellyswipe.tmdb.make_http_request", return_value=mock_search)
+
+        result = lookup_cast("Nonexistent Movie", 2024)
+        assert result == []
+
+    def test_network_failure_returns_empty_list(self, mocker):
+        """Search raises exception → returns []."""
+        mocker.patch(
+            "jellyswipe.tmdb.make_http_request",
+            side_effect=Exception("Connection refused"),
+        )
+
+        result = lookup_cast("Test Movie", 2024)
+        assert result == []
+
+    def test_network_failure_on_credits_returns_empty_list(self, mocker):
+        """Search succeeds, credits raises → returns []."""
+        mock_search = self._make_mock_response({"results": [{"id": 12345}]})
+        mocker.patch(
+            "jellyswipe.tmdb.make_http_request",
+            side_effect=[mock_search, Exception("Timeout")],
+        )
+
+        result = lookup_cast("Test Movie", 2024)
+        assert result == []
+
+    def test_malformed_response_returns_empty_list(self, mocker):
+        """Credits response missing cast key → returns []."""
+        mock_search = self._make_mock_response({"results": [{"id": 12345}]})
+        mock_credits = self._make_mock_response({})  # no "cast" key
+
+        mocker.patch(
+            "jellyswipe.tmdb.make_http_request",
+            side_effect=[mock_search, mock_credits],
+        )
+
+        result = lookup_cast("Test Movie", 2024)
+        assert result == []
+
+    def test_cast_member_without_profile_path_has_none(self, mocker):
+        """Cast member without profile_path → profile_path is None in result."""
+        cast_members = [
+            {"name": "Actor 1", "character": "Lead"},  # no profile_path
+            {"name": "Actor 2", "character": "Supporting", "profile_path": None},
+        ]
+        mock_search = self._make_mock_response({"results": [{"id": 12345}]})
+        mock_credits = self._make_mock_response({"cast": cast_members})
+
+        mocker.patch(
+            "jellyswipe.tmdb.make_http_request",
+            side_effect=[mock_search, mock_credits],
+        )
+
+        result = lookup_cast("Test Movie", 2024)
+        assert len(result) == 2
+        assert result[0]["profile_path"] is None
+        assert result[1]["profile_path"] is None
+
+    def test_cast_member_dict_shape(self, mocker):
+        """Verify cast member dict has correct shape: name, character, profile_path."""
+        mock_search = self._make_mock_response({"results": [{"id": 12345}]})
+        mock_credits = self._make_mock_response(
+            {
+                "cast": [
+                    {
+                        "name": "Test Actor",
+                        "character": "Test Role",
+                        "profile_path": "/test.jpg",
+                    }
+                ]
+            }
+        )
+
+        mocker.patch(
+            "jellyswipe.tmdb.make_http_request",
+            side_effect=[mock_search, mock_credits],
+        )
+
+        result = lookup_cast("Test Movie", 2024)
+        assert len(result) == 1
+        member = result[0]
+        assert set(member.keys()) == {"name", "character", "profile_path"}
+        assert member["name"] == "Test Actor"
+        assert member["character"] == "Test Role"
+        assert member["profile_path"] == "https://image.tmdb.org/t/p/w185/test.jpg"

--- a/tests/test_tmdb_auth.py
+++ b/tests/test_tmdb_auth.py
@@ -72,9 +72,9 @@ class TestBearerTokenHeaders:
         }
         second_response.status_code = 200
 
-        # Patch where make_http_request is looked up: jellyswipe.routers.media (D-14)
+        # Patch where make_http_request is looked up: jellyswipe.tmdb (ORCH-020)
         with patch(
-            "jellyswipe.routers.media.make_http_request",
+            "jellyswipe.tmdb.make_http_request",
             side_effect=[mock_response, second_response],
         ) as mock_http:
             response = client.get("/get-trailer/test_movie_id")
@@ -112,9 +112,9 @@ class TestBearerTokenHeaders:
         }
         second_response.status_code = 200
 
-        # Patch where make_http_request is looked up: jellyswipe.routers.media (D-14)
+        # Patch where make_http_request is looked up: jellyswipe.tmdb (ORCH-020)
         with patch(
-            "jellyswipe.routers.media.make_http_request",
+            "jellyswipe.tmdb.make_http_request",
             side_effect=[mock_response, second_response],
         ) as mock_http:
             response = client.get("/cast/test_movie_id")


### PR DESCRIPTION
## Summary

- Create `jellyswipe/tmdb.py` with `lookup_trailer` and `lookup_cast` pure functions
- Module uses `make_http_request` from `http_client` and `TMDB_AUTH_HEADERS` from `config`
- Zero external dependencies — no provider, DB, or FastAPI imports
- Add `tests/test_tmdb.py` with comprehensive mocked HTTP tests

## Validation

- `uv run pytest tests/` — PASS
- `uv run ruff check jellyswipe` — PASS
- `docker build -t jellyswipe-test .` — PASS