### PR TITLE
refactor: Extract jellyfin_media_item — MediaItem transformation and genre alias locality

### DIFF
--- a/jellyswipe/jellyfin_library.py
+++ b/jellyswipe/jellyfin_library.py
@@ -12,6 +12,13 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import requests
 
+from jellyswipe.jellyfin_media_item import (
+    display_genre_name,
+    movie_to_media_item,
+    query_genre_name,
+    series_to_media_item,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -27,16 +34,6 @@ def _media_browser_header(access_token: str) -> str:
         'MediaBrowser Client="JellySwipe", Device="FlaskApp", '
         f'DeviceId="{_DEVICE_ID}", Version="1.0.0", Token="{access_token}"'
     )
-
-
-def _format_runtime(seconds: int) -> str:
-    if seconds <= 0:
-        return ""
-    hrs, rem = divmod(seconds, 3600)
-    mins = rem // 60
-    if hrs > 0:
-        return f"{hrs}h {mins}m"
-    return f"{mins}m"
 
 
 class JellyfinLibraryProvider:
@@ -261,40 +258,9 @@ class JellyfinLibraryProvider:
                     pass
 
         names = sorted({n for n in names if n})
-        display = ["Sci-Fi" if n == "Science Fiction" else n for n in names]
+        display = [display_genre_name(n) for n in names]
         self._genre_cache[cache_key] = display
         return display
