### PR TITLE
feat(ORCH-037): Remove auto-commit from get_db_uow and add uncommitted-writes warning

### DIFF
--- a/jellyswipe/dependencies.py
+++ b/jellyswipe/dependencies.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Annotated, Optional
 
 from fastapi import Depends, HTTPException, Request
 
+import logging
 import threading
 
 import jellyswipe.auth as auth
@@ -23,6 +24,8 @@ from jellyswipe.rate_limiter import rate_limiter
 if TYPE_CHECKING:
     from jellyswipe.jellyfin_library import JellyfinLibraryProvider
 
+_logger = logging.getLogger(__name__)
+
 _provider_lock = threading.Lock()
 _provider_singleton: Optional["JellyfinLibraryProvider"] = None
 
@@ -30,20 +33,29 @@ _provider_singleton: Optional["JellyfinLibraryProvider"] = None
 @dataclass
 class AuthUser:
     """Authenticated user data for FastAPI dependency injection."""
+
     jf_token: str
     user_id: str
 
 
 async def get_db_uow():
-    """Yield a request-scoped async unit of work."""
+    """Yield a request-scoped async unit of work.
+
+    The caller owns commit. This dependency owns session lifecycle
+    (open, rollback-on-error, close) but NOT commit.
+    """
     session = get_sessionmaker()()
     try:
         yield DatabaseUnitOfWork(session)
-        await session.commit()
     except Exception:
         await session.rollback()
         raise
     finally:
+        if session.dirty or session.new or session.deleted:
+            _logger.warning(
+                "UoW session closed with uncommitted dirty/new/deleted "
+                "objects — writes were silently lost. Did you forget to commit?"
+            )
         await session.close()
 
 
@@ -51,10 +63,10 @@ DBUoW = Annotated[DatabaseUnitOfWork, Depends(get_db_uow, scope="function")]
 
 
 _RATE_LIMITS = {
-    'get-trailer': 200,
-    'cast': 200,
-    'watchlist/add': 300,
-    'proxy': 200,
+    "get-trailer": 200,
+    "cast": 200,
+    "watchlist/add": 300,
+    "proxy": 200,
 }
 
 
@@ -123,6 +135,7 @@ async def get_provider(config: AppConfig = Depends(get_config)):
     with _provider_lock:
         if _provider_singleton is None:
             from jellyswipe.jellyfin_library import JellyfinLibraryProvider
+
             _provider_singleton = JellyfinLibraryProvider(config.jellyfin_url)
 
     return _provider_singleton

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -13,7 +13,12 @@ from starlette.middleware.sessions import SessionMiddleware
 
 import jellyswipe.dependencies as deps
 from jellyswipe.auth_types import AuthRecord
