### PR TITLE
feat(ORCH-034): Add commit_and_wake helper to _helpers.py

### DIFF
--- a/jellyswipe/routers/_helpers.py
+++ b/jellyswipe/routers/_helpers.py
@@ -6,6 +6,8 @@ import traceback
 from fastapi import Request
 
 from jellyswipe import XSSSafeJSONResponse
+from jellyswipe.db_uow import DatabaseUnitOfWork
+from jellyswipe.notifier import notifier
 
 _logger = logging.getLogger(__name__)
 
@@ -42,3 +44,13 @@ def log_exception(
         log_data.update(context)
     target_logger = logger or _logger
     target_logger.error("unhandled_exception", extra=log_data)
+
+
+async def commit_and_wake(uow: DatabaseUnitOfWork, code: str) -> None:
+    """Commit the UoW transaction, then wake SSE subscribers for the room.
+
+    Must be called AFTER all database writes are complete.
+    Commit happens before notify to ensure subscribers read committed data.
+    """
+    await uow.session.commit()
+    notifier.notify(code)

--- a/tests/test_commit_and_wake.py
+++ b/tests/test_commit_and_wake.py
@@ -1,0 +1,44 @@
+"""Tests for commit_and_wake helper."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from jellyswipe.routers._helpers import commit_and_wake
+
+
+@pytest.mark.anyio
+async def test_commit_and_wake_commits_then_notifies():
+    """commit_and_wake calls uow.session.commit() then notifier.notify(code)."""
+    uow = MagicMock()
+    uow.session.commit = AsyncMock()
+
+    call_order = []
+
+    async def track_commit():
+        call_order.append("commit")
+
+    def track_notify(code):
+        call_order.append("notify")
+
+    uow.session.commit.side_effect = track_commit
+
+    with patch("jellyswipe.routers._helpers.notifier") as mock_notifier:
+        mock_notifier.notify.side_effect = track_notify
+        await commit_and_wake(uow, "ABCD")
+
+    assert call_order == ["commit", "notify"]
+    mock_notifier.notify.assert_called_once_with("ABCD")
+
+
+@pytest.mark.anyio
+async def test_commit_and_wake_propagates_commit_error():
+    """If commit raises, the error propagates and notifier.notify is NOT called."""
+    uow = MagicMock()
+    uow.session.commit = AsyncMock(side_effect=RuntimeError("db error"))
+
+    with patch("jellyswipe.routers._helpers.notifier") as mock_notifier:
+        with pytest.raises(RuntimeError, match="db error"):
+            await commit_and_wake(uow, "WXYZ")
+
+    mock_notifier.notify.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -273,7 +273,7 @@ wheels = [
 
 [[package]]
 name = "jellyswipe"
-version = "0.3.2"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Add commit_and_wake helper to _helpers.py

Add an async free function `commit_and_wake(uow, code)` to `jellyswipe/routers/_helpers.py` that composes `uow.session.commit()` + `notifier.notify(code)` into a single call.

**What to build:**

Add to `jellyswipe/routers/_helpers.py`:

```python
from jellyswipe.db_uow import DatabaseUnitOfWork
from jellyswipe.notifier import notifier

async def commit_and_wake(uow: DatabaseUnitOfWork, code: str) -> None:
    """Commit the UoW transaction, then wake SSE subscribers for the room.
    
    Must be called AFTER all database writes are complete.
    Commit happens before notify to ensure subscribers read committed data.
    """
    await uow.session.commit()
    notifier.notify(code)
```

New imports: `DatabaseUnitOfWork` from `jellyswipe.db_uow`, `notifier` from `jellyswipe.notifier`.

**Expected files:**
- `jellyswipe/routers/_helpers.py` (modify — add function + 2 imports)
- `tests/test_commit_and_wake.py` (new)

**Context:** This helper is the foundation for the commit-before-notify invariant. Currently unused — Tickets 2+ will wire it into route handlers.


### Acceptance Criteria

1. `commit_and_wake` exists as an async function in `jellyswipe/routers/_helpers.py`
2. Function signature: `async def commit_and_wake(uow: DatabaseUnitOfWork, code: str) -> None`
3. Calls `await uow.session.commit()` first, then `notifier.notify(code)` — order is guaranteed
4. Imports added: `DatabaseUnitOfWork` from `jellyswipe.db_uow`, `notifier` from `jellyswipe.notifier`
5. No import errors (no circular imports)
6. Existing `_helpers.py` functions (`make_error_response`, `log_exception`) unchanged


---
Ticket: `ORCH-034`