### PR TITLE
feat(ORCH-043): Create jellyswipe/jellyfin_media_item.py with extracted pure functions

### DIFF
--- a/jellyswipe/jellyfin_media_item.py
+++ b/jellyswipe/jellyfin_media_item.py
@@ -1,0 +1,70 @@
+"""Pure, side-effect-free media-item transformation utilities.
+
+Extracted from ``JellyfinLibraryProvider`` so that the conversion logic
+can be reused without importing the HTTP-aware provider class.
+"""
+
+from __future__ import annotations
+
+GENRE_ALIASES: dict[str, str] = {
+    "Science Fiction": "Sci-Fi",
+}
+
+
+def _format_runtime(seconds: int) -> str:
+    """Format seconds as a human-readable duration string."""
+    if seconds <= 0:
+        return ""
+    hrs, rem = divmod(seconds, 3600)
+    mins = rem // 60
+    if hrs > 0:
+        return f"{hrs}h {mins}m"
+    return f"{mins}m"
+
+
+def movie_to_media_item(it: dict) -> dict:
+    """Transform a raw Jellyfin Movie item dict into a card dict."""
+    mid = it.get("Id")
+    ticks = int(it.get("RunTimeTicks") or 0)
+    seconds = ticks // 10_000_000 if ticks else 0
+    rating = it.get("CommunityRating")
+    if rating is None:
+        rating = it.get("CriticRating")
+    return {
+        "id": mid,
+        "title": it.get("Name") or "",
+        "summary": it.get("Overview") or "",
+        "thumb": f"/proxy?path=jellyfin/{mid}/Primary",
+        "rating": rating,
+        "duration": _format_runtime(seconds),
+        "year": it.get("ProductionYear"),
+        "media_type": "movie",
+    }
+
+
+def series_to_media_item(it: dict) -> dict:
+    """Transform a raw Jellyfin Series item dict into a card dict."""
+    mid = it.get("Id")
+    return {
+        "id": mid,
+        "title": it.get("Name") or "",
+        "summary": it.get("Overview") or "",
+        "thumb": f"/proxy?path=jellyfin/{mid}/Primary",
+        "year": it.get("ProductionYear"),
+        "media_type": "tv_show",
+        "season_count": it.get("ChildCount"),
+    }
+
+
+def display_genre_name(name: str) -> str:
+    """Return a display-friendly genre name (e.g. "Sci-Fi")."""
+    return GENRE_ALIASES.get(name, name)
+
+
+def query_genre_name(name: str) -> str:
+    """Reverse-lookup a display name to the canonical Jellyfin genre name.
+
+    If *name* is not found in the reverse mapping it is returned unchanged.
+    """
+    reverse = {v: k for k, v in GENRE_ALIASES.items()}
+    return reverse.get(name, name)

