### PR TITLE
feat(ORCH-023): Extract SSE stream generator into service module

### DIFF
--- a/jellyswipe/routers/rooms.py
+++ b/jellyswipe/routers/rooms.py
@@ -8,10 +8,8 @@ Per D-13: Swipe handler uses the async DBUoW bridge instead of a direct sync
 request-scoped connection dependency.
 """
 
-import asyncio
 import json
 import logging
-import time
 import traceback
 
 from fastapi import APIRouter, Depends, Request
@@ -28,6 +26,7 @@ from jellyswipe.services.room_lifecycle import (
     RoomLifecycleService,
     UniqueRoomCodeExhaustedError,
 )
+from jellyswipe.services.session_event_stream import session_event_stream
 from jellyswipe.services.swipe_match import SwipeMatchService
 
 rooms_router = APIRouter()
@@ -377,13 +376,7 @@ def room_stream(code: str, request: Request, auth: AuthUser = Depends(require_au
     """SSE stream for session events. Event-driven with replay support."""
 
     async def generate():
-        # 1. Resolve cursor: Last-Event-ID header or ?after_event_id= query param
-        cursor = request.headers.get("Last-Event-ID") or request.query_params.get(
-            "after_event_id"
-        )
-        cursor = int(cursor) if cursor else None
-
-        # 2. Look up session instance and current room state
+        # Resolve instance and room
         async with get_sessionmaker()() as session:
             uow = DatabaseUnitOfWork(session)
             instance = await uow.session_instances.get_by_pairing_code(code)
@@ -396,101 +389,21 @@ def room_stream(code: str, request: Request, auth: AuthUser = Depends(require_au
                 return
             room = await uow.rooms.get_room(code)
 
-        instance_id = instance.instance_id
-
-        # 3. Validate cursor if present
-        if cursor is not None:
-            # Check: does this cursor belong to our instance?
-            async with get_sessionmaker()() as session:
-                uow = DatabaseUnitOfWork(session)
-                events_after = await uow.session_events.read_after(
-                    instance_id, cursor, limit=1
-                )
-                if not events_after:
-                    # Cursor might be stale or from wrong instance
-                    yield {
-                        "data": json.dumps(
-                            {"event_type": "session_reset", "reason": "stale_cursor"}
-                        )
-                    }
-                    return
-        else:
-            # First attach — send bootstrap
-            async with get_sessionmaker()() as session:
-                uow = DatabaseUnitOfWork(session)
-                latest_eid = await uow.session_events.read_latest_event_id(instance_id)
-            bootstrap = {
-                "event_type": "session_bootstrap",
-                "instance_id": instance_id,
-                "ready": room.ready if room else False,
-                "genre": room.current_genre if room else "All",
-                "solo": room.solo_mode if room else False,
-                "hide_watched": room.hide_watched if room else False,
-                "replay_boundary": latest_eid or 0,
-            }
-            yield {"id": str(latest_eid or 0), "data": json.dumps(bootstrap)}
-
-        # 4. Replay missed events (if cursor was valid)
-        missed = []
-        latest_eid = None
-        if cursor is not None:
-            async with get_sessionmaker()() as session:
-                uow = DatabaseUnitOfWork(session)
-                missed = await uow.session_events.read_after(
-                    instance_id, cursor, limit=100
-                )
-            for evt in missed:
-                yield {
-                    "id": str(evt.event_id),
-                    "data": json.dumps(
-                        {
-                            "event_id": evt.event_id,
-                            "event_type": evt.event_type,
-                            **json.loads(evt.payload_json),
-                        }
-                    ),
-                }
-                if evt.event_type == "session_closed":
-                    return  # Stream ends after session_closed
-
-        # 5. Subscribe to notifier and stream live events
-        last_event_id = (
-            missed[-1].event_id if cursor is not None and missed else (latest_eid or 0)
+        cursor = request.headers.get("Last-Event-ID") or request.query_params.get(
+            "after_event_id"
         )
-        last_event_time = time.time()
+        cursor = int(cursor) if cursor else None
 
-        while True:
-            if await request.is_disconnected():
-                break
-
-            future = notifier.subscribe(code)
-            try:
-                await asyncio.wait_for(future, timeout=20.0)
-            except asyncio.TimeoutError:
-                # Heartbeat check
-                if time.time() - last_event_time >= 15:
-                    yield {"comment": "ping"}
-                    last_event_time = time.time()
-                continue
-
-            # Woken by notifier — read new events from ledger
-            async with get_sessionmaker()() as session:
-                uow = DatabaseUnitOfWork(session)
-                new_events = await uow.session_events.read_after(
-                    instance_id, last_event_id, limit=100
-                )
-
-            for evt in new_events:
-                payload = {"event_id": evt.event_id, "event_type": evt.event_type}
-                payload.update(json.loads(evt.payload_json))
-                yield {"id": str(evt.event_id), "data": json.dumps(payload)}
-                last_event_id = evt.event_id
-                last_event_time = time.time()
-                if evt.event_type == "session_closed":
-                    notifier.unsubscribe(code, future)
-                    return
-
-            notifier.unsubscribe(code, future)
+        async for event in session_event_stream(
+            code=code,
+            instance_id=instance.instance_id,
+            room=room,
+            cursor=cursor,
+            sessionmaker_factory=get_sessionmaker(),
+            notifier=notifier,
+            is_disconnected=request.is_disconnected,
+        ):
+            yield event
 
     # D-03: EventSourceResponse handles text/event-stream media type and SSE framing.
     # D-04: Verify Cache-Control and X-Accel-Buffering headers are present on response.

--- a/jellyswipe/services/session_event_stream.py
+++ b/jellyswipe/services/session_event_stream.py
@@ -1,0 +1,126 @@
+"""SSE session event stream generator with injectable dependencies.
+
+Extracted from routers/rooms.py to allow direct unit testing with fake
+dependencies (notifier, is_disconnected, sessionmaker).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from collections.abc import AsyncGenerator, Awaitable, Callable
+from typing import Any
+
+from jellyswipe.db_uow import DatabaseUnitOfWork
+
+
+async def session_event_stream(
+    code: str,
+    instance_id: str,
+    room: Any,  # Room model/record
+    cursor: int | None,
+    sessionmaker_factory: Callable,
+    notifier: Any,  # SessionNotifier
+    is_disconnected: Callable[[], Awaitable[bool]],
+) -> AsyncGenerator[dict, None]:
+    """Session Event Stream generator with injectable dependencies.
+
+    Yields dicts with keys: "id" (str), "data" (str), and/or "comment" (str).
+    Same shape EventSourceResponse consumes.
+
+    Args:
+        code: Room pairing code.
+        instance_id: Session instance ID for event ledger queries.
+        room: Room model instance (or None).
+        cursor: Last-Event-ID from client (or None for first attach).
+        sessionmaker_factory: Callable returning an async session context manager.
+        notifier: SessionNotifier instance for subscribe/unsubscribe.
+        is_disconnected: Async callable returning True when client disconnected.
+    """
+    # 1. Cursor validation or bootstrap
+    if cursor is not None:
+        async with sessionmaker_factory() as session:
+            uow = DatabaseUnitOfWork(session)
+            events_after = await uow.session_events.read_after(
+                instance_id, cursor, limit=1
+            )
+            if not events_after:
+                yield {
+                    "data": json.dumps(
+                        {"event_type": "session_reset", "reason": "stale_cursor"}
+                    )
+                }
+                return
+    else:
+        async with sessionmaker_factory() as session:
+            uow = DatabaseUnitOfWork(session)
+            latest_eid = await uow.session_events.read_latest_event_id(instance_id)
+        bootstrap = {
+            "event_type": "session_bootstrap",
+            "instance_id": instance_id,
+            "ready": room.ready if room else False,
+            "genre": room.current_genre if room else "All",
+            "solo": room.solo_mode if room else False,
+            "hide_watched": room.hide_watched if room else False,
+            "replay_boundary": latest_eid or 0,
+        }
+        yield {"id": str(latest_eid or 0), "data": json.dumps(bootstrap)}
+
+    # 2. Replay missed events
+    missed = []
+    latest_eid = None
+    if cursor is not None:
+        async with sessionmaker_factory() as session:
+            uow = DatabaseUnitOfWork(session)
+            missed = await uow.session_events.read_after(instance_id, cursor, limit=100)
+        for evt in missed:
+            yield {
+                "id": str(evt.event_id),
+                "data": json.dumps(
+                    {
+                        "event_id": evt.event_id,
+                        "event_type": evt.event_type,
+                        **json.loads(evt.payload_json),
+                    }
+                ),
+            }
+            if evt.event_type == "session_closed":
+                return
+
+    # 3. Live event subscription loop
+    last_event_id = (
+        missed[-1].event_id if cursor is not None and missed else (latest_eid or 0)
+    )
+    last_event_time = time.time()
+
+    while True:
+        if await is_disconnected():
+            break
+
+        future = notifier.subscribe(code)
+        try:
+            await asyncio.wait_for(future, timeout=20.0)
+        except asyncio.TimeoutError:
+            if time.time() - last_event_time >= 15:
+                yield {"comment": "ping"}
+                last_event_time = time.time()
+            continue
+
+        async with sessionmaker_factory() as session:
+            uow = DatabaseUnitOfWork(session)
+            new_events = await uow.session_events.read_after(
+                instance_id, last_event_id, limit=100
+            )
+
+        for evt in new_events:
+            payload = {"event_id": evt.event_id, "event_type": evt.event_type}
+            payload.update(json.loads(evt.payload_json))
+            yield {"id": str(evt.event_id), "data": json.dumps(payload)}
+            last_event_id = evt.event_id
+            last_event_time = time.time()
+            if evt.event_type == "session_closed":
+                notifier.unsubscribe(code, future)
+                return
+
+        notifier.unsubscribe(code, future)

