### PR TITLE
fix: release ci fixes

### DIFF
--- a/.github/workflows/release-ghcr.yml
+++ b/.github/workflows/release-ghcr.yml
@@ -92,8 +92,8 @@ jobs:
           for f in /tmp/digests/*; do
             DIGESTS="$DIGESTS ${REGISTRY}/${IMAGE_NAME}@$(cat $f)"
           done
-          for tag in $(jq -r '.[]' <<< '${{ steps.meta.outputs.json }}' | jq -r '.tags[]?'); do
-            docker buildx imagetools create -t $tag $DIGESTS
+          jq -r '.tags[]' <<< '${{ steps.meta.outputs.json }}' | while read -r tag; do
+            docker buildx imagetools create -t "$tag" $DIGESTS
           done
       - name: Trivy scan (non-blocking)
         uses: aquasecurity/trivy-action@master


### PR DESCRIPTION
 Root cause

  Look at the "Create manifest list" step:

  for tag in $(jq -r '.[]' <<< '${{ steps.meta.outputs.json }}' | jq -r '.tags[]?'); do
    docker buildx imagetools create -t $tag $DIGESTS
  done

  steps.meta.outputs.json is an object like:
  { "tags": [...], "tag-names": [...], "labels": {...}, "annotations": [...] }

  jq -r '.[]' on that object emits each value (the tags array, the tag-names array, the labels object, …) as separate JSON blobs on stdout. Piping that text into jq -r '.tags[]?'
  parses those blobs and asks each one for a .tags field — none of them have one. The ? swallows the error, the loop iterates zero times, and no imagetools create ever runs.


