### PR TITLE
feat(ORCH-045): Delegate JellyfinLibraryProvider to jellyfin_media_item and remove moved tests

### DIFF
--- a/jellyswipe/jellyfin_library.py
+++ b/jellyswipe/jellyfin_library.py
@@ -12,6 +12,13 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import requests
 
+from jellyswipe.jellyfin_media_item import (
+    display_genre_name,
+    movie_to_media_item,
+    query_genre_name,
+    series_to_media_item,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -27,16 +34,6 @@ def _media_browser_header(access_token: str) -> str:
         'MediaBrowser Client="JellySwipe", Device="FlaskApp", '
         f'DeviceId="{_DEVICE_ID}", Version="1.0.0", Token="{access_token}"'
     )
-
-
-def _format_runtime(seconds: int) -> str:
-    if seconds <= 0:
-        return ""
-    hrs, rem = divmod(seconds, 3600)
-    mins = rem // 60
-    if hrs > 0:
-        return f"{hrs}h {mins}m"
-    return f"{mins}m"
 
 
 class JellyfinLibraryProvider:
@@ -261,40 +258,9 @@ class JellyfinLibraryProvider:
                     pass
 
         names = sorted({n for n in names if n})
-        display = ["Sci-Fi" if n == "Science Fiction" else n for n in names]
+        display = [display_genre_name(n) for n in names]
         self._genre_cache[cache_key] = display
         return display
