### PR TITLE
fix: github codescanning alerts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - "**"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/unraid-template-lint.yml
+++ b/.github/workflows/unraid-template-lint.yml
@@ -3,10 +3,13 @@ name: Unraid Template Lint
 "on":
   push:
     paths:
-      - 'unraid_template/jelly-swipe.html'
+      - "unraid_template/jelly-swipe.html"
   pull_request:
     paths:
-      - 'unraid_template/jelly-swipe.html'
+      - "unraid_template/jelly-swipe.html"
+
+permissions:
+  contents: read
 
 jobs:
   lint:
@@ -19,7 +22,7 @@ jobs:
       - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: "3.13"
 
       - name: Lint Unraid template
         run: python scripts/lint-unraid-template.py unraid_template/jelly-swipe.html

--- a/jellyswipe/routers/rooms.py
+++ b/jellyswipe/routers/rooms.py
@@ -417,7 +417,10 @@ async def set_genre(
         await commit_and_wake(uow, code)
         return new_list
     except EmptyDeckError as e:
-        return XSSSafeJSONResponse(content={"error": str(e)}, status_code=400)
+        _logger.warning(f"EmptyDeckError for room {code}: {e}")
+        return XSSSafeJSONResponse(
+            content={"error": "An internal error has occurred!"}, status_code=400
+        )
 
 
 @rooms_router.post(
@@ -451,9 +454,10 @@ async def set_watched_filter_route(
         )
         await commit_and_wake(uow, code)
         return result
-    except EmptyDeckError:
+    except EmptyDeckError as exc:
+        _logger.warning(f"EmptyDeckError for room {code} (watched filter): {exc}")
         return XSSSafeJSONResponse(
-            content={"error": "No unwatched items available"}, status_code=422
+            content={"error": "An internal error has occurred!"}, status_code=422
         )
 
 

--- a/tests/test_routes_room.py
+++ b/tests/test_routes_room.py
@@ -581,7 +581,7 @@ def test_set_genre_empty_deck_returns_400(client, app, mocker):
         )
 
         assert response.status_code == 400
-        assert "No items available" in response.json()["error"]
+        assert response.json()["error"] == "An internal error has occurred!"
     finally:
         app.dependency_overrides.pop(get_provider, None)
 
@@ -668,7 +668,7 @@ def test_set_watched_filter_empty_deck_returns_422(client, app, mocker):
             "/room/TEST1/watched-filter", json={"hide_watched": True}
         )
         assert response.status_code == 422
-        assert "No unwatched items available" in response.json()["error"]
+        assert response.json()["error"] == "An internal error has occurred!"
     finally:
         app.dependency_overrides.pop(get_provider, None)
 


### PR DESCRIPTION
* Prevents info leakage by logging in room routers instead of returning a stack trace error
* Adjusts github workflows for testing by adding permissions to restrict their scope

Fixes:
https://github.com/andrewthetechie/jelly-swipe/security/code-scanning/1
https://github.com/andrewthetechie/jelly-swipe/security/code-scanning/2
https://github.com/andrewthetechie/jelly-swipe/security/code-scanning/130