### PR TITLE
feat(ORCH-022): wire TMDB module and caching into media route handlers

### DIFF
--- a/jellyswipe/routers/media.py
+++ b/jellyswipe/routers/media.py
@@ -3,21 +3,21 @@
 Per D-06, D-07: 4 media routes with TMDB API integration and rate limiting.
 """
 
+import json
 import logging
 import traceback
 
 from fastapi import APIRouter, Request, Depends
 from jellyswipe import XSSSafeJSONResponse
-from urllib.parse import urlencode
 
 from jellyswipe.dependencies import (
     require_auth,
     AuthUser,
     check_rate_limit,
     get_provider,
+    DBUoW,
 )
-from jellyswipe.http_client import make_http_request
-from jellyswipe.config import TMDB_AUTH_HEADERS
+from jellyswipe.tmdb import lookup_trailer, lookup_cast
 
 _logger = logging.getLogger(__name__)
 
@@ -54,30 +54,30 @@ def log_exception(exc: Exception, request: Request, context: dict = None) -> Non
 
 
 @media_router.get("/get-trailer/{movie_id}")
-def get_trailer(movie_id: str, request: Request, _: None = Depends(check_rate_limit)):
+async def get_trailer(
+    movie_id: str, request: Request, uow: DBUoW, _: None = Depends(check_rate_limit)
+):
     """Get YouTube trailer key for a movie."""
     try:
+        # Check cache first
+        cached = await uow.tmdb_cache.get(movie_id, "trailer")
+        if cached:
+            result = json.loads(cached.result_json)
+            if result.get("youtube_key"):
+                return result
+            return make_error_response("Not found", 404, request)
+
+        # Cache miss — resolve item and call TMDB
         item = get_provider().resolve_item_for_tmdb(movie_id)
-        params = urlencode({"query": item.title, "year": item.year})
-        search_url = f"https://api.themoviedb.org/3/search/movie?{params}"
-        search_response = make_http_request(
-            method="GET", url=search_url, headers=TMDB_AUTH_HEADERS, timeout=(5, 15)
-        )
-        r = search_response.json()
-        if r.get("results"):
-            tmdb_id = r["results"][0]["id"]
-            v_url = f"https://api.themoviedb.org/3/movie/{tmdb_id}/videos"
-            videos_response = make_http_request(
-                method="GET", url=v_url, headers=TMDB_AUTH_HEADERS, timeout=(5, 15)
-            )
-            v_res = videos_response.json()
-            trailers = [
-                v
-                for v in v_res.get("results", [])
-                if v["site"] == "YouTube" and v["type"] == "Trailer"
-            ]
-            if trailers:
-                return {"youtube_key": trailers[0]["key"]}
+        youtube_key = lookup_trailer(item.title, item.year)
+
+        if youtube_key:
+            result = {"youtube_key": youtube_key}
+            await uow.tmdb_cache.put(movie_id, "trailer", json.dumps(result))
+            return result
+
+        # No trailer found — cache the miss to avoid repeated lookups
+        await uow.tmdb_cache.put(movie_id, "trailer", json.dumps({}))
         return make_error_response("Not found", 404, request)
     except RuntimeError as e:
         if "item lookup failed" in str(e).lower():
@@ -90,39 +90,23 @@ def get_trailer(movie_id: str, request: Request, _: None = Depends(check_rate_li
 
 
 @media_router.get("/cast/{movie_id}")
-def get_cast(movie_id: str, request: Request, _: None = Depends(check_rate_limit)):
+async def get_cast(
+    movie_id: str, request: Request, uow: DBUoW, _: None = Depends(check_rate_limit)
+):
     """Get cast information for a movie."""
     try:
+        # Check cache first
+        cached = await uow.tmdb_cache.get(movie_id, "cast")
+        if cached:
+            return {"cast": json.loads(cached.result_json)}
+
+        # Cache miss — resolve item and call TMDB
         item = get_provider().resolve_item_for_tmdb(movie_id)
-        params = urlencode({"query": item.title, "year": item.year})
-        search_url = f"https://api.themoviedb.org/3/search/movie?{params}"
-        search_response = make_http_request(
-            method="GET", url=search_url, headers=TMDB_AUTH_HEADERS, timeout=(5, 15)
-        )
-        r = search_response.json()
-        if r.get("results"):
-            tmdb_id = r["results"][0]["id"]
-            credits_url = f"https://api.themoviedb.org/3/movie/{tmdb_id}/credits"
-            credits_response = make_http_request(
-                method="GET",
-                url=credits_url,
-                headers=TMDB_AUTH_HEADERS,
-                timeout=(5, 15),
-            )
-            c_res = credits_response.json()
-            cast = []
-            for actor in c_res.get("cast", [])[:8]:
-                cast.append(
-                    {
-                        "name": actor["name"],
-                        "character": actor.get("character", ""),
-                        "profile_path": f"https://image.tmdb.org/t/p/w185{actor['profile_path']}"
-                        if actor.get("profile_path")
-                        else None,
-                    }
-                )
-            return {"cast": cast}
-        return {"cast": []}
+        cast = lookup_cast(item.title, item.year)
+
+        # Store in cache (even if empty)
+        await uow.tmdb_cache.put(movie_id, "cast", json.dumps(cast))
+        return {"cast": cast}
     except RuntimeError as e:
         if "item lookup failed" in str(e).lower():
             return make_error_response(

--- a/jellyswipe/tmdb.py
+++ b/jellyswipe/tmdb.py
@@ -1,0 +1,101 @@
+"""Pure TMDB module — search, trailer, and cast lookups.
+
+All failures (network, not found, bad response) return None or [].
+Uses make_http_request for actual HTTP calls.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+from urllib.parse import urlencode
+
+from jellyswipe.config import TMDB_AUTH_HEADERS
+from jellyswipe.http_client import make_http_request
+
+_logger = logging.getLogger(__name__)
+
+TMDB_SEARCH_TIMEOUT = (5, 15)
+TMDB_BASE = "https://api.themoviedb.org/3"
+
+
+def lookup_trailer(title: str, year: Optional[int]) -> Optional[str]:
+    """Search TMDB for a movie and return the YouTube trailer key.
+
+    Returns None on any failure (network error, no match, no trailer).
+    """
+    try:
+        params = urlencode({"query": title, "year": year})
+        search_url = f"{TMDB_BASE}/search/movie?{params}"
+        search_response = make_http_request(
+            method="GET",
+            url=search_url,
+            headers=TMDB_AUTH_HEADERS,
+            timeout=TMDB_SEARCH_TIMEOUT,
+        )
+        r = search_response.json()
+        if not r.get("results"):
+            return None
+
+        tmdb_id = r["results"][0]["id"]
+        v_url = f"{TMDB_BASE}/movie/{tmdb_id}/videos"
+        videos_response = make_http_request(
+            method="GET",
+            url=v_url,
+            headers=TMDB_AUTH_HEADERS,
+            timeout=TMDB_SEARCH_TIMEOUT,
+        )
+        v_res = videos_response.json()
+        trailers = [
+            v
+            for v in v_res.get("results", [])
+            if v.get("site") == "YouTube" and v.get("type") == "Trailer"
+        ]
+        if trailers:
+            return trailers[0]["key"]
+        return None
+    except Exception:
+        return None
+
+
+def lookup_cast(title: str, year: Optional[int]) -> list[dict]:
+    """Search TMDB for a movie and return up to 8 cast members.
+
+    Returns [] on any failure (network error, no match).
+    """
+    try:
+        params = urlencode({"query": title, "year": year})
+        search_url = f"{TMDB_BASE}/search/movie?{params}"
+        search_response = make_http_request(
+            method="GET",
+            url=search_url,
+            headers=TMDB_AUTH_HEADERS,
+            timeout=TMDB_SEARCH_TIMEOUT,
+        )
+        r = search_response.json()
+        if not r.get("results"):
+            return []
+
+        tmdb_id = r["results"][0]["id"]
+        credits_url = f"{TMDB_BASE}/movie/{tmdb_id}/credits"
+        credits_response = make_http_request(
+            method="GET",
+            url=credits_url,
+            headers=TMDB_AUTH_HEADERS,
+            timeout=TMDB_SEARCH_TIMEOUT,
+        )
+        c_res = credits_response.json()
+        cast = []
+        for actor in c_res.get("cast", [])[:8]:
+            cast.append(
+                {
+                    "name": actor["name"],
+                    "character": actor.get("character", ""),
+                    "profile_path": f"https://image.tmdb.org/t/p/w185{actor['profile_path']}"
+                    if actor.get("profile_path")
+                    else None,
+                }
+            )
+        return cast
+    except Exception:
+        return []