-
-    def _item_to_card(self, it: dict) -> dict:
-        mid = it.get("Id")
-        ticks = int(it.get("RunTimeTicks") or 0)
-        seconds = ticks // 10_000_000 if ticks else 0
-        rating = it.get("CommunityRating")
-        if rating is None:
-            rating = it.get("CriticRating")
-        return {
-            "id": mid,
-            "title": it.get("Name") or "",
-            "summary": it.get("Overview") or "",
-            "thumb": f"/proxy?path=jellyfin/{mid}/Primary",
-            "rating": rating,
-            "duration": _format_runtime(seconds),
-            "year": it.get("ProductionYear"),
-            "media_type": "movie",
-        }
-
-    def _series_to_card(self, it: dict) -> dict:
-        """Transform a TV Series item to a card."""
-        mid = it.get("Id")
-        return {
-            "id": mid,
-            "title": it.get("Name") or "",
-            "summary": it.get("Overview") or "",
-            "thumb": f"/proxy?path=jellyfin/{mid}/Primary",
-            "year": it.get("ProductionYear"),
-            "media_type": "tv_show",
-            "season_count": it.get("ChildCount"),
-        }
 
     def fetch_deck(
         self,
@@ -346,12 +312,12 @@ class JellyfinLibraryProvider:
         for it in all_items:
             item_type = it.get("Type", "")
             if item_type == "Series":
-                cards.append(self._series_to_card(it))
+                cards.append(series_to_media_item(it))
             else:
-                cards.append(self._item_to_card(it))
+                cards.append(movie_to_media_item(it))
 
         # Shuffle if not recently added
-        search_genre = "Science Fiction" if genre_name == "Sci-Fi" else genre_name
+        search_genre = query_genre_name(genre_name)
         if search_genre not in ("Recently Added", None, "All"):
             random.shuffle(cards)
 
@@ -378,7 +344,7 @@ class JellyfinLibraryProvider:
         if hide_watched:
             params["Filters"] = "IsNotPlayed"
 
-        search_genre = "Science Fiction" if genre_name == "Sci-Fi" else genre_name
+        search_genre = query_genre_name(genre_name)
 
         if genre_name == "Recently Added":
             params["Limit"] = 100

--- a/tests/test_jellyfin_library.py
+++ b/tests/test_jellyfin_library.py
@@ -567,66 +567,6 @@ def test_fetch_deck_recently_added_sort(mocker, monkeypatch):
     assert call_args[1]["params"]["Limit"] == 100
 
 
-# ---- Transformation Tests ----
-
-
-def test_item_to_card_transformation(mocker, monkeypatch):
-    """Test that _item_to_card extracts all 7 fields correctly."""
-    # Mock environment variables
-    monkeypatch.setenv("JELLYFIN_URL", "http://test.local")
-    monkeypatch.setenv("JELLYFIN_API_KEY", "test-api-key")
-
-    # Create provider
-    provider = JellyfinLibraryProvider("http://test.local")
-
-    # Create test item with all fields
-    item = {
-        "Id": "movie-123",
-        "Name": "Test Movie",
-        "Overview": "Test summary",
-        "RunTimeTicks": 81000000000,  # 2h 15m (135 minutes = 8100 seconds)
-        "ProductionYear": 2024,
-        "CommunityRating": 9.0,
-        "CriticRating": 8.5,
-    }
-
-    # Transform item to card
-    card = provider._item_to_card(item)
-
-    # Verify all 7 fields are extracted correctly
-    assert card["id"] == "movie-123"
-    assert card["title"] == "Test Movie"
-    assert card["summary"] == "Test summary"
-    assert card["rating"] == 9.0  # CommunityRating takes precedence
-    assert card["duration"] == "2h 15m"
-    assert card["year"] == 2024
-    assert card["thumb"] == "/proxy?path=jellyfin/movie-123/Primary"
-
-    # Test with missing CommunityRating (should fall back to CriticRating)
-    item2 = {
-        "Id": "movie-456",
-        "Name": "Movie 2",
-        "Overview": "",
-        "RunTimeTicks": 27000000000,  # 45m (45 minutes = 2700 seconds)
-        "ProductionYear": 2023,
-        "CriticRating": 7.5,
-    }
-    card2 = provider._item_to_card(item2)
-    assert card2["rating"] == 7.5
-    assert card2["duration"] == "45m"
-
-    # Test with empty runtime
-    item3 = {
-        "Id": "movie-789",
-        "Name": "Movie 3",
-        "Overview": "",
-        "RunTimeTicks": 0,
-        "ProductionYear": 2022,
-    }
-    card3 = provider._item_to_card(item3)
-    assert card3["duration"] == ""
-
-
 def test_resolve_item_for_tmdb_success(mocker, monkeypatch):
     """Test that resolve_item_for_tmdb returns title and year."""
     # Mock environment variables
@@ -894,53 +834,6 @@ def test_api_non_json_response(mocker, monkeypatch):
     # Verify RuntimeError is raised
     with pytest.raises(RuntimeError, match="Jellyfin returned non-JSON body"):
         provider._api("GET", "/Items")
-
-
-# ---- TV Show Tests ----
-
-
-def test_series_to_card_transformation(mocker, monkeypatch):
-    """Test that _series_to_card extracts TV show fields correctly."""
-    # Mock environment variables
-    monkeypatch.setenv("JELLYFIN_URL", "http://test.local")
-    monkeypatch.setenv("JELLYFIN_API_KEY", "test-api-key")
-
-    # Create provider
-    provider = JellyfinLibraryProvider("http://test.local")
-
-    # Create test series item with all fields
-    series = {
-        "Id": "series-123",
-        "Name": "Test Series",
-        "Overview": "Test series summary",
-        "ProductionYear": 2024,
-        "ChildCount": 3,  # 3 seasons
-        "Type": "Series",
-    }
-
-    # Transform series to card
-    card = provider._series_to_card(series)
-
-    # Verify all TV show fields are extracted correctly
-    assert card["id"] == "series-123"
-    assert card["title"] == "Test Series"
-    assert card["summary"] == "Test series summary"
-    assert card["year"] == 2024
-    assert card["media_type"] == "tv_show"
-    assert card["season_count"] == 3
-    # TV cards should NOT have duration or rating
-    assert "duration" not in card
-    assert "rating" not in card
-
-    # Test with missing ChildCount
-    series2 = {
-        "Id": "series-456",
-        "Name": "Series 2",
-        "Overview": "",
-        "ProductionYear": 2023,
-    }
-    card2 = provider._series_to_card(series2)
-    assert card2["season_count"] is None
 
 
 def test_fetch_deck_tv_shows_only(mocker, monkeypatch):


### PR DESCRIPTION
## Delegate JellyfinLibraryProvider to jellyfin_media_item and remove moved tests

Wire `JellyfinLibraryProvider` to delegate to `jellyfin_media_item` for all MediaItem transformation and genre alias logic, and remove the moved tests from `test_jellyfin_library.py`.

**What to change in `jellyswipe/jellyfin_library.py`:**

1. **Add import** at the top of the file: `from jellyswipe.jellyfin_media_item import movie_to_media_item, series_to_media_item, display_genre_name, query_genre_name`

2. **Remove `_format_runtime`** module-level function (lines 31–38). It now lives in `jellyfin_media_item.py`.

3. **Remove `_item_to_card` method** (lines 267–283). In `fetch_deck` at the call site around line 350, replace `self._item_to_card(it)` with `movie_to_media_item(it)`.

4. **Remove `_series_to_card` method** (lines 285–296). In `fetch_deck` at the call site around line 348, replace `self._series_to_card(it)` with `series_to_media_item(it)`.

5. **In `list_genres`** (line 263), replace the inline comprehension:
   ```python
   # BEFORE:
   display = ["Sci-Fi" if n == "Science Fiction" else n for n in names]
   # AFTER:
   display = [display_genre_name(n) for n in names]
   ```

6. **In `fetch_deck`** (line 353), replace the inline alias:
   ```python
   # BEFORE:
   search_genre = "Science Fiction" if genre_name == "Sci-Fi" else genre_name
   # AFTER:
   search_genre = query_genre_name(genre_name)
   ```

7. **In `_fetch_items_for_library`** (line 380), replace the inline alias:
   ```python
   # BEFORE:
   search_genre = "Science Fiction" if genre_name == "Sci-Fi" else genre_name
   # AFTER:
   search_genre = query_genre_name(genre_name)
   ```

8. **Preserve the fallback logic** in `_fetch_items_for_library` (lines 407–415) unchanged. After the refactor, `search_genre` is `query_genre_name(genre_name)`, and the condition `search_genre != genre_name` correctly detects when an alias was applied, preserving the existing retry-with-original-name behavior.

**What to change in `tests/test_jellyfin_library.py`:**

9. **Delete `test_item_to_card_transformation`** (lines 572–626) — these tests now live as `test_movie_to_media_item_full` and friends in `tests/test_jellyfin_media_item.py`.

10. **Delete `test_series_to_card_transformation`** (lines 901–942) — these tests now live as `test_series_to_media_item_full` and friends in `tests/test_jellyfin_media_item.py`.

11. **Verify all remaining tests pass.** The remaining tests in `test_jellyfin_library.py` (e.g., `test_fetch_deck_all_movies`, `test_fetch_deck_tv_shows_only`, `test_fetch_deck_with_genre_filter`, `test_list_genres_from_items_filters`, etc.) exercise `fetch_deck` and `list_genres` at the provider level and should pass unchanged because the output shapes are identical.

**Expected files:** `jellyswipe/jellyfin_library.py` (modify), `tests/test_jellyfin_library.py` (modify)


### Acceptance Criteria

1. `grep -rn "_item_to_card\|_series_to_card\|_format_runtime" jellyswipe/jellyfin_library.py` returns no hits (methods and function removed)
2. `grep -n "from jellyswipe.jellyfin_media_item import" jellyswipe/jellyfin_library.py` returns the import line with `movie_to_media_item, series_to_media_item, display_genre_name, query_genre_name`
3. `grep -n "test_item_to_card_transformation\|test_series_to_card_transformation" tests/test_jellyfin_library.py` returns no hits
4. `uv run pytest tests/` — full suite passes (remaining provider tests in test_jellyfin_library.py + all tests in test_jellyfin_media_item.py)
5. Public interface unchanged: `fetch_deck` returns identical card shapes, `list_genres` returns identical genre lists
6. Net line count of `jellyfin_library.py` is reduced by approximately 30–40 lines


---
Ticket: `ORCH-045`