### PR TITLE
refactor: Transaction Ownership

### DIFF
--- a/jellyswipe/dependencies.py
+++ b/jellyswipe/dependencies.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Annotated, Optional
 
 from fastapi import Depends, HTTPException, Request
 
+import logging
 import threading
 
 import jellyswipe.auth as auth
@@ -23,6 +24,8 @@ from jellyswipe.rate_limiter import rate_limiter
 if TYPE_CHECKING:
     from jellyswipe.jellyfin_library import JellyfinLibraryProvider
 
+_logger = logging.getLogger(__name__)
+
 _provider_lock = threading.Lock()
 _provider_singleton: Optional["JellyfinLibraryProvider"] = None
 
@@ -30,20 +33,29 @@ _provider_singleton: Optional["JellyfinLibraryProvider"] = None
 @dataclass
 class AuthUser:
     """Authenticated user data for FastAPI dependency injection."""
+
     jf_token: str
     user_id: str
 
 
 async def get_db_uow():
-    """Yield a request-scoped async unit of work."""
+    """Yield a request-scoped async unit of work.
+
+    The caller owns commit. This dependency owns session lifecycle
+    (open, rollback-on-error, close) but NOT commit.
+    """
     session = get_sessionmaker()()
     try:
         yield DatabaseUnitOfWork(session)
-        await session.commit()
     except Exception:
         await session.rollback()
         raise
     finally:
+        if session.dirty or session.new or session.deleted:
+            _logger.warning(
+                "UoW session closed with uncommitted dirty/new/deleted "
+                "objects — writes were silently lost. Did you forget to commit?"
+            )
         await session.close()
 
 
@@ -51,10 +63,10 @@ DBUoW = Annotated[DatabaseUnitOfWork, Depends(get_db_uow, scope="function")]
 
 
 _RATE_LIMITS = {
-    'get-trailer': 200,
-    'cast': 200,
-    'watchlist/add': 300,
-    'proxy': 200,
+    "get-trailer": 200,
+    "cast": 200,
+    "watchlist/add": 300,
+    "proxy": 200,
 }
 
 
@@ -123,6 +135,7 @@ async def get_provider(config: AppConfig = Depends(get_config)):
     with _provider_lock:
         if _provider_singleton is None:
             from jellyswipe.jellyfin_library import JellyfinLibraryProvider
+
             _provider_singleton = JellyfinLibraryProvider(config.jellyfin_url)
 
     return _provider_singleton

--- a/jellyswipe/routers/_helpers.py
+++ b/jellyswipe/routers/_helpers.py
@@ -6,6 +6,8 @@ import traceback
 from fastapi import Request
 
 from jellyswipe import XSSSafeJSONResponse
+from jellyswipe.db_uow import DatabaseUnitOfWork
+from jellyswipe.notifier import notifier
 
 _logger = logging.getLogger(__name__)
 