-from jellyswipe.db_runtime import build_async_sqlite_url, dispose_runtime, get_sessionmaker, initialize_runtime
+from jellyswipe.db_runtime import (
+    build_async_sqlite_url,
+    dispose_runtime,
+    get_sessionmaker,
+    initialize_runtime,
+)
 from jellyswipe.db_uow import DatabaseUnitOfWork
 from jellyswipe.dependencies import (
     AuthUser,
@@ -74,6 +79,19 @@ def _instrument_session(session):
     session.rollback = rollback
     session.close = close
     return counts
+
+
+class _DirtySessionWrapper:
+    """Wraps a session to force dirty/new/deleted to truthy values."""
+
+    def __init__(self, session):
+        self._session = session
+        self.dirty = True
+        self.new = True
+        self.deleted = True
+
+    def __getattr__(self, name):
+        return getattr(self._session, name)
 
 
 def _begin_immediate_insert(sync_session, value: str) -> None:
@@ -162,10 +180,44 @@ class TestRequireAuth:
 class TestGetDbUow:
     """Tests for get_db_uow() dependency."""
 
-    async def test_yields_uow_and_commits_on_success(
-        self, runtime_sessionmaker, monkeypatch
-    ):
-        """Successful downstream work commits once and closes the session."""
+    async def test_no_auto_commit(self, runtime_sessionmaker, monkeypatch):
+        """No auto-commit on success — dirty session triggers warning, data not persisted."""
+        session = runtime_sessionmaker()
+        counts = _instrument_session(session)
+        dirty_session = _DirtySessionWrapper(session)
+        monkeypatch.setattr(deps, "get_sessionmaker", lambda: lambda: dirty_session)
+
+        generator = get_db_uow()
+        uow = await generator.__anext__()
+
+        assert isinstance(uow, DatabaseUnitOfWork)
+
+        await uow.run_sync(_begin_immediate_insert, "uncommitted")
+
+        with patch.object(deps._logger, "warning") as mock_warning:
+            with pytest.raises(StopAsyncIteration):
+                await generator.__anext__()
+            mock_warning.assert_called_once()
+            assert "uncommitted dirty/new/deleted" in mock_warning.call_args[0][0]
+
+        assert counts["commit"] == 0
+        assert counts["close"] == 1
+
+        # Data NOT persisted
+        async with runtime_sessionmaker() as verify_session:
+            rows = (
+                (
+                    await verify_session.execute(
+                        text("SELECT value FROM bridge_rows ORDER BY id")
+                    )
+                )
+                .scalars()
+                .all()
+            )
+        assert rows == []
+
+    async def test_explicit_commit_persists(self, runtime_sessionmaker, monkeypatch):
+        """Explicit commit persists data and no warning is logged."""
         session = runtime_sessionmaker()
         counts = _instrument_session(session)
         monkeypatch.setattr(deps, "get_sessionmaker", lambda: lambda: session)
@@ -173,15 +225,18 @@ class TestGetDbUow:
         generator = get_db_uow()
         uow = await generator.__anext__()
 
-        assert isinstance(uow, DatabaseUnitOfWork)
-
         await uow.run_sync(_begin_immediate_insert, "committed")
+        await uow.session.commit()
 
-        with pytest.raises(StopAsyncIteration):
-            await generator.__anext__()
+        with patch.object(deps._logger, "warning") as mock_warning:
+            with pytest.raises(StopAsyncIteration):
+                await generator.__anext__()
+            mock_warning.assert_not_called()
 
-        assert counts == {"commit": 1, "rollback": 0, "close": 1}
+        assert counts["commit"] == 1
+        assert counts["close"] == 1
 
+        # Data IS persisted
         async with runtime_sessionmaker() as verify_session:
             rows = (
                 (
@@ -194,9 +249,7 @@ class TestGetDbUow:
             )
         assert rows == ["committed"]
 
-    async def test_rolls_back_on_error_after_begin_immediate_bridge(
-        self, runtime_sessionmaker, monkeypatch
-    ):
+    async def test_rollback_on_error_preserved(self, runtime_sessionmaker, monkeypatch):
         """A downstream failure rolls back once after BEGIN IMMEDIATE bridge work."""
         session = runtime_sessionmaker()
         counts = _instrument_session(session)
@@ -222,6 +275,46 @@ class TestGetDbUow:
                 .all()
             )
         assert rows == []
+
+    async def test_warning_on_uncommitted_dirty(
+        self, runtime_sessionmaker, monkeypatch
+    ):
+        """Dirty session without commit logs a warning about uncommitted writes."""
+        session = runtime_sessionmaker()
+        counts = _instrument_session(session)
+        dirty_session = _DirtySessionWrapper(session)
+        monkeypatch.setattr(deps, "get_sessionmaker", lambda: lambda: dirty_session)
+
+        generator = get_db_uow()
+        uow = await generator.__anext__()
+
+        await uow.run_sync(_begin_immediate_insert, "dirty")
+
+        with patch.object(deps._logger, "warning") as mock_warning:
+            with pytest.raises(StopAsyncIteration):
+                await generator.__anext__()
+            mock_warning.assert_called_once()
+            assert "uncommitted dirty/new/deleted" in mock_warning.call_args[0][0]
+
+        assert counts["commit"] == 0
+
+    async def test_no_warning_on_clean_exit(self, runtime_sessionmaker, monkeypatch):
+        """Clean session (no writes) exits without warning."""
+        session = runtime_sessionmaker()
+        counts = _instrument_session(session)
+        monkeypatch.setattr(deps, "get_sessionmaker", lambda: lambda: session)
+
+        generator = get_db_uow()
+        await generator.__anext__()
+
+        # No writes — just yield and close
+        with patch.object(deps._logger, "warning") as mock_warning:
+            with pytest.raises(StopAsyncIteration):
+                await generator.__anext__()
+            mock_warning.assert_not_called()
+
+        assert counts["commit"] == 0
+        assert counts["close"] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -346,6 +439,7 @@ class TestGetProvider:
             "jellyswipe.jellyfin_library.JellyfinLibraryProvider",
             return_value=mock_instance,
         ):
+
             class MockConfig:
                 jellyfin_url = "http://test"
 


### PR DESCRIPTION
## Remove auto-commit from get_db_uow and add uncommitted-writes warning

Remove the auto-commit from `get_db_uow` and add a runtime warning when a session closes with uncommitted writes.

**What to change in `jellyswipe/dependencies.py`:**

1. Add module-level logger:
   ```python
   _logger = logging.getLogger(__name__)
   ```
   (Add `import logging` at top if not already present — currently not imported.)

2. Replace `get_db_uow` (lines 37-47) with:
   ```python
   async def get_db_uow():
       """Yield a request-scoped async unit of work.
       
       The caller owns commit. This dependency owns session lifecycle
       (open, rollback-on-error, close) but NOT commit.
       """
       session = get_sessionmaker()()
       try:
           yield DatabaseUnitOfWork(session)
       except Exception:
           await session.rollback()
           raise
       finally:
           if session.dirty or session.new or session.deleted:
               _logger.warning(
                   "UoW session closed with uncommitted dirty/new/deleted "
                   "objects — writes were silently lost. Did you forget to commit?"
               )
           await session.close()
   ```

**Expected files:**
- `jellyswipe/dependencies.py` (modify — rewrite `get_db_uow`, add `import logging`, add `_logger`)
- `tests/test_dependencies.py` (modify — rewrite `TestGetDbUow` class)

**Context:** This is the behavioral change that makes the dependency honest. Only safe after ORCH-035 and ORCH-036 ensure every mutating route explicitly commits.


### Acceptance Criteria

1. `get_db_uow` in `jellyswipe/dependencies.py` no longer auto-commits — the `try` block only yields the UoW, no `await session.commit()` call
2. Rollback-on-error is preserved — `except Exception` block still calls `await session.rollback()`
3. Warning logged via `_logger.warning(...)` when session closes with `session.dirty or session.new or session.deleted`
4. Warning message: `"UoW session closed with uncommitted dirty/new/deleted objects — writes were silently lost. Did you forget to commit?"`
5. No warning when session closes clean (no dirty, new, or deleted objects)
6. `_logger = logging.getLogger(__name__)` added at module level in `dependencies.py`
7. All existing route tests pass (every mutating route now owns its commit from ORCH-035 and ORCH-036)
8. `__all__` export list unchanged


---
Ticket: `ORCH-037`