--- a/tests/test_routes_sse.py
+++ b/tests/test_routes_sse.py
@@ -1,17 +1,11 @@
 """SSE streaming tests for the event-driven /room/{code}/stream endpoint.
 
-Tests cover:
-- First attach (no cursor): session_bootstrap event
-- Reconnect with valid cursor: missed events replayed
-- Reconnect with stale cursor: session_reset sent
-- Reconnect with wrong instance cursor: session_reset sent
-- Session closed event: stream closes after session_closed
-- SSE id field on every event
-- Heartbeat ping after idle
-- Disconnect detection
-- CancelledError propagation
-- Response headers
-- GET /matches works independently
+After ORCH-023, this file tests only:
+- SSE headers (Cache-Control, X-Accel-Buffering, Content-Type)
+- Route wiring (instance not found → session_reset)
+- Unauthenticated request returns 401
+
+Generator-level behavior is tested in tests/test_session_event_stream.py.
 """
 
 import asyncio
@@ -20,7 +14,6 @@ import os
 import secrets
 import time
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock
 
 
 from jellyswipe.notifier import notifier
@@ -90,18 +83,6 @@ def _seed_room_and_instance(
     return instance_id
 
 
-def _seed_event(conn, instance_id, event_type, payload_json):
-    """Seed a session event directly."""
-    now = datetime.now(timezone.utc).isoformat()
-    cursor = conn.execute(
-        "INSERT INTO session_events (session_instance_id, event_type, payload_json, created_at) "
-        "VALUES (?, ?, ?, ?)",
-        (instance_id, event_type, payload_json, now),
-    )
-    conn.commit()
-    return cursor.lastrowid
-
-
 def _sqlite_conn(app):
     """Get a direct sqlite3 connection to the app's database."""
     import sqlite3
@@ -129,8 +110,15 @@ def _setup_disconnect_after(client, monkeypatch, after_calls=2):
     return call_count
 
 
+def _resolved_future():
+    """Return an already-resolved Future for mocking notifier.subscribe."""
+    f = asyncio.Future()
+    f.set_result(None)
+    return f
+
+
 # ---------------------------------------------------------------------------
-# Section 1: Basic SSE response tests
+# SSE headers and route wiring
 # ---------------------------------------------------------------------------
 
 
@@ -156,383 +144,6 @@ def test_stream_response_headers(client, monkeypatch):
     assert response.headers["X-Accel-Buffering"] == "no"
 
 
-def _resolved_future():
-    """Return an already-resolved Future for mocking notifier.subscribe."""
-    f = asyncio.Future()
-    f.set_result(None)
-    return f
-
-
-# ---------------------------------------------------------------------------
-# Section 2: First attach (no cursor) — session_bootstrap
-# ---------------------------------------------------------------------------
-
-
-def test_stream_first_attach_sends_bootstrap(client, monkeypatch):
-    """First attach (no Last-Event-ID, no after_event_id) sends session_bootstrap."""
-    conn = _sqlite_conn(client)
-    try:
-        instance_id = _seed_room_and_instance(
-            conn,
-            "BOOT1",
-            ready=1,
-            current_genre="Action",
-            solo_mode=1,
-            hide_watched=1,
-        )
-    finally:
-        conn.close()
-    _set_session_room(client, os.environ["FLASK_SECRET"], "BOOT1")
-    _setup_disconnect_after(client, monkeypatch, after_calls=2)
-
-    monkeypatch.setattr(notifier, "subscribe", lambda code: _resolved_future())
-    monkeypatch.setattr(time, "time", lambda: 1000000.0)
-
-    response = client.get("/room/BOOT1/stream")
-    data = response.text
-
-    assert "session_bootstrap" in data
-    assert (
-        f'"instance_id": "{instance_id}"' in data
-        or f'"instance_id":"{instance_id}"' in data
-    )
-    assert '"ready": true' in data
-    assert '"genre": "Action"' in data
-    assert '"solo": true' in data
-    assert '"hide_watched": true' in data
-    assert '"replay_boundary"' in data
-
-
-def test_stream_first_attach_bootstrap_only_event_before_live(client, monkeypatch):
-    """session_bootstrap is the only event before live events start."""
-    conn = _sqlite_conn(client)
-    try:
-        _seed_room_and_instance(conn, "BOOT2")
-    finally:
-        conn.close()
-    _set_session_room(client, os.environ["FLASK_SECRET"], "BOOT2")
-    _setup_disconnect_after(client, monkeypatch, after_calls=2)
-
-    monkeypatch.setattr(notifier, "subscribe", lambda code: _resolved_future())
-    monkeypatch.setattr(time, "time", lambda: 1000000.0)
-
-    response = client.get("/room/BOOT2/stream")
-    data = response.text
-
-    bootstrap_count = data.count("session_bootstrap")
-    assert bootstrap_count == 1, f"Expected 1 bootstrap, got {bootstrap_count}: {data}"
-
-
-def test_stream_first_attach_replay_boundary(client, monkeypatch):
-    """First attach includes replay_boundary set to latest event_id."""
-    conn = _sqlite_conn(client)
-    try:
-        instance_id = _seed_room_and_instance(conn, "BOOT3")
-        _seed_event(conn, instance_id, "swipe", json.dumps({"media_id": "m1"}))
-        _seed_event(conn, instance_id, "swipe", json.dumps({"media_id": "m2"}))
-    finally:
-        conn.close()
-    _set_session_room(client, os.environ["FLASK_SECRET"], "BOOT3")
-    _setup_disconnect_after(client, monkeypatch, after_calls=2)
-
-    monkeypatch.setattr(notifier, "subscribe", lambda code: _resolved_future())
-    monkeypatch.setattr(time, "time", lambda: 1000000.0)
-
-    response = client.get("/room/BOOT3/stream")
-    data = response.text
-
-    assert '"replay_boundary": 2' in data or '"replay_boundary":2' in data
-
-
-# ---------------------------------------------------------------------------
-# Section 3: Reconnect with valid cursor — replay missed events
-# ---------------------------------------------------------------------------
-
-
-def test_stream_reconnect_replays_missed_events(client, monkeypatch):
-    """Reconnect with valid cursor replays missed events in order."""
-    conn = _sqlite_conn(client)
-    try:
-        instance_id = _seed_room_and_instance(conn, "REPLAY1")
-        eid1 = _seed_event(
-            conn,
-            instance_id,
-            "swipe",
-            json.dumps({"media_id": "m1", "direction": "right"}),
-        )
-        eid2 = _seed_event(
-            conn, instance_id, "match_found", json.dumps({"media_id": "m1"})
-        )
-    finally:
-        conn.close()
-    _set_session_room(client, os.environ["FLASK_SECRET"], "REPLAY1")
-    _setup_disconnect_after(client, monkeypatch, after_calls=2)
-
-    monkeypatch.setattr(notifier, "subscribe", lambda code: _resolved_future())
-    monkeypatch.setattr(time, "time", lambda: 1000000.0)
-
-    response = client.get(f"/room/REPLAY1/stream?after_event_id={eid1}")
-    data = response.text
-
-    assert "match_found" in data
-    assert f'"event_id": {eid2}' in data or f'"event_id":{eid2}' in data
-    assert '"event_type": "match_found"' in data or '"event_type":"match_found"' in data
-
-
-def test_stream_reconnect_events_in_order(client, monkeypatch):
-    """Replayed events are delivered in event_id order."""
-    conn = _sqlite_conn(client)
-    try:
-        instance_id = _seed_room_and_instance(conn, "REPLAY2")
-        eid1 = _seed_event(conn, instance_id, "swipe", json.dumps({"media_id": "m1"}))
-        eid2 = _seed_event(conn, instance_id, "swipe", json.dumps({"media_id": "m2"}))
-        eid3 = _seed_event(
-            conn, instance_id, "match_found", json.dumps({"media_id": "m1"})
-        )
-    finally:
-        conn.close()
-    _set_session_room(client, os.environ["FLASK_SECRET"], "REPLAY2")
-    _setup_disconnect_after(client, monkeypatch, after_calls=2)
-
-    monkeypatch.setattr(notifier, "subscribe", lambda code: _resolved_future())
-    monkeypatch.setattr(time, "time", lambda: 1000000.0)
-
-    response = client.get(f"/room/REPLAY2/stream?after_event_id={eid1}")
-    data = response.text
-
-    pos_eid2 = data.find(f'"event_id": {eid2}')
-    if pos_eid2 == -1:
-        pos_eid2 = data.find(f'"event_id":{eid2}')
-    pos_eid3 = data.find(f'"event_id": {eid3}')
-    if pos_eid3 == -1:
-        pos_eid3 = data.find(f'"event_id":{eid3}')
-    assert pos_eid2 < pos_eid3, "Events should be in order"
-
-
-# ---------------------------------------------------------------------------
-# Section 4: Invalid cursor — stale
-# ---------------------------------------------------------------------------
-
-
-def test_stream_stale_cursor_sends_session_reset(client, monkeypatch):
-    """Reconnect with stale cursor (no events after it) sends session_reset."""
-    conn = _sqlite_conn(client)
-    try:
-        _seed_room_and_instance(conn, "STALE1")
-    finally:
-        conn.close()
-    _set_session_room(client, os.environ["FLASK_SECRET"], "STALE1")
-
-    monkeypatch.setattr(time, "time", lambda: 1000000.0)
-
-    response = client.get("/room/STALE1/stream?after_event_id=999")
-    data = response.text
-
-    assert "session_reset" in data
-    assert "stale_cursor" in data
-
-
-# ---------------------------------------------------------------------------
-# Section 5: Session closed event
-# ---------------------------------------------------------------------------
-
-
-def test_stream_session_closed_closes_stream(client, monkeypatch):
-    """When session_closed event is replayed, stream closes after sending it."""
-    conn = _sqlite_conn(client)
-    try:
-        instance_id = _seed_room_and_instance(conn, "CLOSE1")
-        _seed_event(conn, instance_id, "swipe", json.dumps({"media_id": "m1"}))
-        _seed_event(
-            conn, instance_id, "session_closed", json.dumps({"reason": "user_quit"})
-        )
-    finally:
-        conn.close()
-    _set_session_room(client, os.environ["FLASK_SECRET"], "CLOSE1")
-
-    monkeypatch.setattr(time, "time", lambda: 1000000.0)
-
-    response = client.get("/room/CLOSE1/stream?after_event_id=0")
-    data = response.text
-
-    assert "session_closed" in data
-    assert "session_bootstrap" not in data
-
-
-def test_stream_two_matches_close_together(client, monkeypatch):
-    """Two match_found events are delivered as distinct events with different event_ids."""
-    conn = _sqlite_conn(client)
-    try:
-        instance_id = _seed_room_and_instance(conn, "MATCH2")
-        eid1 = _seed_event(
-            conn, instance_id, "match_found", json.dumps({"media_id": "m1"})
-        )
-        eid2 = _seed_event(
-            conn, instance_id, "match_found", json.dumps({"media_id": "m2"})
-        )
-    finally:
-        conn.close()
-    _set_session_room(client, os.environ["FLASK_SECRET"], "MATCH2")
-    _setup_disconnect_after(client, monkeypatch, after_calls=2)
-
-    monkeypatch.setattr(notifier, "subscribe", lambda code: _resolved_future())
-    monkeypatch.setattr(time, "time", lambda: 1000000.0)
-
-    response = client.get("/room/MATCH2/stream?after_event_id=0")
-    data = response.text
-
-    assert data.count("match_found") >= 2
-    assert f'"event_id": {eid1}' in data or f'"event_id":{eid1}' in data
-    assert f'"event_id": {eid2}' in data or f'"event_id":{eid2}' in data
-
-
-# ---------------------------------------------------------------------------
-# Section 6: SSE id field
-# ---------------------------------------------------------------------------
-
-
-def test_stream_sse_id_field(client, monkeypatch):
-    """Each event includes id: line with the event_id."""
-    conn = _sqlite_conn(client)
-    try:
-        instance_id = _seed_room_and_instance(conn, "ID1")
-        eid = _seed_event(conn, instance_id, "swipe", json.dumps({"media_id": "m1"}))
-    finally:
-        conn.close()
-    _set_session_room(client, os.environ["FLASK_SECRET"], "ID1")
-    _setup_disconnect_after(client, monkeypatch, after_calls=2)
-
-    monkeypatch.setattr(notifier, "subscribe", lambda code: _resolved_future())
-    monkeypatch.setattr(time, "time", lambda: 1000000.0)
-
-    response = client.get("/room/ID1/stream?after_event_id=0")
-    data = response.text
-
-    assert f"id: {eid}" in data or f"id:{eid}" in data
-
-
-# ---------------------------------------------------------------------------
-# Section 7: Heartbeat
-# ---------------------------------------------------------------------------
-
-
-def test_stream_heartbeat_ping(client, monkeypatch):
-    """After ~15s of no events, a : ping comment is sent."""
-    conn = _sqlite_conn(client)
-    try:
-        _seed_room_and_instance(conn, "HB1")
-    finally:
-        conn.close()
-    _set_session_room(client, os.environ["FLASK_SECRET"], "HB1")
-    _setup_disconnect_after(client, monkeypatch, after_calls=4)
-
-    time_counter = [0]
-
-    def mock_time():
-        time_counter[0] += 1
-        if time_counter[0] <= 5:
-            return 0.0
-        return 16.0
-
-    monkeypatch.setattr(time, "time", mock_time)
-
-    # Mock wait_for to timeout immediately so the heartbeat check runs
-    original_wait_for = asyncio.wait_for
-
-    async def mock_wait_for(future, timeout):
-        # Let the first call through (bootstrap phase), then timeout immediately
-        if time_counter[0] > 5:
-            raise asyncio.TimeoutError()
-        return await original_wait_for(future, timeout=0.001)
-
-    monkeypatch.setattr(asyncio, "wait_for", mock_wait_for)
-
-    response = client.get("/room/HB1/stream")
-    data = response.text
-
-    assert ": ping" in data, f"Expected heartbeat ping in: {repr(data)}"
-
-
-# ---------------------------------------------------------------------------
-# Section 8: Disconnect detection
-# ---------------------------------------------------------------------------
-
-
-def test_stream_disconnect_exits_cleanly(client, monkeypatch):
-    """If request.is_disconnected() returns True, generator exits cleanly."""
-    conn = _sqlite_conn(client)
-    try:
-        _seed_room_and_instance(conn, "DISC1")
-    finally:
-        conn.close()
-    _set_session_room(client, os.environ["FLASK_SECRET"], "DISC1")
-
-    call_count = _setup_disconnect_after(client, monkeypatch, after_calls=2)
-    monkeypatch.setattr(notifier, "subscribe", lambda code: _resolved_future())
-    monkeypatch.setattr(time, "time", lambda: 1000000.0)
-
-    response = client.get("/room/DISC1/stream")
-    assert response.status_code == 200
-    assert call_count[0] >= 1
-
-
-# ---------------------------------------------------------------------------
-# Section 9: CancelledError propagation
-# ---------------------------------------------------------------------------
-
-
-def test_stream_cancelled_error_not_swallowed(monkeypatch):
-    """CancelledError raised inside the generator must propagate out."""
-    import jellyswipe.routers.rooms as rooms_module
-    from jellyswipe.dependencies import AuthUser
-
-    fake_request = MagicMock()
-    fake_request.is_disconnected = AsyncMock(return_value=False)
-    fake_request.headers = {}
-    fake_request.query_params = {}
-
-    fake_auth = AuthUser(jf_token="t", user_id="u")
-
-    # Custom async context manager that raises CancelledError on entry
-    class _FailingSessionCM:
-        async def __aenter__(self):
-            raise asyncio.CancelledError("simulated cancellation")
-
-        async def __aexit__(self, *args):
-            pass
-
-    monkeypatch.setattr(
-        rooms_module, "get_sessionmaker", lambda: lambda: _FailingSessionCM()
-    )
-
-    result = rooms_module.room_stream(
-        code="CANCEL1",
-        request=fake_request,
-        auth=fake_auth,
-    )
-    generator = result.body_iterator
-
-    cancelled_error_propagated = [False]
-
-    async def drive_generator():
-        try:
-            async for _ in generator:
-                pass
-        except asyncio.CancelledError:
-            cancelled_error_propagated[0] = True
-
-    asyncio.run(drive_generator())
-
-    assert cancelled_error_propagated[0], (
-        "CancelledError was swallowed — it must propagate"
-    )
-
-
-# ---------------------------------------------------------------------------
-# Section 10: Room not found
-# ---------------------------------------------------------------------------
-
-
 def test_stream_room_not_found_no_instance(client, monkeypatch):
     """Stream for room with no instance sends session_reset and closes."""
     _set_session_room(client, os.environ["FLASK_SECRET"], "NOINSTANCE")
@@ -544,29 +155,6 @@ def test_stream_room_not_found_no_instance(client, monkeypatch):
 
     assert "session_reset" in data
     assert "instance_changed" in data
-
-
-# ---------------------------------------------------------------------------
-# Section 11: GET /matches works independently
-# ---------------------------------------------------------------------------
-
-
-def test_get_matches_works_independently(client, monkeypatch):
-    """GET /matches continues to work independently of the stream."""
-    conn = _sqlite_conn(client)
-    try:
-        _seed_room_and_instance(conn, "MATCHES1", ready=1)
-    finally:
-        conn.close()
-    _set_session_room(client, os.environ["FLASK_SECRET"], "MATCHES1")
-
-    response = client.get("/matches")
-    assert response.status_code == 200
-
-
-# ---------------------------------------------------------------------------
-# Section 12: Unauthenticated request
-# ---------------------------------------------------------------------------
 
 
 def test_stream_unauthenticated_request_returns_401(client_real_auth):

--- a/tests/test_session_event_stream.py
+++ b/tests/test_session_event_stream.py
@@ -1,0 +1,444 @@
+"""Tests for session_event_stream generator with injectable dependencies.
+
+Tests the generator directly with fake dependencies:
+- Fake notifier: subscribe returns a Future, notify resolves it on demand
+- Fake is_disconnected: returns True after N calls
+- Real in-memory DB via runtime_sessionmaker
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from jellyswipe.db_runtime import (
+    build_async_sqlite_url,
+    dispose_runtime,
+    get_sessionmaker,
+    initialize_runtime,
+)
+from jellyswipe.migrations import build_sqlite_url, upgrade_to_head
+from jellyswipe.services.session_event_stream import session_event_stream
+
+import jellyswipe.db_paths as db_paths_mod
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def reset_runtime(monkeypatch):
+    """Reset runtime state before each test."""
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_PATH", raising=False)
+    monkeypatch.setattr(db_paths_mod.application_db_path, "path", None)
+    yield
+
+
+@pytest.fixture
+async def runtime_sessionmaker(db_path, monkeypatch):
+    """Provide an async sessionmaker backed by a temp SQLite DB."""
+    sync_database_url = build_sqlite_url(db_path)
+    runtime_database_url = build_async_sqlite_url(db_path)
+
+    monkeypatch.setattr(db_paths_mod.application_db_path, "path", db_path)
+    monkeypatch.setenv("DB_PATH", db_path)
+    monkeypatch.setenv("DATABASE_URL", sync_database_url)
+
+    upgrade_to_head(sync_database_url)
+    await initialize_runtime(runtime_database_url)
+    yield get_sessionmaker()
+    await dispose_runtime()
+
+
+def _seed_room_and_instance(
+    conn,
+    room_code,
+    *,
+    ready=0,
+    solo_mode=0,
+    current_genre="All",
+    instance_id=None,
+    hide_watched=0,
+    include_movies=1,
+    include_tv_shows=0,
+):
+    """Seed a room row and session instance for tests."""
+    import secrets
+
+    if instance_id is None:
+        instance_id = f"inst-{secrets.token_hex(8)}"
+    movie_data = json.dumps([])
+    conn.execute(
+        "INSERT INTO rooms (pairing_code, movie_data, ready, current_genre, solo_mode, "
+        "hide_watched, include_movies, include_tv_shows, deck_position) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            room_code,
+            movie_data,
+            ready,
+            current_genre,
+            solo_mode,
+            hide_watched,
+            include_movies,
+            include_tv_shows,
+            "{}",
+        ),
+    )
+    now = datetime.now(timezone.utc).isoformat()
+    conn.execute(
+        "INSERT INTO session_instances (instance_id, pairing_code, status, created_at) "
+        "VALUES (?, ?, ?, ?)",
+        (instance_id, room_code, "active", now),
+    )
+    conn.commit()
+    return instance_id
+
+
+def _seed_event(conn, instance_id, event_type, payload_json):
+    """Seed a session event directly."""
+    now = datetime.now(timezone.utc).isoformat()
+    cursor = conn.execute(
+        "INSERT INTO session_events (session_instance_id, event_type, payload_json, created_at) "
+        "VALUES (?, ?, ?, ?)",
+        (instance_id, event_type, payload_json, now),
+    )
+    conn.commit()
+    return cursor.lastrowid
+
+
+def _sqlite_conn(db_path):
+    """Get a direct sqlite3 connection."""
+    import sqlite3
+
+    conn = sqlite3.connect(db_path, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys=ON")
+    return conn
+
+
+class FakeNotifier:
+    """Fake notifier that lets tests control when subscribe futures resolve."""
+
+    def __init__(self):
+        self._subscribers: dict[str, set[asyncio.Future]] = {}
+
+    def subscribe(self, room_code: str) -> asyncio.Future:
+        future: asyncio.Future = asyncio.Future()
+        if room_code not in self._subscribers:
+            self._subscribers[room_code] = set()
+        self._subscribers[room_code].add(future)
+        return future
+
+    def notify(self, room_code: str) -> None:
+        """Resolve all subscribers for a room."""
+        if room_code not in self._subscribers:
+            return
+        futures = self._subscribers.pop(room_code)
+        for future in futures:
+            if not future.done():
+                future.set_result(None)
+
+    def unsubscribe(self, room_code: str, future: asyncio.Future) -> None:
+        if room_code not in self._subscribers:
+            return
+        self._subscribers[room_code].discard(future)
+        if not future.done():
+            future.cancel()
+        if not self._subscribers[room_code]:
+            del self._subscribers[room_code]
+
+
+def _make_disconnected_after(after_calls: int):
+    """Return an is_disconnected callable that returns True after N calls."""
+    call_count = [0]
+
+    async def is_disconnected():
+        call_count[0] += 1
+        return call_count[0] >= after_calls
+
+    return is_disconnected, call_count
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+class TestSessionEventStream:
+    """Test the session_event_stream generator directly."""
+
+    async def test_first_attach_no_cursor_yields_bootstrap(
+        self, runtime_sessionmaker, db_path
+    ):
+        """First attach (no cursor) yields session_bootstrap with correct fields."""
+        conn = _sqlite_conn(db_path)
+        instance_id = _seed_room_and_instance(
+            conn, "BOOT1", ready=1, current_genre="Action", solo_mode=1, hide_watched=1
+        )
+        conn.close()
+
+        notifier = FakeNotifier()
+        is_disconnected, _ = _make_disconnected_after(1)
+
+        gen = session_event_stream(
+            code="BOOT1",
+            instance_id=instance_id,
+            room=MagicMock(
+                ready=True, current_genre="Action", solo_mode=True, hide_watched=True
+            ),
+            cursor=None,
+            sessionmaker_factory=runtime_sessionmaker,
+            notifier=notifier,
+            is_disconnected=is_disconnected,
+        )
+
+        events = []
+        async for event in gen:
+            events.append(event)
+
+        assert len(events) >= 1
+        data = json.loads(events[0]["data"])
+        assert data["event_type"] == "session_bootstrap"
+        assert data["instance_id"] == instance_id
+        assert data["ready"] is True
+        assert data["genre"] == "Action"
+        assert data["solo"] is True
+        assert data["hide_watched"] is True
+        assert "replay_boundary" in data
+
+    async def test_first_attach_replay_boundary_is_latest_event_id(
+        self, runtime_sessionmaker, db_path
+    ):
+        """First attach with existing events: replay_boundary is the latest event_id."""
+        conn = _sqlite_conn(db_path)
+        instance_id = _seed_room_and_instance(conn, "BOOT2")
+        _seed_event(conn, instance_id, "swipe", json.dumps({"media_id": "m1"}))
+        eid2 = _seed_event(conn, instance_id, "swipe", json.dumps({"media_id": "m2"}))
+        conn.close()
+
+        notifier = FakeNotifier()
+        is_disconnected, _ = _make_disconnected_after(1)
+
+        gen = session_event_stream(
+            code="BOOT2",
+            instance_id=instance_id,
+            room=MagicMock(
+                ready=False, current_genre="All", solo_mode=False, hide_watched=False
+            ),
+            cursor=None,
+            sessionmaker_factory=runtime_sessionmaker,
+            notifier=notifier,
+            is_disconnected=is_disconnected,
+        )
+
+        events = []
+        async for event in gen:
+            events.append(event)
+
+        data = json.loads(events[0]["data"])
+        assert data["replay_boundary"] == eid2
+
+    async def test_reconnect_valid_cursor_replays_missed_events(
+        self, runtime_sessionmaker, db_path
+    ):
+        """Reconnect with valid cursor: missed events replayed in order."""
+        conn = _sqlite_conn(db_path)
+        instance_id = _seed_room_and_instance(conn, "REPLAY1")
+        eid1 = _seed_event(
+            conn,
+            instance_id,
+            "swipe",
+            json.dumps({"media_id": "m1", "direction": "right"}),
+        )
+        eid2 = _seed_event(
+            conn, instance_id, "match_found", json.dumps({"media_id": "m1"})
+        )
+        conn.close()
+
+        notifier = FakeNotifier()
+        is_disconnected, _ = _make_disconnected_after(1)
+
+        gen = session_event_stream(
+            code="REPLAY1",
+            instance_id=instance_id,
+            room=None,
+            cursor=eid1,
+            sessionmaker_factory=runtime_sessionmaker,
+            notifier=notifier,
+            is_disconnected=is_disconnected,
+        )
+
+        events = []
+        async for event in gen:
+            events.append(event)
+
+        assert len(events) >= 1
+        data = json.loads(events[0]["data"])
+        assert data["event_type"] == "match_found"
+        assert data["event_id"] == eid2
+
+    async def test_reconnect_events_in_order(self, runtime_sessionmaker, db_path):
+        """Replayed events are delivered in event_id order."""
+        conn = _sqlite_conn(db_path)
+        instance_id = _seed_room_and_instance(conn, "REPLAY2")
+        eid1 = _seed_event(conn, instance_id, "swipe", json.dumps({"media_id": "m1"}))
+        eid2 = _seed_event(conn, instance_id, "swipe", json.dumps({"media_id": "m2"}))
+        eid3 = _seed_event(
+            conn, instance_id, "match_found", json.dumps({"media_id": "m1"})
+        )
+        conn.close()
+
+        notifier = FakeNotifier()
+        is_disconnected, _ = _make_disconnected_after(1)
+
+        gen = session_event_stream(
+            code="REPLAY2",
+            instance_id=instance_id,
+            room=None,
+            cursor=eid1,
+            sessionmaker_factory=runtime_sessionmaker,
+            notifier=notifier,
+            is_disconnected=is_disconnected,
+        )
+
+        events = []
+        async for event in gen:
+            events.append(event)
+
+        assert len(events) == 2
+        assert json.loads(events[0]["data"])["event_id"] == eid2
+        assert json.loads(events[1]["data"])["event_id"] == eid3
+
+    async def test_reconnect_stale_cursor_yields_session_reset(
+        self, runtime_sessionmaker, db_path
+    ):
+        """Reconnect with stale cursor: yields session_reset with reason=stale_cursor."""
+        conn = _sqlite_conn(db_path)
+        instance_id = _seed_room_and_instance(conn, "STALE1")
+        conn.close()
+
+        notifier = FakeNotifier()
+        is_disconnected, _ = _make_disconnected_after(1)
+
+        gen = session_event_stream(
+            code="STALE1",
+            instance_id=instance_id,
+            room=None,
+            cursor=999,
+            sessionmaker_factory=runtime_sessionmaker,
+            notifier=notifier,
+            is_disconnected=is_disconnected,
+        )
+
+        events = []
+        async for event in gen:
+            events.append(event)
+
+        assert len(events) == 1
+        data = json.loads(events[0]["data"])
+        assert data["event_type"] == "session_reset"
+        assert data["reason"] == "stale_cursor"
+
+    async def test_session_closed_during_replay_stops_generator(
+        self, runtime_sessionmaker, db_path
+    ):
+        """session_closed event during replay: generator stops after yielding session_closed."""
+        conn = _sqlite_conn(db_path)
+        instance_id = _seed_room_and_instance(conn, "CLOSE1")
+        _seed_event(conn, instance_id, "swipe", json.dumps({"media_id": "m1"}))
+        _seed_event(
+            conn, instance_id, "session_closed", json.dumps({"reason": "user_quit"})
+        )
+        conn.close()
+
+        notifier = FakeNotifier()
+        is_disconnected, _ = _make_disconnected_after(1)
+
+        gen = session_event_stream(
+            code="CLOSE1",
+            instance_id=instance_id,
+            room=None,
+            cursor=0,
+            sessionmaker_factory=runtime_sessionmaker,
+            notifier=notifier,
+            is_disconnected=is_disconnected,
+        )
+
+        events = []
+        async for event in gen:
+            events.append(event)
+
+        # Should have swipe + session_closed, then stop
+        event_types = [json.loads(e["data"])["event_type"] for e in events]
+        assert "session_closed" in event_types
+        # No bootstrap since cursor was provided
+        assert not any("session_bootstrap" in e.get("data", "") for e in events)
+
+    async def test_disconnect_detected_exits_cleanly(
+        self, runtime_sessionmaker, db_path
+    ):
+        """Disconnect detected: is_disconnected returns True -> generator exits cleanly."""
+        conn = _sqlite_conn(db_path)
+        instance_id = _seed_room_and_instance(conn, "DISC1")
+        conn.close()
+
+        notifier = FakeNotifier()
+        is_disconnected, call_count = _make_disconnected_after(1)
+
+        gen = session_event_stream(
+            code="DISC1",
+            instance_id=instance_id,
+            room=None,
+            cursor=None,
+            sessionmaker_factory=runtime_sessionmaker,
+            notifier=notifier,
+            is_disconnected=is_disconnected,
+        )
+
+        events = []
+        async for event in gen:
+            events.append(event)
+
+        # Should get bootstrap then exit on disconnect
+        assert len(events) >= 1
+        assert "session_bootstrap" in events[0]["data"]
+        assert call_count[0] >= 1
+
+    async def test_first_attach_no_room_yields_defaults(
+        self, runtime_sessionmaker, db_path
+    ):
+        """First attach with no room object yields default values."""
+        conn = _sqlite_conn(db_path)
+        instance_id = _seed_room_and_instance(conn, "NOROOM1")
+        conn.close()
+
+        notifier = FakeNotifier()
+        is_disconnected, _ = _make_disconnected_after(1)
+
+        gen = session_event_stream(
+            code="NOROOM1",
+            instance_id=instance_id,
+            room=None,
+            cursor=None,
+            sessionmaker_factory=runtime_sessionmaker,
+            notifier=notifier,
+            is_disconnected=is_disconnected,
+        )
+
+        events = []
+        async for event in gen:
+            events.append(event)
+
+        data = json.loads(events[0]["data"])
+        assert data["ready"] is False
+        assert data["genre"] == "All"
+        assert data["solo"] is False
+        assert data["hide_watched"] is False


### PR DESCRIPTION
## Extract SSE stream generator into service module

Extract the SSE stream generator from the inline `generate()` function in `routers/rooms.py` into a dedicated service module with injectable dependencies.

**Context:** The current `generate()` async generator (lines 379-493 of `rooms.py`) is a 115-line function nested inside the route handler. It handles bootstrap, cursor validation, replay, heartbeat, subscription, and disconnect detection all in one place. Testing requires HTTP-level interactions. Extracting it allows direct testing with fake dependencies.

**New file: `jellyswipe/services/session_event_stream.py`**

```python
async def session_event_stream(
    code: str,
    instance_id: str,
    room,  # Room model/record
    cursor: int | None,
    sessionmaker_factory: Callable,
    notifier: SessionNotifier,
    is_disconnected: Callable[[], Awaitable[bool]],
) -> AsyncGenerator[dict, None]:
    """Session Event Stream generator with injectable dependencies.
    
    Yields dicts with keys: "id" (str), "data" (str), and/or "comment" (str).
    Same shape EventSourceResponse consumes.
    """
    # 1. Cursor validation or bootstrap
    if cursor is not None:
        async with sessionmaker_factory() as session:
            uow = DatabaseUnitOfWork(session)
            events_after = await uow.session_events.read_after(instance_id, cursor, limit=1)
            if not events_after:
                yield {"data": json.dumps({"event_type": "session_reset", "reason": "stale_cursor"})}
                return
    else:
        async with sessionmaker_factory() as session:
            uow = DatabaseUnitOfWork(session)
            latest_eid = await uow.session_events.read_latest_event_id(instance_id)
        bootstrap = {
            "event_type": "session_bootstrap",
            "instance_id": instance_id,
            "ready": room.ready if room else False,
            "genre": room.current_genre if room else "All",
            "solo": room.solo_mode if room else False,
            "hide_watched": room.hide_watched if room else False,
            "replay_boundary": latest_eid or 0,
        }
        yield {"id": str(latest_eid or 0), "data": json.dumps(bootstrap)}
    
    # 2. Replay missed events
    missed = []
    if cursor is not None:
        async with sessionmaker_factory() as session:
            uow = DatabaseUnitOfWork(session)
            missed = await uow.session_events.read_after(instance_id, cursor, limit=100)
        for evt in missed:
            yield {"id": str(evt.event_id), "data": json.dumps({"event_id": evt.event_id, "event_type": evt.event_type, **json.loads(evt.payload_json)})}
            if evt.event_type == "session_closed":
                return
    
    # 3. Live event subscription loop
    last_event_id = missed[-1].event_id if cursor is not None and missed else (latest_eid or 0)
    last_event_time = time.time()
    
    while True:
        if await is_disconnected():
            break
        
        future = notifier.subscribe(code)
        try:
            await asyncio.wait_for(future, timeout=20.0)
        except asyncio.TimeoutError:
            if time.time() - last_event_time >= 15:
                yield {"comment": "ping"}
                last_event_time = time.time()
            continue
        
        async with sessionmaker_factory() as session:
            uow = DatabaseUnitOfWork(session)
            new_events = await uow.session_events.read_after(instance_id, last_event_id, limit=100)
        
        for evt in new_events:
            payload = {"event_id": evt.event_id, "event_type": evt.event_type}
            payload.update(json.loads(evt.payload_json))
            yield {"id": str(evt.event_id), "data": json.dumps(payload)}
            last_event_id = evt.event_id
            last_event_time = time.time()
            if evt.event_type == "session_closed":
                notifier.unsubscribe(code, future)
                return
        
        notifier.unsubscribe(code, future)
```

**Changes to `jellyswipe/routers/rooms.py`:**

The `room_stream` route handler shrinks to:
```python
@rooms_router.get("/room/{code}/stream")
def room_stream(code: str, request: Request, auth: AuthUser = Depends(require_auth)):
    async def generate():
        # Resolve instance and room
        async with get_sessionmaker()() as session:
            uow = DatabaseUnitOfWork(session)
            instance = await uow.session_instances.get_by_pairing_code(code)
            if instance is None or instance.status == "closed":
                yield {"data": json.dumps({"event_type": "session_reset", "reason": "instance_changed"})}
                return
            room = await uow.rooms.get_room(code)
        
        cursor = request.headers.get("Last-Event-ID") or request.query_params.get("after_event_id")
        cursor = int(cursor) if cursor else None
        
        async for event in session_event_stream(
            code=code,
            instance_id=instance.instance_id,
            room=room,
            cursor=cursor,
            sessionmaker_factory=get_sessionmaker(),
            notifier=notifier,
            is_disconnected=request.is_disconnected,
        ):
            yield event
    
    return EventSourceResponse(generate(), headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"})
```

The route handler handles instance resolution (domain logic that requires DB), then delegates all stream logic to the extracted generator.


### Acceptance Criteria

1. `jellyswipe/services/session_event_stream.py` exists with an async generator function that accepts all dependencies as parameters (code, instance_id, room, cursor, sessionmaker_factory, notifier, is_disconnected)
2. The generator yields dicts with `id`, `data`, and/or `comment` keys — same shape `EventSourceResponse` consumes
3. The generator owns: bootstrap construction, cursor validation, replay, heartbeat timing, live event subscription, session_closed detection
4. The route handler in `routers/rooms.py` is ~15 lines: resolve instance + room, parse cursor, call generator, wrap in `EventSourceResponse`
5. No global imports inside the generator — all dependencies injected via parameters
6. All existing SSE route tests pass
7. New test file `tests/test_session_event_stream.py` tests the generator directly with fake dependencies
8. `tests/test_routes_sse.py` shrinks to testing SSE headers, content-type, and thin route wiring


---
Ticket: `ORCH-023`