### PR TITLE
feat(ORCH-019): wire deck pipeline into RoomLifecycleService callers

### DIFF
--- a/alembic/versions/0005_tmdb_cache.py
+++ b/alembic/versions/0005_tmdb_cache.py
@@ -1,0 +1,27 @@
+"""Add tmdb_cache table."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0005_tmdb_cache"
+down_revision = "0004_session_event_ledger"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tmdb_cache",
+        sa.Column("media_id", sa.Text(), nullable=False),
+        sa.Column("lookup_type", sa.Text(), nullable=False),
+        sa.Column("result_json", sa.Text(), nullable=False),
+        sa.Column("fetched_at", sa.Text(), nullable=False),
+        sa.PrimaryKeyConstraint("media_id", "lookup_type"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("tmdb_cache")

--- a/jellyswipe/db_uow.py
+++ b/jellyswipe/db_uow.py
@@ -17,6 +17,7 @@ from jellyswipe.repositories.session_events import (
     SessionInstanceRepository,
 )
 from jellyswipe.repositories.swipes import SwipeRepository
+from jellyswipe.repositories.tmdb_cache import TmdbCacheRepository
 
 T = TypeVar("T")
 
@@ -76,6 +77,7 @@ class DatabaseUnitOfWork:
         self.matches = MatchRepository(session)
         self.session_instances = SessionInstanceRepository(session)
         self.session_events = SessionEventRepository(session)
+        self.tmdb_cache = TmdbCacheRepository(session)
 
     async def run_sync(self, fn: Callable[..., T], /, *args: Any, **kwargs: Any) -> T:
         """Run legacy sync work on the managed session connection.
@@ -98,4 +100,5 @@ __all__ = [
     "SessionEventRepository",
     "SessionInstanceRepository",
     "SwipeRepository",
+    "TmdbCacheRepository",
 ]

--- a/jellyswipe/models/__init__.py
+++ b/jellyswipe/models/__init__.py
@@ -5,5 +5,6 @@ from jellyswipe.models.base import Base
 from jellyswipe.models.match import Match
 from jellyswipe.models.room import Room
 from jellyswipe.models.swipe import Swipe
+from jellyswipe.models.tmdb_cache import TmdbCache
 
-__all__ = ["AuthSession", "Base", "Match", "Room", "Swipe"]
+__all__ = ["AuthSession", "Base", "Match", "Room", "Swipe", "TmdbCache"]

--- a/jellyswipe/models/tmdb_cache.py
+++ b/jellyswipe/models/tmdb_cache.py
@@ -1,0 +1,15 @@
+"""TMDB cache schema model."""
+
+from sqlalchemy import Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from jellyswipe.models.base import Base
+
+
+class TmdbCache(Base):
+    __tablename__ = "tmdb_cache"
+
+    media_id: Mapped[str] = mapped_column(Text, primary_key=True)
+    lookup_type: Mapped[str] = mapped_column(Text, primary_key=True)
+    result_json: Mapped[str] = mapped_column(Text, nullable=False)
+    fetched_at: Mapped[str] = mapped_column(Text, nullable=False)

--- a/jellyswipe/repositories/tmdb_cache.py
+++ b/jellyswipe/repositories/tmdb_cache.py
@@ -1,0 +1,70 @@
+"""Async TMDB cache persistence."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from jellyswipe.models.tmdb_cache import TmdbCache
+from jellyswipe.room_types import TmdbCacheRecord
+
+
+class TmdbCacheRepository:
+    """Persistence access for TMDB cache entries."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get(
+        self, media_id: str, lookup_type: str, max_age_days: int = 7
+    ) -> TmdbCacheRecord | None:
+        """Return cached result if fresh (within max_age_days), else None."""
+        stmt = select(TmdbCache).where(
+            TmdbCache.media_id == media_id,
+            TmdbCache.lookup_type == lookup_type,
+        )
+        result = await self._session.execute(stmt)
+        row = result.scalar_one_or_none()
+        if row is None:
+            return None
+
+        cutoff = datetime.now(timezone.utc) - timedelta(days=max_age_days)
+        fetched = datetime.fromisoformat(row.fetched_at)
+        if fetched <= cutoff:
+            return None
+
+        return TmdbCacheRecord(
+            media_id=row.media_id,
+            lookup_type=row.lookup_type,
+            result_json=row.result_json,
+            fetched_at=row.fetched_at,
+        )
+
+    async def put(self, media_id: str, lookup_type: str, result_json: str) -> None:
+        """Upsert cache entry with current timestamp."""
+        now = datetime.now(timezone.utc).isoformat()
+        await self._session.execute(
+            text(
+                "INSERT INTO tmdb_cache (media_id, lookup_type, result_json, fetched_at) "
+                "VALUES (:media_id, :lookup_type, :result_json, :fetched_at) "
+                "ON CONFLICT(media_id, lookup_type) DO UPDATE SET "
+                "result_json = :result_json, fetched_at = :fetched_at"
+            ),
+            {
+                "media_id": media_id,
+                "lookup_type": lookup_type,
+                "result_json": result_json,
+                "fetched_at": now,
+            },
+        )
+
+    async def cleanup_stale(self, max_age_days: int = 30) -> int:
+        """Delete entries older than max_age_days. Returns count deleted."""
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=max_age_days)).isoformat()
+        result = await self._session.execute(
+            text("DELETE FROM tmdb_cache WHERE fetched_at < :cutoff"),
+            {"cutoff": cutoff},
+        )
+        return result.rowcount or 0

--- a/jellyswipe/room_types.py
+++ b/jellyswipe/room_types.py
@@ -65,3 +65,11 @@ class MatchRecord:
 class SwipeCounterparty:
     user_id: str
     session_id: str | None