--- a/jellyswipe/tmdb.py
+++ b/jellyswipe/tmdb.py
@@ -54,7 +54,11 @@ def lookup_trailer(title: str, year: Optional[int]) -> Optional[str]:
         if trailers:
             return trailers[0]["key"]
         return None
-    except Exception:
+    except Exception as e:
+        _logger.warning(
+            "TMDB trailer lookup failed",
+            extra={"title": title, "year": year, "error": str(e)},
+        )
         return None
 
 
@@ -97,5 +101,9 @@ def lookup_cast(title: str, year: Optional[int]) -> list[dict]:
                 }
             )
         return cast
-    except Exception:
+    except Exception as e:
+        _logger.warning(
+            "TMDB cast lookup failed",
+            extra={"title": title, "year": year, "error": str(e)},
+        )
         return []

--- a/tests/test_routes_media.py
+++ b/tests/test_routes_media.py
@@ -1,0 +1,289 @@
+"""Tests for media route handlers with TMDB caching.
+
+Tests cover cache hit/miss behavior for trailer and cast routes,
+verifying that TMDB lookups are skipped on cache hits and that
+cache misses are properly stored.
+"""
+
+import json
+import os
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+
+from jellyswipe.db_paths import application_db_path
+from tests.conftest import set_session_cookie
+
+
+def _sqlite_conn():
+    path = application_db_path.path
+    assert path is not None
+    import sqlite3
+
+    conn = sqlite3.connect(path, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys=ON")
+    return conn
+
+
+def _seed_cache(media_id, lookup_type, result_json):
+    """Insert a cache row directly into the database with timezone-aware timestamp."""
+    conn = _sqlite_conn()
+    now = datetime.now(timezone.utc).isoformat()
+    try:
+        conn.execute(
+            "INSERT INTO tmdb_cache (media_id, lookup_type, result_json, fetched_at) "
+            "VALUES (:media_id, :lookup_type, :result_json, :fetched_at)",
+            {
+                "media_id": media_id,
+                "lookup_type": lookup_type,
+                "result_json": result_json,
+                "fetched_at": now,
+            },
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _set_session(client):
+    """Inject session state for media route tests."""
+    set_session_cookie(client, {"user_id": "verified-user"}, os.environ["FLASK_SECRET"])
+
+
+# ---------------------------------------------------------------------------
+# Trailer route tests
+# ---------------------------------------------------------------------------
+
+
+class TestTrailerRoute:
+    """Tests for GET /get-trailer/{movie_id}."""
+
+    def test_trailer_cache_hit_returns_cached_data(self, client, app):
+        """Pre-populated cache returns cached youtube_key without TMDB calls."""
+        _seed_cache("movie-1", "trailer", json.dumps({"youtube_key": "abc123"}))
+        _set_session(client)
+
+        with patch("jellyswipe.routers.media.lookup_trailer") as mock_lookup:
+            resp = client.get("/get-trailer/movie-1")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["youtube_key"] == "abc123"
+        mock_lookup.assert_not_called()
+
+    def test_trailer_cache_hit_empty_result_returns_404(self, client, app):
+        """Cached miss ({}) returns 404 without TMDB calls."""
+        _seed_cache("movie-2", "trailer", json.dumps({}))
+        _set_session(client)
+
+        with patch("jellyswipe.routers.media.lookup_trailer") as mock_lookup:
+            resp = client.get("/get-trailer/movie-2")
+
+        assert resp.status_code == 404
+        mock_lookup.assert_not_called()
+
+    def test_trailer_cache_miss_stores_and_returns(self, client, app):
+        """Cache miss resolves item, calls lookup_trailer, stores result, returns."""
+        _set_session(client)
+
+        with patch("jellyswipe.routers.media.lookup_trailer") as mock_lookup:
+            mock_lookup.return_value = "xyz789"
+            resp = client.get("/get-trailer/movie-3")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["youtube_key"] == "xyz789"
+        mock_lookup.assert_called_once()
+
+        # Verify it was stored in cache
+        conn = _sqlite_conn()
+        try:
+            row = conn.execute(
+                "SELECT result_json FROM tmdb_cache WHERE media_id = 'movie-3' AND lookup_type = 'trailer'"
+            ).fetchone()
+            assert row is not None
+            assert json.loads(row["result_json"]) == {"youtube_key": "xyz789"}
+        finally:
+            conn.close()
+
+    def test_trailer_cache_miss_no_trailer_stores_empty(self, client, app):
+        """lookup_trailer returns None → route stores {}, returns 404."""
+        _set_session(client)
+
+        with patch("jellyswipe.routers.media.lookup_trailer") as mock_lookup:
+            mock_lookup.return_value = None
+            resp = client.get("/get-trailer/movie-4")
+
+        assert resp.status_code == 404
+        mock_lookup.assert_called_once()
+
+        # Verify miss was cached
+        conn = _sqlite_conn()
+        try:
+            row = conn.execute(
+                "SELECT result_json FROM tmdb_cache WHERE media_id = 'movie-4' AND lookup_type = 'trailer'"
+            ).fetchone()
+            assert row is not None
+            assert json.loads(row["result_json"]) == {}
+        finally:
+            conn.close()
+
+    def test_trailer_second_call_hits_cache(self, client, app):
+        """First call misses and stores; second call hits cache."""
+        _set_session(client)
+
+        with patch("jellyswipe.routers.media.lookup_trailer") as mock_lookup:
+            mock_lookup.return_value = "first-call-key"
+            resp1 = client.get("/get-trailer/movie-5")
+
+        assert resp1.status_code == 200
+        assert resp1.json()["youtube_key"] == "first-call-key"
+        assert mock_lookup.call_count == 1
+
+        # Second call — should hit cache
+        with patch("jellyswipe.routers.media.lookup_trailer") as mock_lookup2:
+            resp2 = client.get("/get-trailer/movie-5")
+
+        assert resp2.status_code == 200
+        assert resp2.json()["youtube_key"] == "first-call-key"
+        mock_lookup2.assert_not_called()
+
+    def test_trailer_item_lookup_failure_returns_404(self, client, app):
+        """Jellyfin item resolution failure returns 404."""
+        _set_session(client)
+
+        from tests.conftest import FakeProvider
+        import jellyswipe.config as app_config
+        import jellyswipe as app_module
+        from jellyswipe.dependencies import get_provider
+
+        original = app_config._provider_singleton
+
+        class FailingProvider(FakeProvider):
+            def resolve_item_for_tmdb(self, movie_id):
+                raise RuntimeError("item lookup failed")
+
+        failing = FailingProvider()
+        app_config._provider_singleton = failing
+        app_module._provider_singleton = failing
+        app.dependency_overrides[get_provider] = lambda: failing
+
+        try:
+            resp = client.get("/get-trailer/nonexistent")
+            assert resp.status_code == 404
+            assert "Movie metadata not found" in resp.json()["error"]
+        finally:
+            app_config._provider_singleton = original
+            app_module._provider_singleton = original
+
+
+# ---------------------------------------------------------------------------
+# Cast route tests
+# ---------------------------------------------------------------------------
+
+
+class TestCastRoute:
+    """Tests for GET /cast/{movie_id}."""
+
+    def test_cast_cache_hit_returns_cached_data(self, client, app):
+        """Pre-populated cache returns cached cast without TMDB calls."""
+        cast_data = [
+            {
+                "name": "Actor 1",
+                "character": "Role 1",
+                "profile_path": "http://img/1.jpg",
+            },
+            {"name": "Actor 2", "character": "Role 2", "profile_path": None},
+        ]
+        _seed_cache("movie-10", "cast", json.dumps(cast_data))
+        _set_session(client)
+
+        with patch("jellyswipe.routers.media.lookup_cast") as mock_lookup:
+            resp = client.get("/cast/movie-10")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["cast"] == cast_data
+        mock_lookup.assert_not_called()
+
+    def test_cast_cache_miss_stores_and_returns(self, client, app):
+        """Cache miss resolves item, calls lookup_cast, stores result, returns."""
+        _set_session(client)
+        expected_cast = [
+            {"name": "Test Actor", "character": "Test Role", "profile_path": None}
+        ]
+
+        with patch("jellyswipe.routers.media.lookup_cast") as mock_lookup:
+            mock_lookup.return_value = expected_cast
+            resp = client.get("/cast/movie-11")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["cast"] == expected_cast
+        mock_lookup.assert_called_once()
+
+        # Verify it was stored in cache
+        conn = _sqlite_conn()
+        try:
+            row = conn.execute(
+                "SELECT result_json FROM tmdb_cache WHERE media_id = 'movie-11' AND lookup_type = 'cast'"
+            ).fetchone()
+            assert row is not None
+            assert json.loads(row["result_json"]) == expected_cast
+        finally:
+            conn.close()
+
+    def test_cast_route_empty_cast_stores_and_returns(self, client, app):
+        """lookup_cast returns [] → route stores [], returns {"cast": []}."""
+        _set_session(client)
+
+        with patch("jellyswipe.routers.media.lookup_cast") as mock_lookup:
+            mock_lookup.return_value = []
+            resp = client.get("/cast/movie-12")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["cast"] == []
+        mock_lookup.assert_called_once()
+
+        # Verify empty cast was cached
+        conn = _sqlite_conn()
+        try:
+            row = conn.execute(
+                "SELECT result_json FROM tmdb_cache WHERE media_id = 'movie-12' AND lookup_type = 'cast'"
+            ).fetchone()
+            assert row is not None
+            assert json.loads(row["result_json"]) == []
+        finally:
+            conn.close()
+
+    def test_cast_item_lookup_failure_returns_404_with_empty_cast(self, client, app):
+        """Jellyfin item resolution failure returns 404 with empty cast."""
+        _set_session(client)
+
+        from tests.conftest import FakeProvider
+        import jellyswipe.config as app_config
+        import jellyswipe as app_module
+        from jellyswipe.dependencies import get_provider
+
+        original = app_config._provider_singleton
+
+        class FailingProvider(FakeProvider):
+            def resolve_item_for_tmdb(self, movie_id):
+                raise RuntimeError("item lookup failed")
+
+        failing = FailingProvider()
+        app_config._provider_singleton = failing
+        app_module._provider_singleton = failing
+        app.dependency_overrides[get_provider] = lambda: failing
+
+        try:
+            resp = client.get("/cast/nonexistent")
+            assert resp.status_code == 404
+            data = resp.json()
+            assert "Movie metadata not found" in data["error"]
+            assert data["cast"] == []
+        finally:
+            app_config._provider_singleton = original
+            app_module._provider_singleton = original

--- a/tests/test_tmdb.py
+++ b/tests/test_tmdb.py
@@ -1,0 +1,211 @@
+"""Tests for the pure TMDB module (lookup_trailer, lookup_cast).
+
+Tests cover successful lookups, no-match scenarios, network failures,
+and malformed responses. No DB or provider needed.
+"""
+
+from unittest.mock import patch, MagicMock
+
+import requests
+
+from jellyswipe.tmdb import lookup_trailer, lookup_cast
+
+
+class TestLookupTrailer:
+    """Tests for lookup_trailer function."""
+
+    def test_successful_trailer_lookup(self):
+        """Returns YouTube key when trailer is found."""
+        search_response = MagicMock()
+        search_response.json.return_value = {
+            "results": [{"id": 12345, "title": "Test Movie"}]
+        }
+
+        videos_response = MagicMock()
+        videos_response.json.return_value = {
+            "results": [
+                {"site": "YouTube", "type": "Trailer", "key": "abc123"},
+                {"site": "YouTube", "type": "Teaser", "key": "xyz789"},
+            ]
+        }
+
+        with patch("jellyswipe.tmdb.make_http_request") as mock_http:
+            mock_http.side_effect = [search_response, videos_response]
+            result = lookup_trailer("Test Movie", 2024)
+
+        assert result == "abc123"
+        assert mock_http.call_count == 2
+
+    def test_no_search_results_returns_none(self):
+        """Returns None when TMDB search has no results."""
+        search_response = MagicMock()
+        search_response.json.return_value = {"results": []}
+
+        with patch("jellyswipe.tmdb.make_http_request") as mock_http:
+            mock_http.return_value = search_response
+            result = lookup_trailer("Nonexistent Movie", 2024)
+
+        assert result is None
+
+    def test_no_trailer_videos_returns_none(self):
+        """Returns None when movie has no YouTube trailers."""
+        search_response = MagicMock()
+        search_response.json.return_value = {
+            "results": [{"id": 12345, "title": "Test Movie"}]
+        }
+
+        videos_response = MagicMock()
+        videos_response.json.return_value = {
+            "results": [
+                {"site": "Vimeo", "type": "Trailer", "key": "vimeo123"},
+                {"site": "YouTube", "type": "Teaser", "key": "teaser123"},
+            ]
+        }
+
+        with patch("jellyswipe.tmdb.make_http_request") as mock_http:
+            mock_http.side_effect = [search_response, videos_response]
+            result = lookup_trailer("Test Movie", 2024)
+
+        assert result is None
+
+    def test_network_failure_returns_none(self):
+        """Returns None on network error."""
+        with patch("jellyswipe.tmdb.make_http_request") as mock_http:
+            mock_http.side_effect = requests.exceptions.ConnectionError(
+                "Connection refused"
+            )
+            result = lookup_trailer("Test Movie", 2024)
+
+        assert result is None
+
+    def test_malformed_search_response_returns_none(self):
+        """Returns None when search response is malformed."""
+        search_response = MagicMock()
+        search_response.json.return_value = {"unexpected": "format"}
+
+        with patch("jellyswipe.tmdb.make_http_request") as mock_http:
+            mock_http.return_value = search_response
+            result = lookup_trailer("Test Movie", 2024)
+
+        assert result is None
+
+    def test_year_none_still_works(self):
+        """Works when year is None."""
+        search_response = MagicMock()
+        search_response.json.return_value = {
+            "results": [{"id": 12345, "title": "Test Movie"}]
+        }
+
+        videos_response = MagicMock()
+        videos_response.json.return_value = {
+            "results": [{"site": "YouTube", "type": "Trailer", "key": "key123"}]
+        }
+
+        with patch("jellyswipe.tmdb.make_http_request") as mock_http:
+            mock_http.side_effect = [search_response, videos_response]
+            result = lookup_trailer("Test Movie", None)
+
+        assert result == "key123"
+
+
+class TestLookupCast:
+    """Tests for lookup_cast function."""
+
+    def test_successful_cast_lookup(self):
+        """Returns cast list when found."""
+        search_response = MagicMock()
+        search_response.json.return_value = {
+            "results": [{"id": 12345, "title": "Test Movie"}]
+        }
+
+        credits_response = MagicMock()
+        credits_response.json.return_value = {
+            "cast": [
+                {"name": "Actor 1", "character": "Role 1", "profile_path": "/img1.jpg"},
+                {"name": "Actor 2", "character": "Role 2", "profile_path": None},
+            ]
+        }
+
+        with patch("jellyswipe.tmdb.make_http_request") as mock_http:
+            mock_http.side_effect = [search_response, credits_response]
+            result = lookup_cast("Test Movie", 2024)
+
+        assert len(result) == 2
+        assert result[0]["name"] == "Actor 1"
+        assert result[0]["character"] == "Role 1"
+        assert result[0]["profile_path"] == "https://image.tmdb.org/t/p/w185/img1.jpg"
+        assert result[1]["profile_path"] is None
+
+    def test_no_search_results_returns_empty(self):
+        """Returns [] when TMDB search has no results."""
+        search_response = MagicMock()
+        search_response.json.return_value = {"results": []}
+
+        with patch("jellyswipe.tmdb.make_http_request") as mock_http:
+            mock_http.return_value = search_response
+            result = lookup_cast("Nonexistent Movie", 2024)
+
+        assert result == []
+
+    def test_network_failure_returns_empty(self):
+        """Returns [] on network error."""
+        with patch("jellyswipe.tmdb.make_http_request") as mock_http:
+            mock_http.side_effect = requests.exceptions.Timeout("Request timed out")
+            result = lookup_cast("Test Movie", 2024)
+
+        assert result == []
+
+    def test_limits_to_8_cast_members(self):
+        """Returns at most 8 cast members."""
+        search_response = MagicMock()
+        search_response.json.return_value = {
+            "results": [{"id": 12345, "title": "Test Movie"}]
+        }
+
+        credits_response = MagicMock()
+        credits_response.json.return_value = {
+            "cast": [
+                {"name": f"Actor {i}", "character": f"Role {i}", "profile_path": None}
+                for i in range(15)
+            ]
+        }
+
+        with patch("jellyswipe.tmdb.make_http_request") as mock_http:
+            mock_http.side_effect = [search_response, credits_response]
+            result = lookup_cast("Test Movie", 2024)
+
+        assert len(result) == 8
+
+    def test_missing_character_defaults_to_empty_string(self):
+        """Missing character field defaults to empty string."""
+        search_response = MagicMock()
+        search_response.json.return_value = {
+            "results": [{"id": 12345, "title": "Test Movie"}]
+        }
+
+        credits_response = MagicMock()
+        credits_response.json.return_value = {
+            "cast": [{"name": "Actor 1", "profile_path": None}]
+        }
+
+        with patch("jellyswipe.tmdb.make_http_request") as mock_http:
+            mock_http.side_effect = [search_response, credits_response]
+            result = lookup_cast("Test Movie", 2024)
+
+        assert result[0]["character"] == ""
+
+    def test_empty_cast_list_returns_empty(self):
+        """Returns [] when movie has no cast."""
+        search_response = MagicMock()
+        search_response.json.return_value = {
+            "results": [{"id": 12345, "title": "Test Movie"}]
+        }
+
+        credits_response = MagicMock()
+        credits_response.json.return_value = {"cast": []}
+
+        with patch("jellyswipe.tmdb.make_http_request") as mock_http:
+            mock_http.side_effect = [search_response, credits_response]
+            result = lookup_cast("Test Movie", 2024)
+
+        assert result == []

--- a/tests/test_tmdb_auth.py
+++ b/tests/test_tmdb_auth.py
@@ -72,9 +72,9 @@ class TestBearerTokenHeaders:
         }
         second_response.status_code = 200
 
-        # Patch where make_http_request is looked up: jellyswipe.routers.media (D-14)
+        # Patch where make_http_request is looked up: jellyswipe.tmdb (refactored from media.py)
         with patch(
-            "jellyswipe.routers.media.make_http_request",
+            "jellyswipe.tmdb.make_http_request",
             side_effect=[mock_response, second_response],
         ) as mock_http:
             response = client.get("/get-trailer/test_movie_id")
@@ -112,9 +112,9 @@ class TestBearerTokenHeaders:
         }
         second_response.status_code = 200
 
