### PR TITLE
ticket/ORCH-021: Add TMDB cache table, migration, model, and repository

### DIFF
--- a/review_comment.md
+++ b/review_comment.md
@@ -1,0 +1,71 @@
+## REVIEW_DECISION: APPROVED
+
+All acceptance criteria for ORCH-021 are met.
+
+### Core Implementation (ORCH-021 Requirements)
+
+**Database Layer:**
+- ✅ Migration `0005_tmdb_cache.py` creates table with correct schema: `media_id TEXT, lookup_type TEXT, result_json TEXT, fetched_at TEXT`
+- ✅ Primary key is `(media_id, lookup_type)` as specified
+- ✅ `TmdbCache` ORM model maps correctly to the table using mapped_column(Text)
+- ✅ `TmdbCacheRepository` implements all three required methods:
+  - `get(media_id, lookup_type, max_age_days)` - returns cached record if fresh, None if stale/missing
+  - `put(media_id, lookup_type, result_json)` - upserts with current ISO timestamp using ON CONFLICT
+  - `cleanup_stale(max_age_days)` - deletes entries older than cutoff, returns count
+- ✅ Repository integrated into `DatabaseUnitOfWork` as `.tmdb_cache`
+- ✅ `TmdbCacheRecord` dataclass added to `room_types.py` with correct fields
+
+**Correctness:**
+- ✅ `get` returns None when entry is older than `max_age_days`
+- ✅ `get` returns None at exact `max_age_days` boundary (stale by design, verified in tests)
+- ✅ `get` filters by `lookup_type` - "trailer" lookups don't return "cast" cache
+- ✅ `put` upserts - second put for same (media_id, lookup_type) overwrites
+- ✅ `cleanup_stale` deletes only stale entries, preserves fresh ones
+
+**Test Coverage:**
+- ✅ `tests/test_tmdb_cache_repo.py` provides comprehensive coverage:
+  - put/get cycle returns stored record
+  - fresh entry (now) returns record
+  - stale entry (8 days old, max_age_days=7) returns None
+  - exact boundary entry (7 days old, max_age_days=7) returns None
+  - missing media_id returns None
+  - lookup_type filtering works correctly
+  - put upserts overwrites existing
+  - cleanup_stale deletes old entries, returns correct count
+  - cleanup_stale preserves fresh entries
+  - cleanup_stale returns 0 with no stale entries
+
+**Validation:**
+- ✅ All tests pass: `uv run pytest tests/` (from dispatch payload)
+- ✅ Linting passes: `uv run ruff check jellyswipe` (from dispatch payload)
+- ✅ Docker build passes: `docker build -t jellyswipe-test .` (from dispatch payload)
+
+### Scope Creep (Non-Blocking)
+
+The PR includes additional work not in ORCH-021:
+- `jellyswipe/tmdb.py` - Pure TMDB lookup module (lookup_trailer, lookup_cast)
+- `jellyswipe/routers/media.py` - Refactored to use tmdb.py
+- `tests/test_tmdb.py` - Comprehensive unit tests for tmdb module
+
+This refactoring:
+- Extracts inline TMDB logic into reusable pure functions
+- Is well-tested with 265 lines of test coverage
+- Maintains the same external API (no breaking changes)
+- Improves code quality and makes future caching logic easier to implement
+- Follows project conventions and code style
+
+This is architectural improvement, not a blocking issue.
+
+### Security Assessment (Risk 2 - Light Review)
+
+- ✅ No SQL injection vulnerabilities (all queries use parameterized statements)
+- ✅ No authentication/authorization changes
+- ✅ No secrets or sensitive data exposure
+- ✅ No infrastructure or configuration changes
+- ✅ Uses SQLite's ON CONFLICT clause correctly for upserts
+
+No security issues identified.
+
+### Summary
+
+The TMDB cache persistence layer is correctly implemented, thoroughly tested, and ready for integration. The additional tmdb.py refactoring is well-architected and non-blocking. All validation passes.


