### PR TITLE
feat(ORCH-036): Add explicit commits to auth and media routes

### DIFF
--- a/jellyswipe/routers/auth.py
+++ b/jellyswipe/routers/auth.py
@@ -25,7 +25,9 @@ auth_router = APIRouter()
 
 
 @auth_router.post("/auth/jellyfin-use-server-identity")
-async def jellyfin_use_server_identity(request: Request, uow: DBUoW, provider = Depends(get_provider)):
+async def jellyfin_use_server_identity(
+    request: Request, uow: DBUoW, provider=Depends(get_provider)
+):
     """Authenticate using Jellyfin server delegate identity."""
     try:
         token = provider.server_access_token_for_delegate()
@@ -33,6 +35,7 @@ async def jellyfin_use_server_identity(request: Request, uow: DBUoW, provider = 
     except RuntimeError:
         return make_error_response("Jellyfin delegate unavailable", 401, request)
     await create_session(token, uid, request.session, uow)
+    await uow.session.commit()
     return {"userId": uid}
 
 
@@ -45,12 +48,18 @@ async def logout(
 ):
     """Destroy the current user session."""
     await destroy_session(request.session, uow)
+    await uow.session.commit()
     response.delete_cookie("session", path="/")
     return {"status": "logged_out"}
 
 
 @auth_router.get("/me")
-async def get_me(request: Request, uow: DBUoW, user: AuthUser = Depends(require_auth), provider = Depends(get_provider)):
+async def get_me(
+    request: Request,
+    uow: DBUoW,
+    user: AuthUser = Depends(require_auth),
+    provider=Depends(get_provider),
+):
     """Return current user information."""
     active_room = await resolve_active_room(request.session, uow)
     info = provider.server_info()
@@ -64,7 +73,7 @@ async def get_me(request: Request, uow: DBUoW, user: AuthUser = Depends(require_
 
 
 @auth_router.get("/jellyfin/server-info")
-def jellyfin_server_info(request: Request, provider = Depends(get_provider)):
+def jellyfin_server_info(request: Request, provider=Depends(get_provider)):
     """Return Jellyfin server information."""
     try:
         info = provider.server_info()

--- a/jellyswipe/routers/media.py
+++ b/jellyswipe/routers/media.py
@@ -28,7 +28,12 @@ media_router = APIRouter()
 
 @media_router.get("/get-trailer/{movie_id}")
 async def get_trailer(
-    movie_id: str, request: Request, uow: DBUoW, config: AppConfig = Depends(get_config), provider = Depends(get_provider), _: None = Depends(check_rate_limit)
+    movie_id: str,
+    request: Request,
+    uow: DBUoW,
+    config: AppConfig = Depends(get_config),
+    provider=Depends(get_provider),
+    _: None = Depends(check_rate_limit),
 ):
     """Get YouTube trailer key for a movie."""
     try:
@@ -42,15 +47,19 @@ async def get_trailer(
 
         # Cache miss — resolve item and call TMDB
         item = provider.resolve_item_for_tmdb(movie_id)
-        youtube_key = lookup_trailer(item.title, item.year, api_token=config.tmdb_access_token)
+        youtube_key = lookup_trailer(
+            item.title, item.year, api_token=config.tmdb_access_token
+        )
 
         if youtube_key:
             result = {"youtube_key": youtube_key}
             await uow.tmdb_cache.put(movie_id, "trailer", json.dumps(result))
+            await uow.session.commit()
             return result
 
         # No trailer found — cache the miss to avoid repeated lookups
         await uow.tmdb_cache.put(movie_id, "trailer", json.dumps({}))
+        await uow.session.commit()
         return make_error_response("Not found", 404, request)
     except RuntimeError as e:
         if "item lookup failed" in str(e).lower():
@@ -64,7 +73,12 @@ async def get_trailer(
 
 @media_router.get("/cast/{movie_id}")
 async def get_cast(
-    movie_id: str, request: Request, uow: DBUoW, config: AppConfig = Depends(get_config), provider = Depends(get_provider), _: None = Depends(check_rate_limit)
+    movie_id: str,
+    request: Request,
+    uow: DBUoW,
+    config: AppConfig = Depends(get_config),
+    provider=Depends(get_provider),
+    _: None = Depends(check_rate_limit),
 ):
     """Get cast information for a movie."""
     try:
@@ -79,6 +93,7 @@ async def get_cast(
 
         # Store in cache (even if empty)
         await uow.tmdb_cache.put(movie_id, "cast", json.dumps(cast))
+        await uow.session.commit()
         return {"cast": cast}
     except RuntimeError as e:
         if "item lookup failed" in str(e).lower():
@@ -97,7 +112,7 @@ async def get_cast(
 
 
 @media_router.get("/genres")
-def get_genres(request: Request, provider = Depends(get_provider)):
+def get_genres(request: Request, provider=Depends(get_provider)):
     """Get list of available genres from Jellyfin."""
     try:
         return provider.list_genres()
@@ -111,7 +126,7 @@ def add_to_watchlist(
     user: AuthUser = Depends(require_auth),
     _: None = Depends(check_rate_limit),
     body: dict = None,
-    provider = Depends(get_provider),
+    provider=Depends(get_provider),
 ):
     """Add a movie to the user's watchlist/favorites."""
     try:


### PR DESCRIPTION
## Add explicit commits to auth and media routes

Add explicit `await uow.session.commit()` calls to the 4 route handlers that currently write to the database but rely on `get_db_uow`'s auto-commit to persist those writes.

**What to change in `jellyswipe/routers/auth.py`:**

1. **`jellyfin_use_server_identity`** — add commit after `create_session`:
   ```python
   await create_session(token, uid, request.session, uow)
   await uow.session.commit()
   return {"userId": uid}
   ```

2. **`logout`** — add commit after `destroy_session`:
   ```python
   await destroy_session(request.session, uow)
   await uow.session.commit()
   response.delete_cookie("session", path="/")
   return {"status": "logged_out"}
   ```

**What to change in `jellyswipe/routers/media.py`:**

3. **`get_trailer`** — add commit after each `tmdb_cache.put` call (2 sites):

   Site 1 (cache miss with result, ~line 49):
   ```python
   await uow.tmdb_cache.put(movie_id, "trailer", json.dumps(result))
   await uow.session.commit()
   return result
   ```

   Site 2 (cache miss, no trailer found, ~line 53):
   ```python
   await uow.tmdb_cache.put(movie_id, "trailer", json.dumps({}))
   await uow.session.commit()
   return make_error_response("Not found", 404, request)
   ```

4. **`get_cast`** — add commit after `tmdb_cache.put` call (1 site, ~line 81):
   ```python
   await uow.tmdb_cache.put(movie_id, "cast", json.dumps(cast))
   await uow.session.commit()
   return {"cast": cast}
   ```

**Why no `commit_and_wake`:** These routes have no SSE subscribers to notify. They use direct commit only.

**Expected files:**
- `jellyswipe/routers/auth.py` (modify — add 2 lines)
- `jellyswipe/routers/media.py` (modify — add 3 lines)

**No behavior change:** Auto-commit in `get_db_uow` still fires as a harmless no-op.


### Acceptance Criteria

1. `jellyfin_use_server_identity` in `auth.py` has `await uow.session.commit()` after `create_session(...)` and before `return {"userId": uid}`
2. `logout` in `auth.py` has `await uow.session.commit()` after `destroy_session(...)` and before `response.delete_cookie(...)`
3. `get_trailer` in `media.py` has `await uow.session.commit()` after each `uow.tmdb_cache.put(...)` call (2 sites: line ~49 and line ~53)
4. `get_cast` in `media.py` has `await uow.session.commit()` after `uow.tmdb_cache.put(...)` call (1 site: line ~81)
5. All existing auth and media tests pass unchanged
6. No behavior change — auto-commit in `get_db_uow` still fires as harmless duplicate no-op


---
Ticket: `ORCH-036`