--- a/uv.lock
+++ b/uv.lock
@@ -273,7 +273,7 @@ wheels = [
 
 [[package]]
 name = "jellyswipe"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Create jellyswipe/jellyfin_media_item.py with extracted pure functions

Create `jellyswipe/jellyfin_media_item.py` containing only pure, side-effect-free functions and constants extracted from `JellyfinLibraryProvider`. No imports from HTTP libraries, no imports from `jellyfin_library`, no mutable state.

**What to build:**

1. `GENRE_ALIASES: dict[str, str]` — `{"Science Fiction": "Sci-Fi"}` (single source of truth for the genre alias rule)
2. `_format_runtime(seconds: int) -> str` — moved unchanged from `jellyfin_library.py` lines 31–38. Formats seconds as "1h 45m" or "45m"; returns "" for seconds <= 0.
3. `movie_to_media_item(it: dict) -> dict` — extracted from `JellyfinLibraryProvider._item_to_card` (lines 267–283). Reads `Id`, `Name`, `Overview`, `RunTimeTicks`, `CommunityRating`, `CriticRating`, `ProductionYear` from raw Jellyfin Movie item response. Produces: `id`, `title`, `summary`, `thumb` (format: `/proxy?path=jellyfin/{mid}/Primary`), `rating` (CommunityRating with CriticRating fallback, or None), `duration` (via `_format_runtime`), `year`, `media_type` (always `"movie"`).
4. `series_to_media_item(it: dict) -> dict` — extracted from `JellyfinLibraryProvider._series_to_card` (lines 285–296). Reads `Id`, `Name`, `Overview`, `ProductionYear`, `ChildCount`. Produces: `id`, `title`, `summary`, `thumb`, `year`, `media_type` (always `"tv_show"`), `season_count`.
5. `display_genre_name(name: str) -> str` — returns `GENRE_ALIASES.get(name, name)`. Translates Jellyfin canonical names to display names for outbound use (e.g. "Science Fiction" → "Sci-Fi").
6. `query_genre_name(name: str) -> str` — reverse lookup of `GENRE_ALIASES`. Returns the canonical Jellyfin name for a display name (e.g. "Sci-Fi" → "Science Fiction"). If no reverse mapping found, returns the name unchanged.

**Reference implementations (copy-and-adapt):**

```python
# _format_runtime — from jellyfin_library.py lines 31–38
def _format_runtime(seconds: int) -> str:
    if seconds <= 0:
        return ""
    hrs, rem = divmod(seconds, 3600)
    mins = rem // 60
    if hrs > 0:
        return f"{hrs}h {mins}m"
    return f"{mins}m"

# _item_to_card — from jellyfin_library.py lines 267–283 (becomes movie_to_media_item)
def _item_to_card(self, it: dict) -> dict:
    mid = it.get("Id")
    ticks = int(it.get("RunTimeTicks") or 0)
    seconds = ticks // 10_000_000 if ticks else 0
    rating = it.get("CommunityRating")
    if rating is None:
        rating = it.get("CriticRating")
    return {
        "id": mid,
        "title": it.get("Name") or "",
        "summary": it.get("Overview") or "",
        "thumb": f"/proxy?path=jellyfin/{mid}/Primary",
        "rating": rating,
        "duration": _format_runtime(seconds),
        "year": it.get("ProductionYear"),
        "media_type": "movie",
    }

# _series_to_card — from jellyfin_library.py lines 285–296 (becomes series_to_media_item)
def _series_to_card(self, it: dict) -> dict:
    mid = it.get("Id")
    return {
        "id": mid,
        "title": it.get("Name") or "",
        "summary": it.get("Overview") or "",
        "thumb": f"/proxy?path=jellyfin/{mid}/Primary",
        "year": it.get("ProductionYear"),
        "media_type": "tv_show",
        "season_count": it.get("ChildCount"),
    }
```

**Expected files:** `jellyswipe/jellyfin_media_item.py` (new)


### Acceptance Criteria

1. Module imports successfully: `from jellyswipe.jellyfin_media_item import movie_to_media_item, series_to_media_item, display_genre_name, query_genre_name`
2. No imports from `requests`, `jellyfin_library`, or any HTTP/auth/database module — the module is pure Python with no side effects
3. `movie_to_media_item({"Id": "a", "Name": "T", "Overview": "S", "RunTimeTicks": 81000000000, "CommunityRating": 9.0, "ProductionYear": 2024})` returns `{"id": "a", "title": "T", "summary": "S", "thumb": "/proxy?path=jellyfin/a/Primary", "rating": 9.0, "duration": "2h 15m", "year": 2024, "media_type": "movie"}`
4. `series_to_media_item({"Id": "s", "Name": "S", "Overview": "O", "ProductionYear": 2023, "ChildCount": 3})` returns `{"id": "s", "title": "S", "summary": "O", "thumb": "/proxy?path=jellyfin/s/Primary", "year": 2023, "media_type": "tv_show", "season_count": 3}`
5. `display_genre_name("Science Fiction") == "Sci-Fi"` and `display_genre_name("Action") == "Action"`
6. `query_genre_name("Sci-Fi") == "Science Fiction"` and `query_genre_name("Action") == "Action"`
7. Existing test suite passes unchanged (`uv run pytest tests/`)


---
Ticket: `ORCH-043`