-        # Patch where make_http_request is looked up: jellyswipe.routers.media (D-14)
+        # Patch where make_http_request is looked up: jellyswipe.tmdb (refactored from media.py)
         with patch(
-            "jellyswipe.routers.media.make_http_request",
+            "jellyswipe.tmdb.make_http_request",
             side_effect=[mock_response, second_response],
         ) as mock_http:
             response = client.get("/cast/test_movie_id")


### PR DESCRIPTION
## Wire TMDB module and caching into media route handlers

Refactor the trailer and cast route handlers in `routers/media.py` to use the TMDB pure module and cache layer. The routes become thin orchestration: resolve item → check cache → call TMDB → store in cache → return.

**Context:** Currently `get_trailer` and `get_cast` in `routers/media.py` contain inline TMDB orchestration (search → fetch videos/credits). This ticket wires in the pure TMDB module (ORCH-020) and cache repository (ORCH-021) to eliminate code duplication and add caching.

**Changes to `jellyswipe/routers/media.py`:**

### `get_trailer` route:

Replace the current inline implementation with:
```python
@media_router.get("/get-trailer/{movie_id}")
def get_trailer(movie_id: str, request: Request, uow: DBUoW, _: None = Depends(check_rate_limit)):
    try:
        # Check cache first
        cached = await uow.tmdb_cache.get(movie_id, "trailer")
        if cached:
            result = json.loads(cached.result_json)
            if result.get("youtube_key"):
                return result
            return make_error_response("Not found", 404, request)
        
        # Cache miss — resolve item and call TMDB
        item = get_provider().resolve_item_for_tmdb(movie_id)
        youtube_key = lookup_trailer(item.title, item.year)
        
        if youtube_key:
            result = {"youtube_key": youtube_key}
            await uow.tmdb_cache.put(movie_id, "trailer", json.dumps(result))
            return result
        
        # No trailer found — cache the miss to avoid repeated lookups
        await uow.tmdb_cache.put(movie_id, "trailer", json.dumps({}))
        return make_error_response("Not found", 404, request)
    except RuntimeError as e:
        if "item lookup failed" in str(e).lower():
            return make_error_response("Movie metadata not found", 404, request)
        log_exception(e, request)
        return make_error_response("Internal server error", 500, request)
    except Exception as e:
        log_exception(e, request)
        return make_error_response("Internal server error", 500, request)
```