+
+
+@dataclass(slots=True)
+class TmdbCacheRecord:
+    media_id: str
+    lookup_type: str
+    result_json: str
+    fetched_at: str

--- a/jellyswipe/routers/media.py
+++ b/jellyswipe/routers/media.py
@@ -8,7 +8,6 @@ import traceback
 
 from fastapi import APIRouter, Request, Depends
 from jellyswipe import XSSSafeJSONResponse
-from urllib.parse import urlencode
 
 from jellyswipe.dependencies import (
     require_auth,
@@ -16,8 +15,7 @@ from jellyswipe.dependencies import (
     check_rate_limit,
     get_provider,
 )
-from jellyswipe.http_client import make_http_request
-from jellyswipe.config import TMDB_AUTH_HEADERS
+from jellyswipe.tmdb import lookup_trailer, lookup_cast
 
 _logger = logging.getLogger(__name__)
 
@@ -58,26 +56,9 @@ def get_trailer(movie_id: str, request: Request, _: None = Depends(check_rate_li
     """Get YouTube trailer key for a movie."""
     try:
         item = get_provider().resolve_item_for_tmdb(movie_id)
-        params = urlencode({"query": item.title, "year": item.year})
-        search_url = f"https://api.themoviedb.org/3/search/movie?{params}"
-        search_response = make_http_request(
-            method="GET", url=search_url, headers=TMDB_AUTH_HEADERS, timeout=(5, 15)
-        )
-        r = search_response.json()
-        if r.get("results"):
-            tmdb_id = r["results"][0]["id"]
-            v_url = f"https://api.themoviedb.org/3/movie/{tmdb_id}/videos"
-            videos_response = make_http_request(
-                method="GET", url=v_url, headers=TMDB_AUTH_HEADERS, timeout=(5, 15)
-            )
-            v_res = videos_response.json()
-            trailers = [
-                v
-                for v in v_res.get("results", [])
-                if v["site"] == "YouTube" and v["type"] == "Trailer"
-            ]
-            if trailers:
-                return {"youtube_key": trailers[0]["key"]}
+        youtube_key = lookup_trailer(item.title, item.year)
+        if youtube_key:
+            return {"youtube_key": youtube_key}
         return make_error_response("Not found", 404, request)
     except RuntimeError as e:
         if "item lookup failed" in str(e).lower():
@@ -94,33 +75,8 @@ def get_cast(movie_id: str, request: Request, _: None = Depends(check_rate_limit
     """Get cast information for a movie."""
     try:
         item = get_provider().resolve_item_for_tmdb(movie_id)
-        params = urlencode({"query": item.title, "year": item.year})
-        search_url = f"https://api.themoviedb.org/3/search/movie?{params}"
-        search_response = make_http_request(
-            method="GET", url=search_url, headers=TMDB_AUTH_HEADERS, timeout=(5, 15)
-        )
-        r = search_response.json()
-        if r.get("results"):
-            tmdb_id = r["results"][0]["id"]
-            credits_url = f"https://api.themoviedb.org/3/movie/{tmdb_id}/credits"
-            credits_response = make_http_request(
-                method="GET",
-                url=credits_url,
-                headers=TMDB_AUTH_HEADERS,
-                timeout=(5, 15),
-            )
-            c_res = credits_response.json()
-            cast = []
-            for actor in c_res.get("cast", [])[:8]:
-                cast.append(
-                    {
-                        "name": actor["name"],
-                        "character": actor.get("character", ""),
-                        "profile_path": f"https://image.tmdb.org/t/p/w185{actor['profile_path']}"
-                        if actor.get("profile_path")
-                        else None,
-                    }
-                )
+        cast = lookup_cast(item.title, item.year)
+        if cast:
             return {"cast": cast}
         return {"cast": []}
     except RuntimeError as e:

--- a/jellyswipe/services/deck_pipeline.py
+++ b/jellyswipe/services/deck_pipeline.py
@@ -1,0 +1,136 @@
+"""Unified Swipe Deck building pipeline.
+
+Consolidates the 7-step deck building process (fetch, interleave, exclude swiped,
+validate, persist, convert) into a single function.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Protocol
+
+from jellyswipe.db_uow import DatabaseUnitOfWork
+
+logger = logging.getLogger(__name__)
+
+
+class EmptyDeckError(Exception):
+    """Deck build produced zero items — no state change occurred."""
+
+    def __init__(self, reason: str = "No items matched the filter criteria") -> None:
+        super().__init__(reason)
+
+
+class DeckProvider(Protocol):
+    def fetch_deck(
+        self,
+        media_types: list[str],
+        genre_name: str | None = None,
+        hide_watched: bool = False,
+    ) -> list[dict[str, Any]]: ...
+
+
+def _interleave(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Apply Balanced Interleaving (round-robin) to movies and TV shows."""
+    movies = [m for m in items if m.get("media_type") == "movie"]
+    tv_shows = [t for t in items if t.get("media_type") == "tv_show"]
+    interleaved = []
+    max_len = max(len(movies), len(tv_shows))
+    for i in range(max_len):
+        if i < len(movies):
+            interleaved.append(movies[i])
+        if i < len(tv_shows):
+            interleaved.append(tv_shows[i])
+    return interleaved
+
+
+def _to_api_format(deck: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Convert internal card dicts (with 'id') to API format (with 'media_id')."""
+    result = []
+    for card in deck:
+        api_item = {k: v for k, v in card.items() if k != "id"}
+        api_item["media_id"] = card.get("id")
+        result.append(api_item)
+    return result
+
+
+async def build_deck(
+    provider: DeckProvider,
+    uow: DatabaseUnitOfWork,
+    room_code: str,
+    media_types: list[str],
+    genre: str | None = None,
+    hide_watched: bool = False,
+    persist: bool = True,
+) -> list[dict]:
+    """Unified Swipe Deck building pipeline.
+
+    Steps:
+    1. Fetch from provider via DeckProvider Protocol
+    2. Apply Balanced Interleaving when both media types present
+    3. Exclude swiped Media Candidate IDs
+    4. Validate non-empty (raise EmptyDeckError)
+    5. If persist=True: persist to room row, convert to API format
+    6. Return deck
+
+    Args:
+        provider: DeckProvider implementation for fetching media items
+        uow: DatabaseUnitOfWork for DB access
+        room_code: Room pairing code
+        media_types: List of media types to fetch (e.g., ["movie", "tv_show"])
+        genre: Optional genre filter
+        hide_watched: Whether to hide watched items
+        persist: If True, persist deck to room row and return API format.
+                 If False, return internal format without persisting.
+
+    Returns:
+        List of card dicts (API format if persist=True, internal format if persist=False)
+
+    Raises:
+        EmptyDeckError: If deck is empty after exclusion
+    """
+    # Step 1: Fetch from provider
+    items = provider.fetch_deck(
+        media_types=media_types,
+        genre_name=genre,
+        hide_watched=hide_watched,
+    )
+
+    # Step 2: Apply Balanced Interleaving when both media types present
+    has_movies = "movie" in media_types
+    has_tv = "tv_show" in media_types
+    if has_movies and has_tv:
+        items = _interleave(items)
+
+    # Step 3: Exclude swiped Media Candidate IDs
+    swiped_ids = await uow.swipes.list_swiped_media_ids(room_code)
+    filtered_deck = [item for item in items if item.get("id") not in swiped_ids]
+
+    # Step 4: Validate non-empty
+    if not filtered_deck:
+        logger.warning(
+            "Empty deck for room %s: media_types=%s, genre=%s, hide_watched=%s, excluded %d swiped items",
+            room_code,
+            media_types,
+            genre,
+            hide_watched,
+            len(swiped_ids),
+        )
+        raise EmptyDeckError("No items available. Try a different filter.")
+
+    # Step 5 & 6: Persist (if requested) and return
+    if persist:
+        # Persist internal format to room row
+        await uow.rooms.set_filters_and_deck(
+            room_code,
+            genre=genre or "All",
+            hide_watched=hide_watched,
+            movie_data_json=json.dumps(filtered_deck),
+            deck_position_json=json.dumps({}),
+        )
+        # Return API format
+        return _to_api_format(filtered_deck)
+
+    # No-persist flow: return internal format
+    return filtered_deck

--- a/jellyswipe/services/room_lifecycle.py
+++ b/jellyswipe/services/room_lifecycle.py
@@ -6,12 +6,21 @@ import asyncio
 import json
 import logging
 import secrets
-from typing import Any, Protocol
+from typing import Any
 from uuid import uuid4
 
 from jellyswipe.db_uow import DatabaseUnitOfWork
 from jellyswipe.db_runtime import get_sessionmaker
 from jellyswipe.room_types import MatchRecord
+from jellyswipe.services.deck_pipeline import build_deck, DeckProvider, EmptyDeckError
+
+# Re-export for backward compatibility
+__all__ = [
+    "DeckProvider",
+    "EmptyDeckError",
+    "RoomLifecycleService",
+    "UniqueRoomCodeExhaustedError",
+]
 
 logger = logging.getLogger(__name__)
 
@@ -21,22 +30,6 @@ class UniqueRoomCodeExhaustedError(Exception):
 
     def __init__(self) -> None:
         super().__init__("Could not generate unique room code")
-
-
-class EmptyDeckError(Exception):
-    """Deck rebuild produced zero items — no state change occurred."""
-
-    def __init__(self, reason: str = "No items matched the filter criteria") -> None:
-        super().__init__(reason)
-
-
-class DeckProvider(Protocol):
-    def fetch_deck(
-        self,
-        media_types: list[str],
-        genre_name: str | None = None,
-        hide_watched: bool = False,
-    ) -> list[dict[str, Any]]: ...
 
 
 class RoomLifecycleService:
@@ -97,26 +90,19 @@ class RoomLifecycleService:
                 media_types.append("movie")
             if include_tv_shows:
                 media_types.append("tv_show")
-            movie_list = provider.fetch_deck(media_types=media_types)
-
-            # Interleave movies and TV shows when both are requested (round-robin)
-            if include_movies and include_tv_shows:
-                movies = [m for m in movie_list if m.get("media_type") == "movie"]
-                tv_shows = [t for t in movie_list if t.get("media_type") == "tv_show"]
-                interleaved = []
-                max_len = max(len(movies), len(tv_shows))
-                for i in range(max_len):
-                    if i < len(movies):
-                        interleaved.append(movies[i])
-                    if i < len(tv_shows):
-                        interleaved.append(tv_shows[i])
-                movie_list = interleaved
+            deck = await build_deck(
+                provider=provider,
+                uow=uow,
+                room_code=pairing_code,
+                media_types=media_types,
+                persist=False,
+            )
 
             deck_json = json.dumps({user_id: 0})
             instance_id = uuid4().hex
             await uow.rooms.create(
                 pairing_code,
-                movie_data_json=json.dumps(movie_list),
+                movie_data_json=json.dumps(deck),
                 ready=solo,  # ready defaults to True when solo=True
                 current_genre="All",
                 solo_mode=solo,
@@ -154,12 +140,18 @@ class RoomLifecycleService:
                 continue
             # Build media_types list from boolean flags - solo mode defaults to movies only
             media_types = ["movie"]
-            movie_list = provider.fetch_deck(media_types=media_types)
+            deck = await build_deck(
+                provider=provider,
+                uow=uow,
+                room_code=pairing_code,
+                media_types=media_types,
+                persist=False,
+            )
             deck_json = json.dumps({user_id: 0})
             instance_id = uuid4().hex
             await uow.rooms.create(
                 pairing_code,
-                movie_data_json=json.dumps(movie_list),
+                movie_data_json=json.dumps(deck),
                 ready=True,
                 current_genre="All",
                 solo_mode=True,
@@ -272,99 +264,6 @@ class RoomLifecycleService:
             result.append(item)
         return result
 
-    async def _rebuild_deck(
-        self,
-        code: str,
-        provider: DeckProvider,
-        uow: DatabaseUnitOfWork,
-        genre: str | None = None,
-        hide_watched: bool | None = None,
-    ) -> list[dict[str, Any]]:
-        """Rebuild room deck with optional genre and watched filter changes.
-
-        Args:
-            code: Room pairing code
-            provider: Deck provider to fetch media
-            uow: Unit of work for DB access
-            genre: New genre filter (None = keep current)
-            hide_watched: New watched filter state (None = keep current)
-
-        Returns:
-            New deck list
-
-        Raises:
-            EmptyDeckError: If rebuilt deck has zero items (no state changed)
-        """
-        # Read room config from DB
-        room = await uow.rooms.get_room(code)
-        if room is None:
-            raise EmptyDeckError("Room not found")
-
-        # Determine effective values: use provided or keep current
-        effective_genre = genre if genre is not None else room.current_genre
-        effective_hide_watched = (
-            hide_watched if hide_watched is not None else room.hide_watched
-        )
-
-        # Build media_types from room config
-        media_types = []
-        if room.include_movies:
-            media_types.append("movie")
-        if room.include_tv_shows:
-            media_types.append("tv_show")
-
-        # Fetch deck from provider with genre + hide_watched filters
-        new_list = provider.fetch_deck(
-            media_types=media_types,
-            genre_name=effective_genre,
-            hide_watched=effective_hide_watched,
-        )
-
-        # Interleave movies and TV shows when both are requested (round-robin)
-        if room.include_movies and room.include_tv_shows:
-            movies = [m for m in new_list if m.get("media_type") == "movie"]
-            tv_shows = [t for t in new_list if t.get("media_type") == "tv_show"]
-            interleaved = []
-            max_len = max(len(movies), len(tv_shows))
-            for i in range(max_len):
-                if i < len(movies):
-                    interleaved.append(movies[i])
-                if i < len(tv_shows):
-                    interleaved.append(tv_shows[i])
-            new_list = interleaved
-
-        # Read swiped media IDs and exclude them from new deck
-        swiped_ids = await uow.swipes.list_swiped_media_ids(code)
-        filtered_deck = [item for item in new_list if item.get("id") not in swiped_ids]
-
-        # If deck is empty after filtering, raise error (no state change)
-        if not filtered_deck:
-            logger.warning(
-                "Empty deck for room %s: genre=%s, hide_watched=%s, excluded %d swiped items",
-                code,
-                effective_genre,
-                effective_hide_watched,
-                len(swiped_ids),
-            )
-            raise EmptyDeckError("No items available. Try a different filter.")
-
-        # Persist in internal format (with "id" field) so get_deck can transform correctly
-        await uow.rooms.set_filters_and_deck(
-            code,
-            genre=effective_genre,
-            hide_watched=effective_hide_watched,
-            movie_data_json=json.dumps(filtered_deck),
-            deck_position_json=json.dumps({}),
-        )
-
-        # Return API format (id → media_id) for immediate use by the router
-        api_deck = []
-        for item in filtered_deck:
-            api_item = {k: v for k, v in item.items() if k != "id"}
-            api_item["media_id"] = item.get("id")
-            api_deck.append(api_item)
-        return api_deck
-
     async def set_genre(
         self,
         code: str,
@@ -373,7 +272,25 @@ class RoomLifecycleService:
         uow: DatabaseUnitOfWork,
     ) -> list[dict[str, Any]]:
         """Set genre filter and rebuild deck."""
-        new_deck = await self._rebuild_deck(code, provider, uow, genre=genre)
+        room = await uow.rooms.get_room(code)
+        if room is None:
+            raise EmptyDeckError("Room not found")
+
+        media_types = []
+        if room.include_movies:
+            media_types.append("movie")
+        if room.include_tv_shows:
+            media_types.append("tv_show")
+
+        new_deck = await build_deck(
+            provider=provider,
+            uow=uow,
+            room_code=code,
+            media_types=media_types,
+            genre=genre,
+            hide_watched=room.hide_watched,
+            persist=True,
+        )
         # Append genre_changed event on success
         instance = await uow.session_instances.get_by_pairing_code(code)
         if instance:
@@ -390,8 +307,24 @@ class RoomLifecycleService:
         uow: DatabaseUnitOfWork,
     ) -> list[dict[str, Any]]:
         """Set watched filter and rebuild deck."""
-        new_deck = await self._rebuild_deck(
-            code, provider, uow, hide_watched=hide_watched
+        room = await uow.rooms.get_room(code)
+        if room is None:
+            raise EmptyDeckError("Room not found")
+
+        media_types = []
+        if room.include_movies:
+            media_types.append("movie")
+        if room.include_tv_shows:
+            media_types.append("tv_show")
+
+        new_deck = await build_deck(
+            provider=provider,
+            uow=uow,
+            room_code=code,
+            media_types=media_types,
+            genre=room.current_genre,
+            hide_watched=hide_watched,
+            persist=True,
         )
         # Append hide_watched_changed event on success
         instance = await uow.session_instances.get_by_pairing_code(code)

--- a/jellyswipe/tmdb.py
+++ b/jellyswipe/tmdb.py
@@ -1,0 +1,87 @@
+"""Pure TMDB lookup module — zero external dependencies.
+
+All functions are best-effort enrichment. Network failures, missing results,
+and malformed responses return safe defaults (None or []).
+"""
+
+from urllib.parse import urlencode
+
+from jellyswipe.config import TMDB_AUTH_HEADERS
+from jellyswipe.http_client import make_http_request
+
+TMDB_BASE_URL = "https://api.themoviedb.org/3"
+
+
+def lookup_trailer(title: str, year) -> str | None:
+    """Search TMDB for a movie, return YouTube trailer key.
+
+    Steps:
+    1. GET /search/movie?query={title}&year={year}
+    2. Take first result's tmdb_id
+    3. GET /movie/{tmdb_id}/videos
+    4. Find first YouTube Trailer
+
+    All failures return None. Best-effort enrichment.
+    """
+    try:
+        params = urlencode({"query": title, "year": year})
+        search_url = f"{TMDB_BASE_URL}/search/movie?{params}"
+        search_response = make_http_request(
+            method="GET", url=search_url, headers=TMDB_AUTH_HEADERS, timeout=(5, 15)
+        )
+        r = search_response.json()
+        if not r.get("results"):
+            return None
+        tmdb_id = r["results"][0]["id"]
+
+        v_url = f"{TMDB_BASE_URL}/movie/{tmdb_id}/videos"
+        videos_response = make_http_request(
+            method="GET", url=v_url, headers=TMDB_AUTH_HEADERS, timeout=(5, 15)
+        )
+        v_res = videos_response.json()
+        trailers = [
+            v
+            for v in v_res.get("results", [])
+            if v["site"] == "YouTube" and v["type"] == "Trailer"
+        ]
+        return trailers[0]["key"] if trailers else None
+    except Exception:
+        return None
+
+
+def lookup_cast(title: str, year) -> list[dict]:
+    """Search TMDB for a movie, return up to 8 cast members.
+
+    Returns list of {"name": str, "character": str, "profile_path": str | None}.
+    All failures return [].
+    """
+    try:
+        params = urlencode({"query": title, "year": year})
+        search_url = f"{TMDB_BASE_URL}/search/movie?{params}"
+        search_response = make_http_request(
+            method="GET", url=search_url, headers=TMDB_AUTH_HEADERS, timeout=(5, 15)
+        )
+        r = search_response.json()
+        if not r.get("results"):
+            return []
+        tmdb_id = r["results"][0]["id"]
+
+        credits_url = f"{TMDB_BASE_URL}/movie/{tmdb_id}/credits"
+        credits_response = make_http_request(
+            method="GET", url=credits_url, headers=TMDB_AUTH_HEADERS, timeout=(5, 15)
+        )
+        c_res = credits_response.json()
+        cast = []
+        for actor in c_res.get("cast", [])[:8]:
+            cast.append(
+                {
+                    "name": actor["name"],
+                    "character": actor.get("character", ""),
+                    "profile_path": f"https://image.tmdb.org/t/p/w185{actor['profile_path']}"
+                    if actor.get("profile_path")
+                    else None,
+                }
+            )
+        return cast
+    except Exception:
+        return []

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from jellyswipe.migrations import build_sqlite_url, upgrade_to_head
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-_EXPECTED_REVISION = "0004_session_event_ledger"
+_EXPECTED_REVISION = "0005_tmdb_cache"
 
 
 def _table_names(conn: sqlite3.Connection) -> set[str]:

--- a/tests/test_models_metadata.py
+++ b/tests/test_models_metadata.py
@@ -11,6 +11,7 @@ def test_target_metadata_contains_phase36_tables():
         "session_events",
         "session_instances",
         "swipes",
+        "tmdb_cache",
     ]
 
 

--- a/tests/test_tmdb.py
+++ b/tests/test_tmdb.py
@@ -1,0 +1,265 @@
+"""Unit tests for the pure TMDB lookup module.
+
+Tests cover lookup_trailer and lookup_cast with mocked HTTP calls.
+"""
+
+from unittest.mock import Mock
+
+from jellyswipe.tmdb import lookup_trailer, lookup_cast
+
+
+class TestLookupTrailer:
+    """Test suite for lookup_trailer function."""
+
+    def _make_mock_response(self, json_data):
+        """Helper to create a mock response object."""
+        mock = Mock()
+        mock.json.return_value = json_data
+        return mock
+
+    def test_successful_lookup_returns_youtube_key(self, mocker):
+        """Search returns results, videos returns YouTube trailer → returns key."""
+        mock_search = self._make_mock_response(
+            {
+                "results": [
+                    {"id": 12345, "title": "Test Movie", "release_date": "2024-01-01"}
+                ]
+            }
+        )
+        mock_videos = self._make_mock_response(
+            {
+                "results": [
+                    {"site": "YouTube", "type": "Trailer", "key": "abc123"},
+                    {"site": "YouTube", "type": "Teaser", "key": "xyz789"},
+                ]
+            }
+        )
+
+        mocker.patch(
+            "jellyswipe.tmdb.make_http_request",
+            side_effect=[mock_search, mock_videos],
+        )
+
+        result = lookup_trailer("Test Movie", 2024)
+        assert result == "abc123"
+
+    def test_no_tmdb_match_returns_none(self, mocker):
+        """Search returns empty results → returns None."""
+        mock_search = self._make_mock_response({"results": []})
+        mocker.patch("jellyswipe.tmdb.make_http_request", return_value=mock_search)
+
+        result = lookup_trailer("Nonexistent Movie", 2024)
+        assert result is None
+
+    def test_no_trailer_found_returns_none(self, mocker):
+        """Search returns results, videos returns non-YouTube entries → returns None."""
+        mock_search = self._make_mock_response({"results": [{"id": 12345}]})
+        mock_videos = self._make_mock_response(
+            {
+                "results": [
+                    {"site": "Vimeo", "type": "Trailer", "key": "vimeo123"},
+                    {"site": "YouTube", "type": "Behind the Scenes", "key": "bts456"},
+                ]
+            }
+        )
+
+        mocker.patch(
+            "jellyswipe.tmdb.make_http_request",
+            side_effect=[mock_search, mock_videos],
+        )
+
+        result = lookup_trailer("Test Movie", 2024)
+        assert result is None
+
+    def test_network_failure_on_search_returns_none(self, mocker):
+        """Search raises exception → returns None."""
+        mocker.patch(
+            "jellyswipe.tmdb.make_http_request",
+            side_effect=Exception("Connection refused"),
+        )
+
+        result = lookup_trailer("Test Movie", 2024)
+        assert result is None
+
+    def test_network_failure_on_videos_returns_none(self, mocker):
+        """Search succeeds, videos raises → returns None."""
+        mock_search = self._make_mock_response({"results": [{"id": 12345}]})
+
+        mocker.patch(
+            "jellyswipe.tmdb.make_http_request",
+            side_effect=[mock_search, Exception("Timeout")],
+        )
+
+        result = lookup_trailer("Test Movie", 2024)
+        assert result is None
+
+    def test_malformed_response_returns_none(self, mocker):
+        """Search returns results without id key → returns None."""
+        mock_search = self._make_mock_response(
+            {
+                "results": [{"title": "Test Movie"}]  # missing "id"
+            }
+        )
+        mocker.patch("jellyswipe.tmdb.make_http_request", return_value=mock_search)
+
+        result = lookup_trailer("Test Movie", 2024)
+        assert result is None
+
+    def test_malformed_videos_response_returns_none(self, mocker):
+        """Videos response missing results key → returns None."""
+        mock_search = self._make_mock_response({"results": [{"id": 12345}]})
+        mock_videos = self._make_mock_response({})  # no "results" key
+
+        mocker.patch(
+            "jellyswipe.tmdb.make_http_request",
+            side_effect=[mock_search, mock_videos],
+        )
+
+        result = lookup_trailer("Test Movie", 2024)
+        assert result is None
+
+
+class TestLookupCast:
+    """Test suite for lookup_cast function."""
+
+    def _make_mock_response(self, json_data):
+        """Helper to create a mock response object."""
+        mock = Mock()
+        mock.json.return_value = json_data
+        return mock
+
+    def test_successful_lookup_returns_cast_list(self, mocker):
+        """Search + credits return data → returns list of cast dicts."""
+        cast_members = [
+            {
+                "name": f"Actor {i}",
+                "character": f"Character {i}",
+                "profile_path": f"/img{i}.jpg",
+            }
+            for i in range(10)
+        ]
+        mock_search = self._make_mock_response({"results": [{"id": 12345}]})
+        mock_credits = self._make_mock_response({"cast": cast_members})
+
+        mocker.patch(
+            "jellyswipe.tmdb.make_http_request",
+            side_effect=[mock_search, mock_credits],
+        )
+
+        result = lookup_cast("Test Movie", 2024)
+        assert len(result) == 8  # capped at 8
+        assert result[0] == {
+            "name": "Actor 0",
+            "character": "Character 0",
+            "profile_path": "https://image.tmdb.org/t/p/w185/img0.jpg",
+        }
+
+    def test_fewer_than_8_cast_members_returns_all(self, mocker):
+        """Returns all available when fewer than 8."""
+        cast_members = [
+            {"name": "Actor 1", "character": "Lead", "profile_path": "/lead.jpg"},
+            {
+                "name": "Actor 2",
+                "character": "Supporting",
+                "profile_path": "/support.jpg",
+            },
+        ]
+        mock_search = self._make_mock_response({"results": [{"id": 12345}]})
+        mock_credits = self._make_mock_response({"cast": cast_members})
+
+        mocker.patch(
+            "jellyswipe.tmdb.make_http_request",
+            side_effect=[mock_search, mock_credits],
+        )
+
+        result = lookup_cast("Test Movie", 2024)
+        assert len(result) == 2
+
+    def test_no_tmdb_match_returns_empty_list(self, mocker):
+        """Search returns empty results → returns []."""
+        mock_search = self._make_mock_response({"results": []})
+        mocker.patch("jellyswipe.tmdb.make_http_request", return_value=mock_search)
+
+        result = lookup_cast("Nonexistent Movie", 2024)
+        assert result == []
+
+    def test_network_failure_returns_empty_list(self, mocker):
+        """Search raises exception → returns []."""
+        mocker.patch(
+            "jellyswipe.tmdb.make_http_request",
+            side_effect=Exception("Connection refused"),
+        )
+
+        result = lookup_cast("Test Movie", 2024)
+        assert result == []
+
+    def test_network_failure_on_credits_returns_empty_list(self, mocker):
+        """Search succeeds, credits raises → returns []."""
+        mock_search = self._make_mock_response({"results": [{"id": 12345}]})
+        mocker.patch(
+            "jellyswipe.tmdb.make_http_request",
+            side_effect=[mock_search, Exception("Timeout")],
+        )
+
+        result = lookup_cast("Test Movie", 2024)
+        assert result == []
+
+    def test_malformed_response_returns_empty_list(self, mocker):
+        """Credits response missing cast key → returns []."""
+        mock_search = self._make_mock_response({"results": [{"id": 12345}]})
+        mock_credits = self._make_mock_response({})  # no "cast" key
+
+        mocker.patch(
+            "jellyswipe.tmdb.make_http_request",
+            side_effect=[mock_search, mock_credits],
+        )
+
+        result = lookup_cast("Test Movie", 2024)
+        assert result == []
+
+    def test_cast_member_without_profile_path_has_none(self, mocker):
+        """Cast member without profile_path → profile_path is None in result."""
+        cast_members = [
+            {"name": "Actor 1", "character": "Lead"},  # no profile_path
+            {"name": "Actor 2", "character": "Supporting", "profile_path": None},
+        ]
+        mock_search = self._make_mock_response({"results": [{"id": 12345}]})
+        mock_credits = self._make_mock_response({"cast": cast_members})
+
+        mocker.patch(
+            "jellyswipe.tmdb.make_http_request",
+            side_effect=[mock_search, mock_credits],
+        )
+
+        result = lookup_cast("Test Movie", 2024)
+        assert len(result) == 2
+        assert result[0]["profile_path"] is None
+        assert result[1]["profile_path"] is None
+
+    def test_cast_member_dict_shape(self, mocker):
+        """Verify cast member dict has correct shape: name, character, profile_path."""
+        mock_search = self._make_mock_response({"results": [{"id": 12345}]})
+        mock_credits = self._make_mock_response(
+            {
+                "cast": [
+                    {
+                        "name": "Test Actor",
+                        "character": "Test Role",
+                        "profile_path": "/test.jpg",
+                    }
+                ]
+            }
+        )
+
+        mocker.patch(
+            "jellyswipe.tmdb.make_http_request",
+            side_effect=[mock_search, mock_credits],
+        )
+
+        result = lookup_cast("Test Movie", 2024)
+        assert len(result) == 1
+        member = result[0]
+        assert set(member.keys()) == {"name", "character", "profile_path"}
+        assert member["name"] == "Test Actor"
+        assert member["character"] == "Test Role"
+        assert member["profile_path"] == "https://image.tmdb.org/t/p/w185/test.jpg"

--- a/tests/test_tmdb_auth.py
+++ b/tests/test_tmdb_auth.py
@@ -72,9 +72,9 @@ class TestBearerTokenHeaders:
         }
         second_response.status_code = 200
 
-        # Patch where make_http_request is looked up: jellyswipe.routers.media (D-14)
+        # Patch where make_http_request is looked up: jellyswipe.tmdb (ORCH-020)
         with patch(
-            "jellyswipe.routers.media.make_http_request",
+            "jellyswipe.tmdb.make_http_request",
             side_effect=[mock_response, second_response],
         ) as mock_http:
             response = client.get("/get-trailer/test_movie_id")
@@ -112,9 +112,9 @@ class TestBearerTokenHeaders:
         }
         second_response.status_code = 200
 
-        # Patch where make_http_request is looked up: jellyswipe.routers.media (D-14)
+        # Patch where make_http_request is looked up: jellyswipe.tmdb (ORCH-020)
         with patch(
-            "jellyswipe.routers.media.make_http_request",
+            "jellyswipe.tmdb.make_http_request",
             side_effect=[mock_response, second_response],
         ) as mock_http:
             response = client.get("/cast/test_movie_id")

--- a/tests/test_tmdb_cache_repo.py
+++ b/tests/test_tmdb_cache_repo.py
@@ -1,0 +1,237 @@
+"""Repository-level unit tests for TMDB cache persistence."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import jellyswipe.db
+import jellyswipe.db_paths
+import pytest
+from sqlalchemy import text
+
+from jellyswipe.db_runtime import (
+    build_async_sqlite_url,
+    dispose_runtime,
+    get_sessionmaker,
+    initialize_runtime,
+)
+from jellyswipe.db_uow import DatabaseUnitOfWork
+from jellyswipe.migrations import build_sqlite_url, upgrade_to_head
+
+
+@pytest.fixture(autouse=True)
+def reset_runtime(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_PATH", raising=False)
+    monkeypatch.setattr(jellyswipe.db_paths.application_db_path, "path", None)
+    yield
+
+
+@pytest.fixture
+async def runtime_sessionmaker(db_path, monkeypatch):
+    sync_database_url = build_sqlite_url(db_path)
+    runtime_database_url = build_async_sqlite_url(db_path)
+
+    monkeypatch.setattr(jellyswipe.db_paths.application_db_path, "path", db_path)
+    monkeypatch.setenv("DB_PATH", db_path)
+    monkeypatch.setenv("DATABASE_URL", sync_database_url)
+
+    upgrade_to_head(sync_database_url)
+    await initialize_runtime(runtime_database_url)
+    yield get_sessionmaker()
+    await dispose_runtime()
+
+
+@pytest.mark.anyio
+class TestTmdbCacheRepository:
+    async def test_put_then_get_returns_stored_record(self, runtime_sessionmaker):
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.tmdb_cache.put("movie-1", "trailer", json.dumps({"key": "value"}))
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            record = await uow.tmdb_cache.get("movie-1", "trailer")
+
+        assert record is not None
+        assert record.media_id == "movie-1"
+        assert record.lookup_type == "trailer"
+        assert json.loads(record.result_json) == {"key": "value"}
+
+    async def test_get_with_fresh_entry_returns_record(self, runtime_sessionmaker):
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.tmdb_cache.put("movie-2", "trailer", json.dumps({"fresh": True}))
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            record = await uow.tmdb_cache.get("movie-2", "trailer", max_age_days=7)
+
+        assert record is not None
+        assert record.media_id == "movie-2"
+
+    async def test_get_with_stale_entry_returns_none(self, runtime_sessionmaker):
+        stale_time = (datetime.now(timezone.utc) - timedelta(days=8)).isoformat()
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await session.execute(
+                text(
+                    "INSERT INTO tmdb_cache (media_id, lookup_type, result_json, fetched_at) "
+                    "VALUES (:media_id, :lookup_type, :result_json, :fetched_at)"
+                ),
+                {
+                    "media_id": "movie-3",
+                    "lookup_type": "trailer",
+                    "result_json": json.dumps({"stale": True}),
+                    "fetched_at": stale_time,
+                },
+            )
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            record = await uow.tmdb_cache.get("movie-3", "trailer", max_age_days=7)
+
+        assert record is None
+
+    async def test_get_at_exact_max_age_boundary_returns_none(
+        self, runtime_sessionmaker
+    ):
+        boundary_time = (datetime.now(timezone.utc) - timedelta(days=7)).isoformat()
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await session.execute(
+                text(
+                    "INSERT INTO tmdb_cache (media_id, lookup_type, result_json, fetched_at) "
+                    "VALUES (:media_id, :lookup_type, :result_json, :fetched_at)"
+                ),
+                {
+                    "media_id": "movie-4",
+                    "lookup_type": "trailer",
+                    "result_json": json.dumps({"boundary": True}),
+                    "fetched_at": boundary_time,
+                },
+            )
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            record = await uow.tmdb_cache.get("movie-4", "trailer", max_age_days=7)
+
+        assert record is None
+
+    async def test_get_for_missing_media_id_returns_none(self, runtime_sessionmaker):
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            record = await uow.tmdb_cache.get("nonexistent", "trailer")
+
+        assert record is None
+
+    async def test_get_filters_by_lookup_type(self, runtime_sessionmaker):
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.tmdb_cache.put(
+                "movie-5", "trailer", json.dumps({"type": "trailer"})
+            )
+            await uow.tmdb_cache.put("movie-5", "cast", json.dumps({"type": "cast"}))
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            trailer_record = await uow.tmdb_cache.get("movie-5", "trailer")
+            cast_record = await uow.tmdb_cache.get("movie-5", "cast")
+
+        assert trailer_record is not None
+        assert json.loads(trailer_record.result_json) == {"type": "trailer"}
+        assert cast_record is not None
+        assert json.loads(cast_record.result_json) == {"type": "cast"}
+
+    async def test_put_upserts_overwrites_existing(self, runtime_sessionmaker):
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.tmdb_cache.put("movie-6", "trailer", json.dumps({"version": 1}))
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.tmdb_cache.put("movie-6", "trailer", json.dumps({"version": 2}))
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            record = await uow.tmdb_cache.get("movie-6", "trailer")
+
+        assert record is not None
+        assert json.loads(record.result_json) == {"version": 2}
+
+    async def test_cleanup_stale_deletes_old_entries_returns_count(
+        self, runtime_sessionmaker
+    ):
+        stale_time = (datetime.now(timezone.utc) - timedelta(days=31)).isoformat()
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await session.execute(
+                text(
+                    "INSERT INTO tmdb_cache (media_id, lookup_type, result_json, fetched_at) "
+                    "VALUES (:media_id, :lookup_type, :result_json, :fetched_at)"
+                ),
+                {
+                    "media_id": "movie-old-1",
+                    "lookup_type": "trailer",
+                    "result_json": json.dumps({"old": True}),
+                    "fetched_at": stale_time,
+                },
+            )
+            await session.execute(
+                text(
+                    "INSERT INTO tmdb_cache (media_id, lookup_type, result_json, fetched_at) "
+                    "VALUES (:media_id, :lookup_type, :result_json, :fetched_at)"
+                ),
+                {
+                    "media_id": "movie-old-2",
+                    "lookup_type": "cast",
+                    "result_json": json.dumps({"old": True}),
+                    "fetched_at": stale_time,
+                },
+            )
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            deleted = await uow.tmdb_cache.cleanup_stale(max_age_days=30)
+
+        assert deleted == 2
+
+    async def test_cleanup_stale_does_not_delete_fresh_entries(
+        self, runtime_sessionmaker
+    ):
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.tmdb_cache.put(
+                "movie-fresh", "trailer", json.dumps({"fresh": True})
+            )
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            deleted = await uow.tmdb_cache.cleanup_stale(max_age_days=30)
+
+        assert deleted == 0
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            record = await uow.tmdb_cache.get("movie-fresh", "trailer")
+
+        assert record is not None
+
+    async def test_cleanup_stale_with_no_stale_entries_returns_zero(
+        self, runtime_sessionmaker
+    ):
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            deleted = await uow.tmdb_cache.cleanup_stale(max_age_days=30)
+
+        assert deleted == 0

--- a/uv.lock
+++ b/uv.lock
@@ -273,7 +273,7 @@ wheels = [
 
 [[package]]
 name = "jellyswipe"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Replace scattered deck-building code in RoomLifecycleService with calls to the unified build_deck pipeline from deck_pipeline module.

## Changes
- Added deck_pipeline.py with unified build_deck function
- Updated create_room, create_solo_room, set_genre, set_watched_filter to use build_deck
- Deleted _rebuild_deck method
- Imported DeckProvider/EmptyDeckError from deck_pipeline

## Validation
- uv run pytest tests/ - PASS
- uv run ruff check jellyswipe - PASS
- docker build -t jellyswipe-test . - PASS