@@ -42,3 +44,13 @@ def log_exception(
         log_data.update(context)
     target_logger = logger or _logger
     target_logger.error("unhandled_exception", extra=log_data)
+
+
+async def commit_and_wake(uow: DatabaseUnitOfWork, code: str) -> None:
+    """Commit the UoW transaction, then wake SSE subscribers for the room.
+
+    Must be called AFTER all database writes are complete.
+    Commit happens before notify to ensure subscribers read committed data.
+    """
+    await uow.session.commit()
+    notifier.notify(code)

--- a/jellyswipe/routers/auth.py
+++ b/jellyswipe/routers/auth.py
@@ -25,7 +25,9 @@ auth_router = APIRouter()
 
 
 @auth_router.post("/auth/jellyfin-use-server-identity")
-async def jellyfin_use_server_identity(request: Request, uow: DBUoW, provider = Depends(get_provider)):
+async def jellyfin_use_server_identity(
+    request: Request, uow: DBUoW, provider=Depends(get_provider)
+):
     """Authenticate using Jellyfin server delegate identity."""
     try:
         token = provider.server_access_token_for_delegate()
@@ -33,6 +35,7 @@ async def jellyfin_use_server_identity(request: Request, uow: DBUoW, provider = 
     except RuntimeError:
         return make_error_response("Jellyfin delegate unavailable", 401, request)
     await create_session(token, uid, request.session, uow)
+    await uow.session.commit()
     return {"userId": uid}
 
 
@@ -45,12 +48,18 @@ async def logout(
 ):
     """Destroy the current user session."""
     await destroy_session(request.session, uow)
+    await uow.session.commit()
     response.delete_cookie("session", path="/")
     return {"status": "logged_out"}
 
 
 @auth_router.get("/me")
-async def get_me(request: Request, uow: DBUoW, user: AuthUser = Depends(require_auth), provider = Depends(get_provider)):
+async def get_me(
+    request: Request,
+    uow: DBUoW,
+    user: AuthUser = Depends(require_auth),
+    provider=Depends(get_provider),
+):
     """Return current user information."""
     active_room = await resolve_active_room(request.session, uow)
     info = provider.server_info()
@@ -64,7 +73,7 @@ async def get_me(request: Request, uow: DBUoW, user: AuthUser = Depends(require_
 
 
 @auth_router.get("/jellyfin/server-info")
-def jellyfin_server_info(request: Request, provider = Depends(get_provider)):
+def jellyfin_server_info(request: Request, provider=Depends(get_provider)):
     """Return Jellyfin server information."""
     try:
         info = provider.server_info()

--- a/jellyswipe/routers/media.py
+++ b/jellyswipe/routers/media.py
@@ -28,7 +28,12 @@ media_router = APIRouter()
 
 @media_router.get("/get-trailer/{movie_id}")
 async def get_trailer(
-    movie_id: str, request: Request, uow: DBUoW, config: AppConfig = Depends(get_config), provider = Depends(get_provider), _: None = Depends(check_rate_limit)
+    movie_id: str,
+    request: Request,
+    uow: DBUoW,
+    config: AppConfig = Depends(get_config),
+    provider=Depends(get_provider),
+    _: None = Depends(check_rate_limit),
 ):
     """Get YouTube trailer key for a movie."""
     try:
@@ -42,15 +47,19 @@ async def get_trailer(
 
         # Cache miss — resolve item and call TMDB
         item = provider.resolve_item_for_tmdb(movie_id)
-        youtube_key = lookup_trailer(item.title, item.year, api_token=config.tmdb_access_token)
+        youtube_key = lookup_trailer(
+            item.title, item.year, api_token=config.tmdb_access_token
+        )
 
         if youtube_key:
             result = {"youtube_key": youtube_key}
             await uow.tmdb_cache.put(movie_id, "trailer", json.dumps(result))
+            await uow.session.commit()
             return result
 
         # No trailer found — cache the miss to avoid repeated lookups
         await uow.tmdb_cache.put(movie_id, "trailer", json.dumps({}))
+        await uow.session.commit()
         return make_error_response("Not found", 404, request)
     except RuntimeError as e:
         if "item lookup failed" in str(e).lower():
@@ -64,7 +73,12 @@ async def get_trailer(
 
 @media_router.get("/cast/{movie_id}")
 async def get_cast(
-    movie_id: str, request: Request, uow: DBUoW, config: AppConfig = Depends(get_config), provider = Depends(get_provider), _: None = Depends(check_rate_limit)
+    movie_id: str,
+    request: Request,
+    uow: DBUoW,
+    config: AppConfig = Depends(get_config),
+    provider=Depends(get_provider),
+    _: None = Depends(check_rate_limit),
 ):
     """Get cast information for a movie."""
     try:
@@ -79,6 +93,7 @@ async def get_cast(
 
         # Store in cache (even if empty)
         await uow.tmdb_cache.put(movie_id, "cast", json.dumps(cast))
+        await uow.session.commit()
         return {"cast": cast}
     except RuntimeError as e:
         if "item lookup failed" in str(e).lower():
@@ -97,7 +112,7 @@ async def get_cast(
 
 
 @media_router.get("/genres")
-def get_genres(request: Request, provider = Depends(get_provider)):
+def get_genres(request: Request, provider=Depends(get_provider)):
     """Get list of available genres from Jellyfin."""
     try:
         return provider.list_genres()
@@ -111,7 +126,7 @@ def add_to_watchlist(
     user: AuthUser = Depends(require_auth),
     _: None = Depends(check_rate_limit),
     body: dict = None,
-    provider = Depends(get_provider),
+    provider=Depends(get_provider),
 ):
     """Add a movie to the user's watchlist/favorites."""
     try:

--- a/jellyswipe/routers/rooms.py
+++ b/jellyswipe/routers/rooms.py
@@ -36,7 +36,9 @@ from jellyswipe.services.session_match_mutation import (
     UndoChanged,
 )
 
-from jellyswipe.routers._helpers import make_error_response, log_exception  # noqa: F401
+from jellyswipe.routers._helpers import (
+    commit_and_wake,
+)  # noqa: F401
 
 rooms_router = APIRouter()
 
@@ -53,7 +55,10 @@ session_match_mutation = SessionMatchMutation()
 
 @rooms_router.post("/room")
 async def create_room(
-    request: Request, uow: DBUoW, user: AuthUser = Depends(require_auth), provider = Depends(get_provider)
+    request: Request,
+    uow: DBUoW,
+    user: AuthUser = Depends(require_auth),
+    provider=Depends(get_provider),
 ):
     """Create a new room with setup choices.
 
@@ -148,14 +153,18 @@ async def join_room_route(
     if payload is None:
         return XSSSafeJSONResponse(content={"error": "Invalid Code"}, status_code=404)
     # Commit before notifying to ensure events are persisted
-    await uow.session.commit()
-    notifier.notify(code)
+    await commit_and_wake(uow, code)
     return payload
 
 
 @rooms_router.post("/room/{code}/swipe")
 async def swipe(
-    code: str, request: Request, uow: DBUoW, user: AuthUser = Depends(require_auth), config: AppConfig = Depends(get_config), provider = Depends(get_provider)
+    code: str,
+    request: Request,
+    uow: DBUoW,
+    user: AuthUser = Depends(require_auth),
+    config: AppConfig = Depends(get_config),
+    provider=Depends(get_provider),
 ):
     """Swipe on a movie with BEGIN IMMEDIATE transaction.
 
@@ -200,8 +209,7 @@ async def swipe(
     if isinstance(result, SwipeRejected):
         return XSSSafeJSONResponse(content={"error": result.reason}, status_code=404)
     # SwipeAccepted — commit and notify
-    await uow.session.commit()
-    notifier.notify(code)
+    await commit_and_wake(uow, code)
     return {"accepted": True}
 
 
@@ -224,8 +232,7 @@ async def quit_room(
         code, request.session, user.user_id, uow
     )
     # Commit before notifying to ensure events are persisted
-    await uow.session.commit()
-    notifier.notify(code)
+    await commit_and_wake(uow, code)
     return result
 
 
@@ -282,8 +289,7 @@ async def undo_swipe(
         uow=uow,
     )
     if isinstance(result, UndoChanged):
-        await uow.session.commit()
-        notifier.notify(code)
+        await commit_and_wake(uow, code)
     return {"status": "undone"}
 
 
@@ -303,7 +309,11 @@ async def get_deck(
 
 @rooms_router.post("/room/{code}/genre")
 async def set_genre(
-    code: str, request: Request, uow: DBUoW, user: AuthUser = Depends(require_auth), provider = Depends(get_provider)
+    code: str,
+    request: Request,
+    uow: DBUoW,
+    user: AuthUser = Depends(require_auth),
+    provider=Depends(get_provider),
 ):
     """Set the genre filter for the room and reload the deck."""
     try:
@@ -314,12 +324,9 @@ async def set_genre(
     if not genre:
         return XSSSafeJSONResponse(content={"error": "Genre required"}, status_code=400)
     try:
-        new_list = await room_lifecycle_service.set_genre(
-            code, genre, provider, uow
-        )
+        new_list = await room_lifecycle_service.set_genre(code, genre, provider, uow)
         # Commit before notifying to ensure events are persisted
-        await uow.session.commit()
-        notifier.notify(code)
+        await commit_and_wake(uow, code)
         return new_list
     except EmptyDeckError as e:
         return XSSSafeJSONResponse(content={"error": str(e)}, status_code=400)
@@ -327,7 +334,11 @@ async def set_genre(
 
 @rooms_router.post("/room/{code}/watched-filter")
 async def set_watched_filter_route(
-    code: str, request: Request, uow: DBUoW, user: AuthUser = Depends(require_auth), provider = Depends(get_provider)
+    code: str,
+    request: Request,
+    uow: DBUoW,
+    user: AuthUser = Depends(require_auth),
+    provider=Depends(get_provider),
 ):
     """Set the watched filter for the room and reload the deck."""
     try:
@@ -348,8 +359,7 @@ async def set_watched_filter_route(
             code, hide_watched, provider, uow
         )
         # Commit before notifying to ensure events are persisted
-        await uow.session.commit()
-        notifier.notify(code)
+        await commit_and_wake(uow, code)
         return result
     except EmptyDeckError:
         return XSSSafeJSONResponse(

--- a/tests/test_commit_and_wake.py
+++ b/tests/test_commit_and_wake.py
@@ -1,0 +1,44 @@
+"""Tests for commit_and_wake helper."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from jellyswipe.routers._helpers import commit_and_wake
+
+
+@pytest.mark.anyio
+async def test_commit_and_wake_commits_then_notifies():
+    """commit_and_wake calls uow.session.commit() then notifier.notify(code)."""
+    uow = MagicMock()
+    uow.session.commit = AsyncMock()
+
+    call_order = []
+
+    async def track_commit():
+        call_order.append("commit")
+
+    def track_notify(code):
+        call_order.append("notify")
+
+    uow.session.commit.side_effect = track_commit
+
+    with patch("jellyswipe.routers._helpers.notifier") as mock_notifier:
+        mock_notifier.notify.side_effect = track_notify
+        await commit_and_wake(uow, "ABCD")
+
+    assert call_order == ["commit", "notify"]
+    mock_notifier.notify.assert_called_once_with("ABCD")
+
+
+@pytest.mark.anyio
+async def test_commit_and_wake_propagates_commit_error():
+    """If commit raises, the error propagates and notifier.notify is NOT called."""
+    uow = MagicMock()
+    uow.session.commit = AsyncMock(side_effect=RuntimeError("db error"))
+
+    with patch("jellyswipe.routers._helpers.notifier") as mock_notifier:
+        with pytest.raises(RuntimeError, match="db error"):
+            await commit_and_wake(uow, "WXYZ")
+
+    mock_notifier.notify.assert_not_called()

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -13,7 +13,12 @@ from starlette.middleware.sessions import SessionMiddleware
 
 import jellyswipe.dependencies as deps
 from jellyswipe.auth_types import AuthRecord
-from jellyswipe.db_runtime import build_async_sqlite_url, dispose_runtime, get_sessionmaker, initialize_runtime
+from jellyswipe.db_runtime import (
+    build_async_sqlite_url,
+    dispose_runtime,
+    get_sessionmaker,
+    initialize_runtime,
+)
 from jellyswipe.db_uow import DatabaseUnitOfWork
 from jellyswipe.dependencies import (
     AuthUser,
@@ -74,6 +79,19 @@ def _instrument_session(session):
     session.rollback = rollback
     session.close = close
     return counts
+
+
+class _DirtySessionWrapper:
+    """Wraps a session to force dirty/new/deleted to truthy values."""
+
+    def __init__(self, session):
+        self._session = session
+        self.dirty = True
+        self.new = True
+        self.deleted = True
+
+    def __getattr__(self, name):
+        return getattr(self._session, name)
 
 
 def _begin_immediate_insert(sync_session, value: str) -> None:
@@ -162,10 +180,44 @@ class TestRequireAuth:
 class TestGetDbUow:
     """Tests for get_db_uow() dependency."""
 
-    async def test_yields_uow_and_commits_on_success(
-        self, runtime_sessionmaker, monkeypatch
-    ):
-        """Successful downstream work commits once and closes the session."""
+    async def test_no_auto_commit(self, runtime_sessionmaker, monkeypatch):
+        """No auto-commit on success — dirty session triggers warning, data not persisted."""
+        session = runtime_sessionmaker()
+        counts = _instrument_session(session)
+        dirty_session = _DirtySessionWrapper(session)
+        monkeypatch.setattr(deps, "get_sessionmaker", lambda: lambda: dirty_session)
+
+        generator = get_db_uow()
+        uow = await generator.__anext__()
+
+        assert isinstance(uow, DatabaseUnitOfWork)
+
+        await uow.run_sync(_begin_immediate_insert, "uncommitted")
+
+        with patch.object(deps._logger, "warning") as mock_warning:
+            with pytest.raises(StopAsyncIteration):
+                await generator.__anext__()
+            mock_warning.assert_called_once()
+            assert "uncommitted dirty/new/deleted" in mock_warning.call_args[0][0]
+
+        assert counts["commit"] == 0
+        assert counts["close"] == 1
+
+        # Data NOT persisted
+        async with runtime_sessionmaker() as verify_session:
+            rows = (
+                (
+                    await verify_session.execute(
+                        text("SELECT value FROM bridge_rows ORDER BY id")
+                    )
+                )
+                .scalars()
+                .all()
+            )
+        assert rows == []
+
+    async def test_explicit_commit_persists(self, runtime_sessionmaker, monkeypatch):
+        """Explicit commit persists data and no warning is logged."""
         session = runtime_sessionmaker()
         counts = _instrument_session(session)
         monkeypatch.setattr(deps, "get_sessionmaker", lambda: lambda: session)
@@ -173,15 +225,18 @@ class TestGetDbUow:
         generator = get_db_uow()
         uow = await generator.__anext__()
 
-        assert isinstance(uow, DatabaseUnitOfWork)
-
         await uow.run_sync(_begin_immediate_insert, "committed")
+        await uow.session.commit()
 
-        with pytest.raises(StopAsyncIteration):
-            await generator.__anext__()
+        with patch.object(deps._logger, "warning") as mock_warning:
+            with pytest.raises(StopAsyncIteration):
+                await generator.__anext__()
+            mock_warning.assert_not_called()
 
-        assert counts == {"commit": 1, "rollback": 0, "close": 1}
+        assert counts["commit"] == 1
+        assert counts["close"] == 1
 
+        # Data IS persisted
         async with runtime_sessionmaker() as verify_session:
             rows = (
                 (
@@ -194,9 +249,7 @@ class TestGetDbUow:
             )
         assert rows == ["committed"]
 
-    async def test_rolls_back_on_error_after_begin_immediate_bridge(
-        self, runtime_sessionmaker, monkeypatch
-    ):
+    async def test_rollback_on_error_preserved(self, runtime_sessionmaker, monkeypatch):
         """A downstream failure rolls back once after BEGIN IMMEDIATE bridge work."""
         session = runtime_sessionmaker()
         counts = _instrument_session(session)
@@ -222,6 +275,46 @@ class TestGetDbUow:
                 .all()
             )
         assert rows == []
+
+    async def test_warning_on_uncommitted_dirty(
+        self, runtime_sessionmaker, monkeypatch
+    ):
+        """Dirty session without commit logs a warning about uncommitted writes."""
+        session = runtime_sessionmaker()
+        counts = _instrument_session(session)
+        dirty_session = _DirtySessionWrapper(session)
+        monkeypatch.setattr(deps, "get_sessionmaker", lambda: lambda: dirty_session)
+
+        generator = get_db_uow()
+        uow = await generator.__anext__()
+
+        await uow.run_sync(_begin_immediate_insert, "dirty")
+
+        with patch.object(deps._logger, "warning") as mock_warning:
+            with pytest.raises(StopAsyncIteration):
+                await generator.__anext__()
+            mock_warning.assert_called_once()
+            assert "uncommitted dirty/new/deleted" in mock_warning.call_args[0][0]
+
+        assert counts["commit"] == 0
+
+    async def test_no_warning_on_clean_exit(self, runtime_sessionmaker, monkeypatch):
+        """Clean session (no writes) exits without warning."""
+        session = runtime_sessionmaker()
+        counts = _instrument_session(session)
+        monkeypatch.setattr(deps, "get_sessionmaker", lambda: lambda: session)
+
+        generator = get_db_uow()
+        await generator.__anext__()
+
+        # No writes — just yield and close
+        with patch.object(deps._logger, "warning") as mock_warning:
+            with pytest.raises(StopAsyncIteration):
+                await generator.__anext__()
+            mock_warning.assert_not_called()
+
+        assert counts["commit"] == 0
+        assert counts["close"] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -346,6 +439,7 @@ class TestGetProvider:
             "jellyswipe.jellyfin_library.JellyfinLibraryProvider",
             return_value=mock_instance,
         ):
+
             class MockConfig:
                 jellyfin_url = "http://test"
 

--- a/uv.lock
+++ b/uv.lock
@@ -273,7 +273,7 @@ wheels = [
 
 [[package]]
 name = "jellyswipe"
-version = "0.3.2"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Problem Statement

The get_db_uow FastAPI dependency claims to own the transaction lifecycle — it auto-commits on clean exit and rolls back on exception. But every mutating room route in rooms.py calls await uow.session.commit() explicitly before notifier.notify(code), because SSE subscribers must read committed data. The dependency's auto-commit is a silent second commit that does nothing on the happy path.

This creates two concrete problems:

- The transaction seam is dishonest. The dependency's interface says "I own commit/rollback," but the rooms router actually owns commit. If a developer writes a new mutating route and trusts the dependency to commit, the commit fires after the response returns — and after any notifier.notify() call, causing a race where SSE subscribers read stale data.
- The commit-then-notify pattern is copy-pasted across 6 route handlers. join, swipe, quit, undo, genre, and watched-filter all duplicate the same two-line sequence: await uow.session.commit() / notifier.notify(code). The invariant — "commit must happen before notify" — is enforced only by convention.

## Solution

Two changes:

- Make get_db_uow honest. Remove auto-commit. The dependency owns session lifecycle (open, rollback-on-error, close) but not commit. Add a warning log when a session with uncommitted dirty/new objects reaches finally without an explicit commit, so forgotten commits surface at runtime rather than silently losing data.
- Extract a commit_and_wake helper. A free function in jellyswipe/routers/_helpers.py that composes uow.session.commit() and notifier.notify(code) into a single call. The 6 commit-then-notify sites in rooms.py use the helper. The 4 commit-only sites (create_room, delete_match, and the 2 auth routes) continue calling await uow.session.commit() directly.

Closes https://github.com/andrewthetechie/jelly-swipe/issues/117