### PR TITLE
feat(ORCH-025): Define domain types and SessionMatchMutation module shell

### DIFF
--- a/jellyswipe/services/session_match_mutation.py
+++ b/jellyswipe/services/session_match_mutation.py
@@ -1,0 +1,128 @@
+"""Session Match Mutation — domain types and stub class.
+
+This module defines the types and class shell for the Session Match Mutation
+module. All types are immutable dataclasses. The class methods are stubs that
+raise ``NotImplementedError`` — implementations will be filled in by
+subsequent tickets.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from jellyswipe.db_uow import DatabaseUnitOfWork
+
+
+@dataclass(slots=True, frozen=True)
+class SessionActor:
+    """Replaces raw request.session dict plumbing."""
+
+    user_id: str
+    session_id: str | None
+    active_room: str | None
+
+
+@dataclass(slots=True, frozen=True)
+class CatalogFacts:
+    """Minimal external facts the module cannot derive from Session state."""
+
+    title: str | None = None
+    thumb: str | None = None
+
+
+@dataclass(slots=True, frozen=True)
+class SwipeAccepted:
+    """Swipe was applied successfully."""
+
+    match_created: bool
+
+
+@dataclass(slots=True, frozen=True)
+class SwipeRejected:
+    """Swipe was rejected."""
+
+    reason: str  # "room_not_found"
+
+
+ApplySwipeResult = SwipeAccepted | SwipeRejected
+
+
+@dataclass(slots=True, frozen=True)
+class UndoChanged:
+    """Swipe was found and removed."""
+
+    match_removed: bool  # True if an active match was also removed
+
+
+@dataclass(slots=True, frozen=True)
+class UndoNoOp:
+    """No matching swipe found to undo."""
+
+
+UndoSwipeResult = UndoChanged | UndoNoOp
+
+
+@dataclass(slots=True, frozen=True)
+class DeleteChanged:
+    """Match was found and deleted."""
+
+
+@dataclass(slots=True, frozen=True)
+class DeleteNoOp:
+    """No matching match found to delete."""
+
+
+DeleteMatchResult = DeleteChanged | DeleteNoOp
+
+
+class SessionMatchMutation:
+    """Typed stub methods for session-based match mutations."""
+
+    async def apply_swipe(
+        self,
+        *,
+        code: str,
+        actor: SessionActor,
+        media_id: str,
+        direction: str | None,
+        catalog_facts: CatalogFacts,
+        uow: DatabaseUnitOfWork,
+    ) -> ApplySwipeResult:
+        raise NotImplementedError
+
+    async def undo_swipe(
+        self,
+        *,
+        code: str,
+        actor: SessionActor,
+        media_id: str,
+        uow: DatabaseUnitOfWork,
+    ) -> UndoSwipeResult:
+        raise NotImplementedError
+
+    async def delete_match(
+        self,
+        *,
+        actor: SessionActor,
+        media_id: str,
+        uow: DatabaseUnitOfWork,
+    ) -> DeleteMatchResult:
+        raise NotImplementedError
+
+
+__all__ = [
+    "ApplySwipeResult",
+    "CatalogFacts",
+    "DeleteChanged",
+    "DeleteMatchResult",
+    "DeleteNoOp",
+    "SessionActor",
+    "SessionMatchMutation",
+    "SwipeAccepted",
+    "SwipeRejected",
+    "UndoChanged",
+    "UndoNoOp",
+    "UndoSwipeResult",
+]

--- a/tests/test_session_match_mutation.py
+++ b/tests/test_session_match_mutation.py
@@ -1,0 +1,144 @@
+"""Tests for session_match_mutation domain types and stub class."""
+
+import pytest
+
+from jellyswipe.services.session_match_mutation import (
+    ApplySwipeResult,
+    CatalogFacts,
+    DeleteChanged,
+    DeleteMatchResult,
+    DeleteNoOp,
+    SessionActor,
+    SessionMatchMutation,
+    SwipeAccepted,
+    SwipeRejected,
+    UndoChanged,
+    UndoNoOp,
+    UndoSwipeResult,
+)
+
+
+class TestSessionActor:
+    def test_instantiation(self) -> None:
+        actor = SessionActor(user_id="u1", session_id="s1", active_room="R1")
+        assert actor.user_id == "u1"
+        assert actor.session_id == "s1"
+        assert actor.active_room == "R1"
+
+    def test_frozen(self) -> None:
+        actor = SessionActor(user_id="u1", session_id="s1", active_room="R1")
+        with pytest.raises(AttributeError):
+            actor.user_id = "u2"  # type: ignore[misc]
+
+    def test_optional_fields(self) -> None:
+        actor = SessionActor(user_id="u1", session_id=None, active_room=None)
+        assert actor.session_id is None
+        assert actor.active_room is None
+
+
+class TestCatalogFacts:
+    def test_instantiation(self) -> None:
+        facts = CatalogFacts(title="Movie", thumb="/t.jpg")
+        assert facts.title == "Movie"
+        assert facts.thumb == "/t.jpg"
+
+    def test_defaults(self) -> None:
+        facts = CatalogFacts()
+        assert facts.title is None
+        assert facts.thumb is None
+
+    def test_frozen(self) -> None:
+        facts = CatalogFacts(title="Movie")
+        with pytest.raises(AttributeError):
+            facts.title = "Other"  # type: ignore[misc]
+
+
+class TestSwipeResultTypes:
+    def test_swipe_accepted(self) -> None:
+        result = SwipeAccepted(match_created=True)
+        assert result.match_created is True
+
+    def test_swipe_rejected(self) -> None:
+        result = SwipeRejected(reason="room_not_found")
+        assert result.reason == "room_not_found"
+
+    def test_apply_swipe_result_union(self) -> None:
+        accepted: ApplySwipeResult = SwipeAccepted(match_created=False)
+        rejected: ApplySwipeResult = SwipeRejected(reason="invalid")
+        assert isinstance(accepted, SwipeAccepted)
+        assert isinstance(rejected, SwipeRejected)
+
+
+class TestUndoSwipeResultTypes:
+    def test_undo_changed(self) -> None:
+        result = UndoChanged(match_removed=True)
+        assert result.match_removed is True
+
+    def test_undo_no_op(self) -> None:
+        result = UndoNoOp()
+        assert result is not None
+
+    def test_undo_swipe_result_union(self) -> None:
+        changed: UndoSwipeResult = UndoChanged(match_removed=False)
+        no_op: UndoSwipeResult = UndoNoOp()
+        assert isinstance(changed, UndoChanged)
+        assert isinstance(no_op, UndoNoOp)
+
+
+class TestDeleteMatchResultTypes:
+    def test_delete_changed(self) -> None:
+        result = DeleteChanged()
+        assert result is not None
+
+    def test_delete_no_op(self) -> None:
+        result = DeleteNoOp()
+        assert result is not None
+
+    def test_delete_match_result_union(self) -> None:
+        changed: DeleteMatchResult = DeleteChanged()
+        no_op: DeleteMatchResult = DeleteNoOp()
+        assert isinstance(changed, DeleteChanged)
+        assert isinstance(no_op, DeleteNoOp)
+
+
+class TestSessionMatchMutation:
+    def test_instantiation(self) -> None:
+        mutation = SessionMatchMutation()
+        assert mutation is not None
+
+    @pytest.mark.anyio
+    async def test_apply_swipe_raises_not_implemented(self) -> None:
+        mutation = SessionMatchMutation()
+        actor = SessionActor(user_id="u1", session_id="s1", active_room="R1")
+        with pytest.raises(NotImplementedError):
+            await mutation.apply_swipe(
+                code="1234",
+                actor=actor,
+                media_id="m1",
+                direction="right",
+                catalog_facts=CatalogFacts(),
+                uow=None,  # type: ignore[arg-type]
+            )
+
+    @pytest.mark.anyio
+    async def test_undo_swipe_raises_not_implemented(self) -> None:
+        mutation = SessionMatchMutation()
+        actor = SessionActor(user_id="u1", session_id="s1", active_room="R1")
+        with pytest.raises(NotImplementedError):
+            await mutation.undo_swipe(
+                code="1234",
+                actor=actor,
+                media_id="m1",
+                uow=None,  # type: ignore[arg-type]
+            )
+
+    @pytest.mark.anyio
+    async def test_delete_match_raises_not_implemented(self) -> None:
+        mutation = SessionMatchMutation()
+        actor = SessionActor(user_id="u1", session_id="s1", active_room="R1")
+        with pytest.raises(NotImplementedError):
+            await mutation.delete_match(
+                actor=actor,
+                media_id="m1",
+                uow=None,  # type: ignore[arg-type]
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -273,7 +273,7 @@ wheels = [
 
 [[package]]
 name = "jellyswipe"
-version = "0.2.0"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Define domain types and SessionMatchMutation module shell

Create the foundation types and class shell for the new Session Match Mutation module. This ticket produces **no behavioral changes** — it only introduces types and stubs that subsequent tickets will fill in.

**What to build in `jellyswipe/services/session_match_mutation.py` (new file):**

1. **`SessionActor` dataclass** — replaces raw `request.session` dict plumbing:
   ```python
   @dataclass(slots=True, frozen=True)
   class SessionActor:
       user_id: str
       session_id: str | None
       active_room: str | None
   ```

2. **`CatalogFacts` dataclass** — minimal external facts the module cannot derive from Session state:
   ```python
   @dataclass(slots=True, frozen=True)
   class CatalogFacts:
       title: str | None = None
       thumb: str | None = None
   ```

3. **Domain result types** for all three commands:

   ```python
   @dataclass(slots=True, frozen=True)
   class SwipeAccepted:
       """Swipe was applied successfully."""
       match_created: bool

   @dataclass(slots=True, frozen=True)
   class SwipeRejected:
       """Swipe was rejected."""
       reason: str  # "room_not_found"

   ApplySwipeResult = SwipeAccepted | SwipeRejected

   @dataclass(slots=True, frozen=True)
   class UndoChanged:
       """Swipe was found and removed."""
       match_removed: bool  # True if an active match was also removed

   @dataclass(slots=True, frozen=True)
   class UndoNoOp:
       """No matching swipe found to undo."""

   UndoSwipeResult = UndoChanged | UndoNoOp

   @dataclass(slots=True, frozen=True)
   class DeleteChanged:
       """Match was found and deleted."""

   @dataclass(slots=True, frozen=True)
   class DeleteNoOp:
       """No matching match found to delete."""

   DeleteMatchResult = DeleteChanged | DeleteNoOp
   ```

4. **`SessionMatchMutation` class shell** with typed stub methods that raise `NotImplementedError`:
   ```python
   class SessionMatchMutation:
       async def apply_swipe(
           self,
           *,
           code: str,
           actor: SessionActor,
           media_id: str,
           direction: str | None,
           catalog_facts: CatalogFacts,
           uow: DatabaseUnitOfWork,
       ) -> ApplySwipeResult:
           raise NotImplementedError

       async def undo_swipe(
           self,
           *,
           code: str,
           actor: SessionActor,
           media_id: str,
           uow: DatabaseUnitOfWork,
       ) -> UndoSwipeResult:
           raise NotImplementedError

       async def delete_match(
           self,
           *,
           actor: SessionActor,
           media_id: str,
           uow: DatabaseUnitOfWork,
       ) -> DeleteMatchResult:
           raise NotImplementedError
   ```

5. **`__all__` export** listing all public types and the class.

**Constraints:**
- All types should use `@dataclass(slots=True, frozen=True)` for immutability.
- Import `DatabaseUnitOfWork` from `jellyswipe.db_uow` (type annotation only).
- This file must pass `ruff check` and `ruff format`.


### Acceptance Criteria

1. File `jellyswipe/services/session_match_mutation.py` exists with all types defined above
2. `SessionActor` has exactly three fields: `user_id: str`, `session_id: str | None`, `active_room: str | None`
3. `CatalogFacts` has exactly two optional fields: `title: str | None`, `thumb: str | None`
4. `ApplySwipeResult` is a union of `SwipeAccepted` and `SwipeRejected`
5. `SwipeAccepted` has `match_created: bool`; `SwipeRejected` has `reason: str`
6. `UndoSwipeResult` is a union of `UndoChanged` and `UndoNoOp`
7. `UndoChanged` has `match_removed: bool`; `UndoNoOp` has no fields
8. `DeleteMatchResult` is a union of `DeleteChanged` and `DeleteNoOp`
9. `SessionMatchMutation` class has three stub methods with correct signatures, all raising `NotImplementedError`
10. `__all__` lists all public names
11. `ruff check jellyswipe/services/session_match_mutation.py` passes
12. `from jellyswipe.services.session_match_mutation import SessionMatchMutation, SessionActor, ...` succeeds without error


---
Ticket: `ORCH-025`