### PR TITLE
feat(ORCH-039): Remove `make_http_request` dependency from Jellyfin adapter

### DIFF
--- a/jellyswipe/jellyfin_library.py
+++ b/jellyswipe/jellyfin_library.py
@@ -12,8 +12,6 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import requests
 
-from .http_client import make_http_request
-
 logger = logging.getLogger(__name__)
 
 
@@ -445,10 +443,9 @@ class JellyfinLibraryProvider:
                 "webUrl": self._base,
             }
         except RuntimeError:
-            response = make_http_request(
-                method="GET",
-                url=f"{self._base}/System/Info/Public",
-                timeout=(5, 15),  # Convert single timeout to (connect, read) tuple
+            response = self._session.get(
+                f"{self._base}/System/Info/Public",
+                timeout=(5, 15),
             )
             pub = response.json()
             return {


### PR DESCRIPTION
## Remove `make_http_request` dependency from Jellyfin adapter

Remove the Jellyfin adapter's single dependency on `http_client.py`. The adapter uses `self._session` (a `requests.Session`) consistently for all Jellyfin API calls, except one fallback call in `server_info()` that uses `make_http_request`. Replace that single call with `self._session.get()` to make the adapter self-consistent.

**What to change in `jellyswipe/jellyfin_library.py`:**

1. Remove the import: `from .http_client import make_http_request` (line 15)

2. In `server_info()` method (~lines 438-457), replace the fallback `make_http_request` call:
   ```python
   # BEFORE (lines 448-453):
   response = make_http_request(
       method="GET",
       url=f"{self._base}/System/Info/Public",
       timeout=(5, 15),
   )
   ```
   ```python
   # AFTER:
   response = self._session.get(
       f"{self._base}/System/Info/Public",
       timeout=(5, 15),
   )
   ```

**What stays unchanged:**
- `http_client.py` itself — no modifications. It remains scoped to stateless external services (TMDB, 4 call sites in `tmdb.py`).
- The `_api()` call in the try block — unchanged.
- The response parsing logic — unchanged.
- All other `self._session.get()` / `self._session.post()` calls throughout the class — unchanged.

**Why this is safe:** Every other HTTP call in `JellyfinLibraryProvider` already goes through `self._session`. This single `make_http_request` call was the outlier. The `self._session` instance is a standard `requests.Session()` with JSON content-type headers. The public endpoint (`/System/Info/Public`) does not require authentication, so sending the session's auth headers is harmless.

**Note on `test_migration_23.py`:** The AST-scanning test `test_no_direct_requests_get_calls` checks for `requests.get()` where `requests` is the module name. It does NOT catch `self._session.get()` (which is an `ast.Attribute` not `ast.Name`). The test will continue to pass.

**Expected files:** `jellyswipe/jellyfin_library.py` (modify only)


### Acceptance Criteria

1. `from .http_client import make_http_request` is removed from `jellyfin_library.py` imports
2. The single `make_http_request(method="GET", url=f"{self._base}/System/Info/Public", timeout=(5, 15))` call in `server_info()` fallback is replaced with `self._session.get(f"{self._base}/System/Info/Public", timeout=(5, 15))`
3. The `_api()` try/except fallback structure in `server_info()` is unchanged — still catches `RuntimeError`, falls back to public endpoint
4. Public endpoint response parsing is unchanged — still extracts `Id`, `ServerName`, returns same dict shape
5. `grep -rn "make_http_request" jellyswipe/jellyfin_library.py` returns no hits
6. `http_client.py` is NOT modified — no changes to that file
7. All existing tests pass (`uv run pytest`), including `test_migration_23.py` (AST scanner catches `requests.get()` not `self._session.get()`)
8. `ruff check .` passes


---
Ticket: `ORCH-039`