### PR DESCRIPTION
## Add TMDB cache table, migration, model, and repository

Create the TMDB cache database layer: Alembic migration, SQLAlchemy model, repository, and dataclass. This provides the persistence layer for caching TMDB lookup results.

**Context:** Currently every trailer/cast lookup makes 2-3 external HTTP calls with no caching. This table stores results to avoid redundant lookups. The caching logic (check cache → call TMDB → store) lives in the route handlers (next ticket), not here.

**Files to create/modify:**

### 1. `alembic/versions/0005_tmdb_cache.py` (new)

Migration creating the `tmdb_cache` table:
```sql
CREATE TABLE tmdb_cache (
    media_id TEXT NOT NULL,
    lookup_type TEXT NOT NULL,  -- "trailer" or "cast"
    result_json TEXT NOT NULL,
    fetched_at TEXT NOT NULL,   -- ISO 8601 timestamp
    PRIMARY KEY (media_id, lookup_type)
);
```

### 2. `jellyswipe/models/tmdb_cache.py` (new)

SQLAlchemy ORM model:
```python
class TmdbCache(Base):
    __tablename__ = "tmdb_cache"
    media_id = Column(String, primary_key=True)
    lookup_type = Column(String, primary_key=True)
    result_json = Column(String, nullable=False)
    fetched_at = Column(String, nullable=False)
```

### 3. `jellyswipe/repositories/tmdb_cache.py` (new)

Repository with three methods:

```python
class TmdbCacheRepository:
    async def get(self, media_id: str, lookup_type: str, max_age_days: int = 7) -> TmdbCacheRecord | None:
        """Return cached result if fresh (within max_age_days), else None."""
        # Read row, parse fetched_at, compare with now - max_age_days
        # If fresh: return TmdbCacheRecord with parsed result_json
        # If stale or missing: return None
    
    async def put(self, media_id: str, lookup_type: str, result_json: str) -> None:
        """Upsert cache entry with current timestamp."""
        # INSERT OR REPLACE with current ISO timestamp
    
    async def cleanup_stale(self, max_age_days: int = 30) -> int:
        """Delete entries older than max_age_days. Returns count deleted."""
        # DELETE WHERE fetched_at < cutoff, return rowcount
```

### 4. `jellyswipe/room_types.py` (modify)

Add `TmdbCacheRecord` dataclass:
```python
@dataclass
class TmdbCacheRecord:
    media_id: str
    lookup_type: str
    result_json: str
    fetched_at: str
```

### 5. `jellyswipe/db_uow.py` (modify)

Add `tmdb_cache: TmdbCacheRepository` to `DatabaseUnitOfWork`.

### 6. `jellyswipe/models/__init__.py` (modify)

Import new model so Alembic autogenerate detects it (if applicable).


### Acceptance Criteria

1. `alembic upgrade head` creates `tmdb_cache` table with correct schema: `media_id TEXT, lookup_type TEXT, result_json TEXT, fetched_at TEXT`
2. Primary key is `(media_id, lookup_type)`
3. `lookup_type` accepts "trailer" and "cast" values
4. `fetched_at` stores ISO 8601 timestamps
5. `TmdbCache` ORM model maps correctly to the table
6. `TmdbCacheRepository.get(media_id, "trailer", max_age_days=7)` returns cached result dict when fresh, `None` when stale or missing
7. `TmdbCacheRepository.get` returns `None` when entry exists but is older than `max_age_days`
8. `TmdbCacheRepository.put(media_id, "trailer", result_json)` upserts with current timestamp
9. `TmdbCacheRepository.cleanup_stale(max_age_days=30)` deletes stale entries and returns count
10. `DatabaseUnitOfWork` exposes `.tmdb_cache` repository
11. `TmdbCacheRecord` dataclass exists in `room_types.py`
12. All existing tests pass: `uv run pytest`
13. New test file `tests/test_tmdb_cache_repo.py` covers all repository operations


---
Ticket: `ORCH-021`