### PR TITLE
feat(ORCH-026): Add sync event append helper for use inside serialized transactions

### DIFF
--- a/jellyswipe/repositories/session_events.py
+++ b/jellyswipe/repositories/session_events.py
@@ -3,10 +3,40 @@
 from __future__ import annotations
 
 from sqlalchemy import delete, func, select, text
+from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.ext.asyncio import AsyncConnection as AsyncConnection
 
 from jellyswipe.models.session_event import SessionEvent, SessionInstance
+
+
+def append_sync(
+    conn: Connection,
+    instance_id: str,
+    event_type: str,
+    payload_json: str,
+) -> int:
+    """Append a session event using a sync Connection (for use inside run_sync).
+
+    Returns the auto-generated event_id.
+    """
+    from datetime import datetime, timezone
+
+    created_at = datetime.now(timezone.utc).isoformat()
+    conn.execute(
+        text("""
+            INSERT INTO session_events (session_instance_id, event_type, payload_json, created_at)
+            VALUES (:instance_id, :event_type, :payload_json, :created_at)
+        """),
+        {
+            "instance_id": instance_id,
+            "event_type": event_type,
+            "payload_json": payload_json,
+            "created_at": created_at,
+        },
+    )
+    result = conn.execute(text("SELECT last_insert_rowid()"))
+    return result.scalar()
 
 
 class SessionInstanceRepository:

--- a/tests/test_session_event_repos.py
+++ b/tests/test_session_event_repos.py
@@ -18,6 +18,7 @@ from jellyswipe.db_runtime import (
 )
 from jellyswipe.db_uow import DatabaseUnitOfWork
 from jellyswipe.migrations import build_sqlite_url, upgrade_to_head
+from jellyswipe.repositories.session_events import append_sync
 
 
 @pytest.fixture(autouse=True)
@@ -178,6 +179,91 @@ class TestSessionEventRepository:
         assert len(events) == 1
         assert events[0].event_type == "raw_event"
         assert json.loads(events[0].payload_json) == {"raw": True}
+
+    async def test_append_sync_returns_positive_event_id(self, runtime_sessionmaker):
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.session_instances.create("inst-sync", "SYNC1")
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            event_id = await session.run_sync(
+                lambda conn: append_sync(
+                    conn, "inst-sync", "sync_event", json.dumps({"sync": True})
+                )
+            )
+            await session.commit()
+
+        assert event_id is not None
+        assert event_id > 0
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            events = await uow.session_events.read_after("inst-sync", after_event_id=0)
+
+        assert len(events) == 1
+        assert events[0].event_type == "sync_event"
+        assert json.loads(events[0].payload_json) == {"sync": True}
+
+    async def test_append_sync_created_at_is_valid_iso8601(self, runtime_sessionmaker):
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.session_instances.create("inst-sync-iso", "SYNC2")
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await session.run_sync(
+                lambda conn: append_sync(
+                    conn, "inst-sync-iso", "iso_test", json.dumps({})
+                )
+            )
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            events = await uow.session_events.read_after(
+                "inst-sync-iso", after_event_id=0
+            )
+
+        assert len(events) == 1
+        # Verify created_at is a valid ISO 8601 string
+        dt = datetime.fromisoformat(events[0].created_at)
+        assert dt.tzinfo is not None
+
+    async def test_append_sync_inside_begin_immediate_transaction(
+        self, runtime_sessionmaker
+    ):
+        """Verify append_sync works inside a BEGIN IMMEDIATE transaction."""
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            await uow.session_instances.create("inst-sync-imm", "SYNC3")
+            await session.commit()
+
+        async with runtime_sessionmaker() as session:
+            # Use run_sync to get a sync connection and execute BEGIN IMMEDIATE
+            def _append_in_immediate(conn):
+                conn.execute(text("BEGIN IMMEDIATE"))
+                event_id = append_sync(
+                    conn, "inst-sync-imm", "immediate_event", json.dumps({"imm": True})
+                )
+                conn.execute(text("COMMIT"))
+                return event_id
+
+            event_id = await session.run_sync(_append_in_immediate)
+
+        assert event_id is not None
+        assert event_id > 0
+
+        async with runtime_sessionmaker() as session:
+            uow = DatabaseUnitOfWork(session)
+            events = await uow.session_events.read_after(
+                "inst-sync-imm", after_event_id=0
+            )
+
+        assert len(events) == 1
+        assert events[0].event_type == "immediate_event"
 
     async def test_delete_for_instance_removes_all_events(self, runtime_sessionmaker):
         async with runtime_sessionmaker() as session:


### PR DESCRIPTION
## Add sync event append helper for use inside serialized transactions

Add a **sync** event append helper function to the session events repository module. The existing `SessionEventRepository.append_raw_sql` takes an `AsyncConnection`, but the `apply_swipe` command runs inside `uow.run_sync(...)` where only a sync `Connection` is available. The mutation module needs a sync path to insert events atomically within the serialized swipe transaction.

**What to add in `jellyswipe/repositories/session_events.py`:**

Add a module-level function (not a method on the async repository class, since it operates on a sync connection):

```python
from sqlalchemy.engine import Connection

def append_sync(
    conn: Connection,
    instance_id: str,
    event_type: str,
    payload_json: str,
) -> int:
    """Append a session event using a sync Connection (for use inside run_sync).
    
    Returns the auto-generated event_id.
    """
    from datetime import datetime, timezone

    created_at = datetime.now(timezone.utc).isoformat()
    conn.execute(
        text("""
            INSERT INTO session_events (session_instance_id, event_type, payload_json, created_at)
            VALUES (:instance_id, :event_type, :payload_json, :created_at)
        """),
        {
            "instance_id": instance_id,
            "event_type": event_type,
            "payload_json": payload_json,
            "created_at": created_at,
        },
    )
    result = conn.execute(text("SELECT last_insert_rowid()"))
    return result.scalar()
```

**Why module-level function, not a method:**
- The `SessionEventRepository` is constructed with an `AsyncSession`
- The sync `Connection` comes from inside `run_sync`, a different lifecycle
- A standalone function avoids the conceptual mismatch of an async repo holding sync state

**Why not modify `append_raw_sql`:**
- `append_raw_sql` is an async method on the repo class, used by the SSE stream
- Changing its signature would break existing callers
- The sync function serves a different context (serialized transaction)

**Constraints:**
- Do NOT modify the existing `append_raw_sql` method
- Do NOT modify any other existing methods
- Only ADD the new function and its import


### Acceptance Criteria

1. `append_sync(conn: Connection, instance_id: str, event_type: str, payload_json: str) -> int` exists as a module-level function in `jellyswipe/repositories/session_events.py`
2. The function takes a **sync** SQLAlchemy `Connection` (from `sqlalchemy.engine`), not an `AsyncConnection`
3. The function inserts a row into `session_events` with `session_instance_id`, `event_type`, `payload_json`, and `created_at` (current UTC ISO 8601)
4. The function returns the auto-generated `event_id` (via `last_insert_rowid()`)
5. The function works when called inside a `run_sync` block (i.e., inside `BEGIN IMMEDIATE` transaction)
6. The function is exported from the module
7. Existing `append_raw_sql` (async) method is NOT modified
8. All existing tests pass (`uv run pytest`)
9. `ruff check` passes


---
Ticket: `ORCH-026`