### PR TITLE
feat(ORCH-038): Delete duplicate image-path regex from proxy route

### DIFF
--- a/jellyswipe/routers/proxy.py
+++ b/jellyswipe/routers/proxy.py
@@ -1,11 +1,10 @@
 """Image proxy route for Jellyfin artwork.
 
-Per D-06: 1 proxy route with rate limiting and regex path validation.
+Per D-06: 1 proxy route with rate limiting.
 Serves images from Jellyfin server through the app to avoid exposing server secrets.
 """
 
 import logging
-import re
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import Response
@@ -22,16 +21,19 @@ _logger = logging.getLogger(__name__)
 proxy_router = APIRouter()
 
 
-@proxy_router.get('/proxy')
-def proxy(request: Request, config: AppConfig = Depends(get_config), provider = Depends(get_provider), _: None = Depends(check_rate_limit)):
+@proxy_router.get("/proxy")
+def proxy(
+    request: Request,
+    config: AppConfig = Depends(get_config),
+    provider=Depends(get_provider),
+    _: None = Depends(check_rate_limit),
+):
     """Proxy image requests to Jellyfin server with path validation."""
-    path = request.query_params.get('path')
+    path = request.query_params.get("path")
     if not path:
         raise HTTPException(status_code=403)
     if not config.jellyfin_url:
         raise HTTPException(status_code=503)
-    if not re.match(r"^jellyfin/(?:[0-9a-fA-F]{32}|[0-9a-fA-F-]{36})/Primary$", path):
-        raise HTTPException(status_code=403)
     try:
         body, content_type = provider.fetch_library_image(path)
     except PermissionError:
@@ -40,5 +42,7 @@ def proxy(request: Request, config: AppConfig = Depends(get_config), provider = 
         raise HTTPException(status_code=404)
     except requests.exceptions.RequestException as exc:
         _logger.warning("proxy: upstream error fetching %s: %s", path, exc)
-        return XSSSafeJSONResponse(content={"error": "Upstream server error"}, status_code=502)
+        return XSSSafeJSONResponse(
+            content={"error": "Upstream server error"}, status_code=502
+        )
     return Response(content=body, media_type=content_type)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import json
 import os
+import re
 import sqlite3
 from base64 import b64encode
 from unittest.mock import MagicMock, patch
@@ -272,6 +273,11 @@ class FakeProvider:
         )
 
     def fetch_library_image(self, path):
+        _JF_IMAGE_PATH = re.compile(
+            r"^jellyfin/([0-9a-fA-F]{32}|[0-9a-fA-F-]{36})/Primary$"
+        )
+        if not _JF_IMAGE_PATH.match(path):
+            raise PermissionError("Invalid Jellyfin image path")
         return (b"", "image/jpeg")
 
 


### PR DESCRIPTION
## Delete duplicate image-path regex from proxy route

Remove the duplicate image-path validation regex from the proxy route handler. The proxy router (`jellyswipe/routers/proxy.py`) and the Jellyfin provider (`jellyswipe/jellyfin_library.py`) both validate Jellyfin image paths with nearly identical regexes (differing only in capture vs. non-capture group). The provider's `_JF_IMAGE_PATH` regex inside `fetch_library_image` is the single validation point; the router's duplicate regex guard should be deleted.

**What to change in `jellyswipe/routers/proxy.py`:**

1. Delete the `re.match(...)` guard (~line 33):
   ```python
   if not re.match(r"^jellyfin/(?:[0-9a-fA-F]{32}|[0-9a-fA-F-]{36})/Primary$", path):
       raise HTTPException(status_code=403)
   ```

2. Remove `import re` (line 8) — no longer used in this file.

3. Update the module docstring (lines 1-5) to remove "regex path validation" reference. The proxy still validates input presence (`if not path`) and catches `PermissionError` from the provider.

**What stays unchanged:**
- `if not path:` presence check (lines 28-30) — that's input validation, not format validation
- `except PermissionError: raise HTTPException(status_code=403)` — this catches the provider's `PermissionError` on invalid paths
- `except FileNotFoundError: raise HTTPException(status_code=404)` — unchanged
- The provider's `_JF_IMAGE_PATH` regex in `jellyfin_library.py` — unchanged, that's the single validation point now

**External behavior is identical.** The proxy already catches `PermissionError` from `fetch_library_image` and returns 403. Removing the pre-validation just means the provider's validation is the only gate.

**Expected files:** `jellyswipe/routers/proxy.py` (modify only)


### Acceptance Criteria

1. The `re.match(...)` guard on ~line 33 of `routers/proxy.py` is deleted
2. `import re` (line 8) is removed — `re` is no longer used in this file
3. Module docstring updated to remove "regex path validation" reference
4. `if not path:` presence check (lines 28-30) remains unchanged
5. `except PermissionError: raise HTTPException(status_code=403)` remains unchanged
6. `grep -rn "re.match" jellyswipe/routers/proxy.py` returns no hits
7. `grep -rn "import re" jellyswipe/routers/proxy.py` returns no hits
8. All existing tests pass (`uv run pytest`)
9. `ruff check .` passes


---
Ticket: `ORCH-038`