### PR TITLE
feat(ORCH-040): Inline auth resolution into `require_auth` and delete `destroy_session_dep`

### DIFF
--- a/jellyswipe/dependencies.py
+++ b/jellyswipe/dependencies.py
@@ -1,7 +1,7 @@
 """FastAPI dependency injection layer — Phase 32.
 
 Exports AuthUser dataclass and Depends()-compatible callables for:
-- Authentication (require_auth, destroy_session_dep)
+- Authentication (require_auth)
 - Database access (get_db_uow, DBUoW)
 - Rate limiting (check_rate_limit)
 - Jellyfin provider singleton (get_provider)
@@ -15,7 +15,6 @@ from fastapi import Depends, HTTPException, Request
 import logging
 import threading
 
-import jellyswipe.auth as auth
 from jellyswipe.config import AppConfig, get_config
 from jellyswipe.db_runtime import get_sessionmaker
 from jellyswipe.db_uow import DatabaseUnitOfWork
@@ -107,23 +106,19 @@ def check_rate_limit(request: Request) -> None:
 async def require_auth(request: Request, uow: DBUoW) -> AuthUser:
     """FastAPI dependency that requires authentication."""
     prior_session_id = request.session.get("session_id")
-    record = await auth.get_current_token(request.session, uow)
+    record = (
+        await uow.auth_sessions.get_by_session_id(prior_session_id)
+        if prior_session_id
+        else None
+    )
     if record is not None:
         return AuthUser(jf_token=record.jf_token, user_id=record.user_id)
 
     if prior_session_id is not None:
-        auth.clear_session_state(request.session)
+        request.session.clear()
         request.state.clear_session_cookie = True
 
     raise HTTPException(status_code=401, detail="Authentication required")
-
-
-async def destroy_session_dep(request: Request, uow: DBUoW) -> None:
-    """FastAPI dependency that destroys the current session.
-
-    Calls auth.destroy_session(request.session).
-    """
-    await auth.destroy_session(request.session, uow)
 
 
 async def get_provider(config: AppConfig = Depends(get_config)):
@@ -153,6 +148,5 @@ __all__ = [
     "get_db_uow",
     "DBUoW",
     "check_rate_limit",
-    "destroy_session_dep",
     "get_provider",
 ]

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import Depends, FastAPI, HTTPException, Request
@@ -23,7 +23,6 @@ from jellyswipe.db_uow import DatabaseUnitOfWork
 from jellyswipe.dependencies import (
     AuthUser,
     check_rate_limit,
-    destroy_session_dep,
     get_db_uow,
     get_provider,
     require_auth,
@@ -382,30 +381,6 @@ class TestCheckRateLimit:
         client = TestClient(app)
         resp = client.get("/get-trailer/test")
         assert resp.status_code == 200
-
-
-# ---------------------------------------------------------------------------
-# TestDestroySessionDep
-# ---------------------------------------------------------------------------
-
-
-class TestDestroySessionDep:
-    """Tests for destroy_session_dep() dependency."""
-
-    @pytest.mark.anyio
-    async def test_calls_auth_destroy_session(self, runtime_sessionmaker):
-        """destroy_session_dep awaits auth.destroy_session(request.session, uow)."""
-        request = MagicMock(spec=Request)
-        request.session = {"session_id": "destroy-session"}
-
-        async with runtime_sessionmaker() as session:
-            uow = DatabaseUnitOfWork(session)
-            with patch(
-                "jellyswipe.auth.destroy_session", new=AsyncMock()
-            ) as mock_destroy:
-                await destroy_session_dep(request, uow)
-
-        mock_destroy.assert_awaited_once_with(request.session, uow)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Inline auth resolution into `require_auth` and delete `destroy_session_dep`

Inline `get_current_token` and `clear_session_state` into `require_auth`, and delete the dead `destroy_session_dep` dependency. This removes `dependencies.py`'s reliance on `auth.py`, but `auth.py` is NOT deleted yet — `routers/auth.py` still imports from it.

**Context:** `auth.py` is a pass-through layer. `get_current_token(session_dict, uow)` just extracts `session_dict.get("session_id")` and calls `uow.auth_sessions.get_by_session_id(sid)`. `clear_session_state(session_dict)` is literally `session_dict.clear()`. `destroy_session_dep` in `dependencies.py` only forwards to `auth.destroy_session` and is never used as a `Depends()` in any route.

**What to change in `jellyswipe/dependencies.py`:**

1. **Remove import:** Delete `import jellyswipe.auth as auth` (line 18)

2. **Inline into `require_auth` (lines 106-117):** Replace:
   ```python
   # BEFORE:
   prior_session_id = request.session.get("session_id")
   record = await auth.get_current_token(request.session, uow)
   if record is not None:
       return AuthUser(jf_token=record.jf_token, user_id=record.user_id)
   if prior_session_id is not None:
       auth.clear_session_state(request.session)
       request.state.clear_session_cookie = True
   ```
   ```python
   # AFTER:
   prior_session_id = request.session.get("session_id")
   sid = request.session.get("session_id")
   record = await uow.auth_sessions.get_by_session_id(sid) if sid else None
   if record is not None:
       return AuthUser(jf_token=record.jf_token, user_id=record.user_id)
   if prior_session_id is not None:
       request.session.clear()
       request.state.clear_session_cookie = True
   ```
   Note: `prior_session_id` and `sid` are the same value — you can simplify to just use `prior_session_id` for both.

3. **Delete `destroy_session_dep`:** Remove the entire function (lines 120-125) and its `"destroy_session_dep"` entry from `__all__` (line 156). This function was never wired into any route via `Depends()` — it only existed as an exported utility and was tested directly.

4. **Update docstring/module comment** (line 4): Remove `destroy_session_dep` from the listed exports if mentioned.

**What to change in `tests/test_dependencies.py`:**

1. **Delete `TestDestroySessionDep` class** (~line 393-408): The function no longer exists.

2. **Remove from imports** (line 26): Remove `destroy_session_dep` from the import block.

3. **Update mock target:** The existing test at line 404 mocks `"jellyswipe.auth.destroy_session"`. Since that mock target is only in `TestDestroySessionDep` (which is being deleted), no other mock targets should need updating. Verify no other tests in this file mock `"jellyswipe.auth.*"` targets.

**Important:** `auth.py` is NOT deleted in this ticket. `routers/auth.py` still imports `create_session`, `destroy_session`, and `resolve_active_room` from it. This ticket only removes `dependencies.py`'s usage of `auth.py`.

**Expected files:** `jellyswipe/dependencies.py` (modify), `tests/test_dependencies.py` (modify)


### Acceptance Criteria

1. `require_auth` calls `uow.auth_sessions.get_by_session_id(request.session.get("session_id"))` directly instead of `auth.get_current_token(request.session, uow)`
2. `require_auth` calls `request.session.clear()` directly instead of `auth.clear_session_state(request.session)`
3. `import jellyswipe.auth as auth` removed from `dependencies.py`
4. `destroy_session_dep` function (lines 120-125) deleted from `dependencies.py`
5. `"destroy_session_dep"` removed from `__all__` list in `dependencies.py`
6. `TestDestroySessionDep` class deleted from `test_dependencies.py`
7. `destroy_session_dep` removed from the import block in `test_dependencies.py` (line 26)
8. Any mock of `"jellyswipe.auth.destroy_session"` in `test_dependencies.py` updated to mock the underlying `uow.auth_sessions.delete_by_session_id` instead
9. `auth.py` still exists after this ticket — only `dependencies.py` stops using it. `routers/auth.py` still imports `create_session`, `destroy_session`, `resolve_active_room` from it.
10. `grep -rn "jellyswipe.auth" jellyswipe/dependencies.py` returns no hits
11. All existing tests pass (`uv run pytest`)
12. `ruff check .` passes


---
Ticket: `ORCH-040`