-
-    def _item_to_card(self, it: dict) -> dict:
-        mid = it.get("Id")
-        ticks = int(it.get("RunTimeTicks") or 0)
-        seconds = ticks // 10_000_000 if ticks else 0
-        rating = it.get("CommunityRating")
-        if rating is None:
-            rating = it.get("CriticRating")
-        return {
-            "id": mid,
-            "title": it.get("Name") or "",
-            "summary": it.get("Overview") or "",
-            "thumb": f"/proxy?path=jellyfin/{mid}/Primary",
-            "rating": rating,
-            "duration": _format_runtime(seconds),
-            "year": it.get("ProductionYear"),
-            "media_type": "movie",
-        }
-
-    def _series_to_card(self, it: dict) -> dict:
-        """Transform a TV Series item to a card."""
-        mid = it.get("Id")
-        return {
-            "id": mid,
-            "title": it.get("Name") or "",
-            "summary": it.get("Overview") or "",
-            "thumb": f"/proxy?path=jellyfin/{mid}/Primary",
-            "year": it.get("ProductionYear"),
-            "media_type": "tv_show",
-            "season_count": it.get("ChildCount"),
-        }
 
     def fetch_deck(
         self,
@@ -346,12 +312,12 @@ class JellyfinLibraryProvider:
         for it in all_items:
             item_type = it.get("Type", "")
             if item_type == "Series":
-                cards.append(self._series_to_card(it))
+                cards.append(series_to_media_item(it))
             else:
-                cards.append(self._item_to_card(it))
+                cards.append(movie_to_media_item(it))
 
         # Shuffle if not recently added
-        search_genre = "Science Fiction" if genre_name == "Sci-Fi" else genre_name
+        search_genre = query_genre_name(genre_name)
         if search_genre not in ("Recently Added", None, "All"):
             random.shuffle(cards)
 
@@ -378,7 +344,7 @@ class JellyfinLibraryProvider:
         if hide_watched:
             params["Filters"] = "IsNotPlayed"
 
-        search_genre = "Science Fiction" if genre_name == "Sci-Fi" else genre_name
+        search_genre = query_genre_name(genre_name)
 
         if genre_name == "Recently Added":
             params["Limit"] = 100

--- a/jellyswipe/jellyfin_media_item.py
+++ b/jellyswipe/jellyfin_media_item.py
@@ -1,0 +1,70 @@
+"""Pure, side-effect-free media-item transformation utilities.
+
+Extracted from ``JellyfinLibraryProvider`` so that the conversion logic
+can be reused without importing the HTTP-aware provider class.
+"""
+
+from __future__ import annotations
+
+GENRE_ALIASES: dict[str, str] = {
+    "Science Fiction": "Sci-Fi",
+}
+
+
+def _format_runtime(seconds: int) -> str:
+    """Format seconds as a human-readable duration string."""
+    if seconds <= 0:
+        return ""
+    hrs, rem = divmod(seconds, 3600)
+    mins = rem // 60
+    if hrs > 0:
+        return f"{hrs}h {mins}m"
+    return f"{mins}m"
+
+
+def movie_to_media_item(it: dict) -> dict:
+    """Transform a raw Jellyfin Movie item dict into a card dict."""
+    mid = it.get("Id")
+    ticks = int(it.get("RunTimeTicks") or 0)
+    seconds = ticks // 10_000_000 if ticks else 0
+    rating = it.get("CommunityRating")
+    if rating is None:
+        rating = it.get("CriticRating")
+    return {
+        "id": mid,
+        "title": it.get("Name") or "",
+        "summary": it.get("Overview") or "",
+        "thumb": f"/proxy?path=jellyfin/{mid}/Primary",
+        "rating": rating,
+        "duration": _format_runtime(seconds),
+        "year": it.get("ProductionYear"),
+        "media_type": "movie",
+    }
+
+
+def series_to_media_item(it: dict) -> dict:
+    """Transform a raw Jellyfin Series item dict into a card dict."""
+    mid = it.get("Id")
+    return {
+        "id": mid,
+        "title": it.get("Name") or "",
+        "summary": it.get("Overview") or "",
+        "thumb": f"/proxy?path=jellyfin/{mid}/Primary",
+        "year": it.get("ProductionYear"),
+        "media_type": "tv_show",
+        "season_count": it.get("ChildCount"),
+    }
+
+
+def display_genre_name(name: str) -> str:
+    """Return a display-friendly genre name (e.g. "Sci-Fi")."""
+    return GENRE_ALIASES.get(name, name)
+
+
+def query_genre_name(name: str) -> str:
+    """Reverse-lookup a display name to the canonical Jellyfin genre name.
+
+    If *name* is not found in the reverse mapping it is returned unchanged.
+    """
+    reverse = {v: k for k, v in GENRE_ALIASES.items()}
+    return reverse.get(name, name)

--- a/tests/test_jellyfin_library.py
+++ b/tests/test_jellyfin_library.py
@@ -567,66 +567,6 @@ def test_fetch_deck_recently_added_sort(mocker, monkeypatch):
     assert call_args[1]["params"]["Limit"] == 100
 
 
-# ---- Transformation Tests ----
-
-
-def test_item_to_card_transformation(mocker, monkeypatch):
-    """Test that _item_to_card extracts all 7 fields correctly."""
-    # Mock environment variables
-    monkeypatch.setenv("JELLYFIN_URL", "http://test.local")
-    monkeypatch.setenv("JELLYFIN_API_KEY", "test-api-key")
-
-    # Create provider
-    provider = JellyfinLibraryProvider("http://test.local")
-
-    # Create test item with all fields
-    item = {
-        "Id": "movie-123",
-        "Name": "Test Movie",
-        "Overview": "Test summary",
-        "RunTimeTicks": 81000000000,  # 2h 15m (135 minutes = 8100 seconds)
-        "ProductionYear": 2024,
-        "CommunityRating": 9.0,
-        "CriticRating": 8.5,
-    }
-
-    # Transform item to card
-    card = provider._item_to_card(item)
-
-    # Verify all 7 fields are extracted correctly
-    assert card["id"] == "movie-123"
-    assert card["title"] == "Test Movie"
-    assert card["summary"] == "Test summary"
-    assert card["rating"] == 9.0  # CommunityRating takes precedence
-    assert card["duration"] == "2h 15m"
-    assert card["year"] == 2024
-    assert card["thumb"] == "/proxy?path=jellyfin/movie-123/Primary"
-
-    # Test with missing CommunityRating (should fall back to CriticRating)
-    item2 = {
-        "Id": "movie-456",
-        "Name": "Movie 2",
-        "Overview": "",
-        "RunTimeTicks": 27000000000,  # 45m (45 minutes = 2700 seconds)
-        "ProductionYear": 2023,
-        "CriticRating": 7.5,
-    }
-    card2 = provider._item_to_card(item2)
-    assert card2["rating"] == 7.5
-    assert card2["duration"] == "45m"
-
-    # Test with empty runtime
-    item3 = {
-        "Id": "movie-789",
-        "Name": "Movie 3",
-        "Overview": "",
-        "RunTimeTicks": 0,
-        "ProductionYear": 2022,
-    }
-    card3 = provider._item_to_card(item3)
-    assert card3["duration"] == ""
-
-
 def test_resolve_item_for_tmdb_success(mocker, monkeypatch):
     """Test that resolve_item_for_tmdb returns title and year."""
     # Mock environment variables
@@ -894,53 +834,6 @@ def test_api_non_json_response(mocker, monkeypatch):
     # Verify RuntimeError is raised
     with pytest.raises(RuntimeError, match="Jellyfin returned non-JSON body"):
         provider._api("GET", "/Items")
-
-
-# ---- TV Show Tests ----
-
-
-def test_series_to_card_transformation(mocker, monkeypatch):
-    """Test that _series_to_card extracts TV show fields correctly."""
-    # Mock environment variables
-    monkeypatch.setenv("JELLYFIN_URL", "http://test.local")
-    monkeypatch.setenv("JELLYFIN_API_KEY", "test-api-key")
-
-    # Create provider
-    provider = JellyfinLibraryProvider("http://test.local")
-
-    # Create test series item with all fields
-    series = {
-        "Id": "series-123",
-        "Name": "Test Series",
-        "Overview": "Test series summary",
-        "ProductionYear": 2024,
-        "ChildCount": 3,  # 3 seasons
-        "Type": "Series",
-    }
-
-    # Transform series to card
-    card = provider._series_to_card(series)
-
-    # Verify all TV show fields are extracted correctly
-    assert card["id"] == "series-123"
-    assert card["title"] == "Test Series"
-    assert card["summary"] == "Test series summary"
-    assert card["year"] == 2024
-    assert card["media_type"] == "tv_show"
-    assert card["season_count"] == 3
-    # TV cards should NOT have duration or rating
-    assert "duration" not in card
-    assert "rating" not in card
-
-    # Test with missing ChildCount
-    series2 = {
-        "Id": "series-456",
-        "Name": "Series 2",
-        "Overview": "",
-        "ProductionYear": 2023,
-    }
-    card2 = provider._series_to_card(series2)
-    assert card2["season_count"] is None
 
 
 def test_fetch_deck_tv_shows_only(mocker, monkeypatch):

--- a/tests/test_jellyfin_media_item.py
+++ b/tests/test_jellyfin_media_item.py
@@ -1,0 +1,189 @@
+"""Tests for ``jellyswipe.jellyfin_media_item`` pure functions.
+
+All tests call the public functions directly with plain dicts.  No HTTP
+mocking, no provider instantiation, and no custom fixtures beyond what
+``pytest`` provides natively.
+"""
+
+import pytest
+from jellyswipe.jellyfin_media_item import (
+    GENRE_ALIASES,
+    display_genre_name,
+    movie_to_media_item,
+    query_genre_name,
+    series_to_media_item,
+)
+
+
+# ---------------------------------------------------------------------------
+# movie_to_media_item
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_movie_to_media_item_full():
+    """Fully-populated movie dict exercises every output field."""
+    it = {
+        "Id": "movie-123",
+        "Name": "Test Movie",
+        "Overview": "Test summary",
+        "RunTimeTicks": 81000000000,
+        "CommunityRating": 9.0,
+        "CriticRating": 8.5,
+        "ProductionYear": 2024,
+    }
+    result = movie_to_media_item(it)
+
+    assert result["id"] == "movie-123"
+    assert result["title"] == "Test Movie"
+    assert result["summary"] == "Test summary"
+    assert result["thumb"] == "/proxy?path=jellyfin/movie-123/Primary"
+    assert result["rating"] == 9.0
+    assert result["duration"] == "2h 15m"
+    assert result["year"] == 2024
+    assert result["media_type"] == "movie"
+
+
+@pytest.mark.anyio
+async def test_movie_to_media_item_missing_rating():
+    """No CommunityRating or CriticRating yields rating None."""
+    it = {
+        "Id": "m2",
+        "Name": "No Rating",
+        "Overview": "",
+        "RunTimeTicks": 0,
+        "ProductionYear": 2022,
+    }
+    result = movie_to_media_item(it)
+    assert result["rating"] is None
+
+
+@pytest.mark.anyio
+async def test_movie_to_media_item_critic_rating_fallback():
+    """CriticRating is used when CommunityRating is absent."""
+    it = {
+        "Id": "m3",
+        "Name": "Critic Only",
+        "Overview": "",
+        "RunTimeTicks": 27000000000,
+        "ProductionYear": 2023,
+        "CriticRating": 7.5,
+    }
+    result = movie_to_media_item(it)
+    assert result["rating"] == 7.5
+    assert result["duration"] == "45m"
+
+
+@pytest.mark.anyio
+async def test_movie_to_media_item_zero_runtime():
+    """RunTimeTicks of zero produces an empty duration string."""
+    it = {
+        "Id": "m4",
+        "Name": "No Runtime",
+        "Overview": "",
+        "RunTimeTicks": 0,
+        "ProductionYear": 2021,
+    }
+    result = movie_to_media_item(it)
+    assert result["duration"] == ""
+
+
+@pytest.mark.anyio
+async def test_movie_to_media_item_missing_year():
+    """Missing ProductionYear yields None for year."""
+    it = {
+        "Id": "m5",
+        "Name": "No Year",
+        "Overview": "",
+    }
+    result = movie_to_media_item(it)
+    assert result["year"] is None
+
+
+# ---------------------------------------------------------------------------
+# series_to_media_item
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_series_to_media_item_full():
+    """Fully-populated series dict exercises every output field."""
+    it = {
+        "Id": "series-123",
+        "Name": "Test Series",
+        "Overview": "Test series summary",
+        "ProductionYear": 2024,
+        "ChildCount": 3,
+        "Type": "Series",
+    }
+    result = series_to_media_item(it)
+
+    assert result["id"] == "series-123"
+    assert result["title"] == "Test Series"
+    assert result["summary"] == "Test series summary"
+    assert result["thumb"] == "/proxy?path=jellyfin/series-123/Primary"
+    assert result["year"] == 2024
+    assert result["media_type"] == "tv_show"
+    assert result["season_count"] == 3
+    assert "duration" not in result
+    assert "rating" not in result
+
+
+@pytest.mark.anyio
+async def test_series_to_media_item_missing_child_count():
+    """Missing ChildCount yields None for season_count, not an error."""
+    it = {
+        "Id": "series-456",
+        "Name": "Series 2",
+        "Overview": "",
+        "ProductionYear": 2023,
+    }
+    result = series_to_media_item(it)
+    assert result["season_count"] is None
+
+
+# ---------------------------------------------------------------------------
+# display_genre_name
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_display_genre_name_with_alias():
+    """Known canonical genre returns its display alias."""
+    assert display_genre_name("Science Fiction") == "Sci-Fi"
+
+
+@pytest.mark.anyio
+async def test_display_genre_name_no_alias():
+    """Unknown genre is returned unchanged."""
+    assert display_genre_name("Action") == "Action"
+
+
+# ---------------------------------------------------------------------------
+# query_genre_name
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_query_genre_name_with_alias():
+    """Display alias is reverse-looked-up to canonical name."""
+    assert query_genre_name("Sci-Fi") == "Science Fiction"
+
+
+@pytest.mark.anyio
+async def test_query_genre_name_no_alias():
+    """Unknown display name is returned unchanged."""
+    assert query_genre_name("Action") == "Action"
+
+
+# ---------------------------------------------------------------------------
+# GENRE_ALIASES round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_genre_alias_round_trip():
+    """Every alias pair round-trips correctly in both directions."""
+    for canonical, display in GENRE_ALIASES.items():
+        assert query_genre_name(display_genre_name(canonical)) == canonical
+        assert display_genre_name(query_genre_name(display)) == display

--- a/uv.lock
+++ b/uv.lock
@@ -273,7 +273,7 @@ wheels = [
 
 [[package]]
 name = "jellyswipe"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
JellyfinLibraryProvider is a 586-line class that mixes seven distinct concerns: HTTP transport, authentication state, in-process caching, MediaItem transformation, genre alias normalisation, query orchestration, and image proxying. The class earns its keep overall, but the concerns are interleaved rather than layered — MediaItem transformation logic (_item_to_card, _series_to_card) and the genre alias rule ("Science Fiction" ↔ "Sci-Fi") are buried in the middle of auth retry loops and cache management.

From the developer's perspective this creates two concrete problems:

    Navigation friction. When a card field is wrong or a genre is missing, the developer must open a 586-line file and context-switch through transport machinery to find 20 lines of domain logic. There is no file to open that says "this is where MediaItems are built."

    Genre alias duplication. The alias rule between Jellyfin's canonical name ("Science Fiction") and the display name ("Sci-Fi") appears in three separate inline one-liners (in list_genres, fetch_deck, and _fetch_items_for_library). One conceptual rule lives in three places; any change must be applied three times.

Neither problem is blocked by an ADR. The [ADR 0001](https://github.com/andrewthetechie/jelly-swipe/adr/0001-remove-username-password-auth.md) cleanup and [PRD 007](https://github.com/andrewthetechie/jelly-swipe/issues/007-shallow-module-cleanup.md) regex deduplication work are complementary and do not constrain this extraction.

## Solution

Extract a new jellyfin_media_item module containing only the pure, side-effect-free logic that transforms raw Jellyfin API response dicts into MediaItems and normalises genre names for display and query. JellyfinLibraryProvider is unchanged in responsibility — it continues to own HTTP transport, auth state, caching, and query orchestration — but it delegates all MediaItem construction and genre name translation to the new module.

The new module has no imports from any HTTP library, no imports from jellyfin_library, and no mutable state. It can be read, understood, and tested in complete isolation from the Jellyfin network layer.

Closes https://github.com/andrewthetechie/jelly-swipe/issues/137