### PR TITLE
feat: CORSMiddelware and configuration

### DIFF
--- a/jellyswipe/__init__.py
+++ b/jellyswipe/__init__.py
@@ -12,6 +12,7 @@ import typing
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.sessions import SessionMiddleware
@@ -244,9 +245,19 @@ def create_app(config: AppConfig | None = None):
         https_only=os.getenv("SESSION_COOKIE_SECURE", "false").lower() == "true",
     )
 
-    # Add 3rd: ProxyHeadersMiddleware (outermost) per D-04
+    # Add 3rd: ProxyHeadersMiddleware per D-04
     trusted = os.getenv("TRUSTED_PROXY_IPS", "127.0.0.1")
     app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=trusted)
+
+    # Add 4th: CORSMiddleware (outermost) — only when CORS_ORIGINS is configured
+    if config.cors_origins:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=config.cors_origins,
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
 
     # Static files mount (prevents path traversal vulnerabilities)
     app.mount(

--- a/jellyswipe/config.py
+++ b/jellyswipe/config.py
@@ -22,6 +22,14 @@ class AppConfig(BaseSettings):
     tmdb_access_token: str
     session_secret: str
     db_path: str = ""  # empty string = compute default
+    cors_origins: list[str] = []
+
+    @field_validator("cors_origins", mode="before")
+    @classmethod
+    def _parse_cors_origins(cls, v: object) -> list[str]:
+        if isinstance(v, str):
+            return [o.strip() for o in v.split(",") if o.strip()]
+        return v
 
     @field_validator("jellyfin_url")
     @classmethod
@@ -35,10 +43,16 @@ class AppConfig(BaseSettings):
     @property
     def sync_db_url(self) -> str:
         """Canonical sync sqlite:///... URL for Alembic and runtime."""
-        path = Path(
-            self.db_path
-            or str(Path(__file__).resolve().parent.parent / "data" / "jellyswipe.db")
-        ).expanduser().resolve()
+        path = (
+            Path(
+                self.db_path
+                or str(
+                    Path(__file__).resolve().parent.parent / "data" / "jellyswipe.db"
+                )
+            )
+            .expanduser()
+            .resolve()
+        )
         return f"sqlite:///{path}"
 
     @computed_field


### PR DESCRIPTION
Support setting cors in the config as cors_origins, a comma separated list, and use the fastapi CORSMiddelware to manage origins