### `get_cast` route:

Same pattern — check cache, resolve item, call `lookup_cast`, store, return.

**Important design note:** Cache "misses" (no trailer found) are also cached as `{}` to avoid repeated external lookups for items that don't have trailers. The cache TTL (7 days) means eventually the system retries.

**Note on UoW injection:** The route handlers need a `uow: DBUoW` parameter for cache access. Currently these routes don't have a UoW parameter — add it via `Depends(get_db_uow)`.


### Acceptance Criteria

1. `get_trailer` route handler uses `lookup_trailer` from `jellyswipe/tmdb.py` instead of inline TMDB orchestration
2. `get_cast` route handler uses `lookup_cast` from `jellyswipe/tmdb.py` instead of inline TMDB orchestration
3. Both routes implement cache-first logic: check `TmdbCacheRepository.get()` → on hit return cached → on miss resolve item via provider → call TMDB pure function → `TmdbCacheRepository.put()` → return
4. Trailer route returns cached `{"youtube_key": "..."}` on cache hit (no TMDB HTTP calls)
5. Cast route returns cached `{"cast": [...]}` on cache hit (no TMDB HTTP calls)
6. Both routes still use `get_provider().resolve_item_for_tmdb(movie_id)` for Jellyfin item resolution (title + year extraction)
7. `TMDB_AUTH_HEADERS` import moved from `jellyswipe.config` to `jellyswipe/tmdb.py` (or kept in config and also used by tmdb module)
8. Inline TMDB URL construction and response parsing removed from route handlers
9. All existing tests pass: `uv run pytest`
10. New/updated tests verify cache hit/miss behavior


---
Ticket: `ORCH-022`